### PR TITLE
Contest UI rework

### DIFF
--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -360,7 +360,7 @@ class ContestJoin(LoginRequiredMixin, ContestMixin, BaseDetailView):
         profile.save()
         contest._updating_stats_only = True
         contest.update_user_count()
-        return HttpResponseRedirect(reverse('problem_list'))
+        return HttpResponseRedirect(reverse('contest_view', args=(contest.key,)))
 
     def ask_for_access_code(self, form=None):
         contest = self.object

--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -27,12 +27,11 @@ from django.views.generic.detail import SingleObjectMixin
 from judge.comments import CommentedDetailView
 from judge.forms import ProblemCloneForm, ProblemSubmitForm
 from judge.models import ContestSubmission, Judge, Language, Problem, ProblemGroup, \
-    ProblemTranslation, ProblemType, RuntimeVersion, Solution, Submission, SubmissionSource, \
-    TranslatedProblemForeignKeyQuerySet
+    ProblemTranslation, ProblemType, RuntimeVersion, Solution, Submission, SubmissionSource
 from judge.pdf_problems import DefaultPdfMaker, HAS_PDF
 from judge.utils.diggpaginator import DiggPaginator
 from judge.utils.opengraph import generate_opengraph
-from judge.utils.problems import contest_attempted_ids, contest_completed_ids, hot_problems, user_attempted_ids, \
+from judge.utils.problems import hot_problems, user_attempted_ids, \
     user_completed_ids
 from judge.utils.strings import safe_float_or_none, safe_int_or_none
 from judge.utils.tickets import own_ticket_filter
@@ -319,7 +318,7 @@ class ProblemList(QueryStringSortMixin, TitleMixin, SolvedProblemMixin, ListView
             if self.show_types:
                 queryset = list(queryset)
                 queryset.sort(key=lambda problem: problem.types_list[0] if problem.types_list else '',
-                                reverse=self.order.startswith('-'))
+                              reverse=self.order.startswith('-'))
         paginator.object_list = queryset
         return paginator
 

--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -76,16 +76,10 @@ class ProblemMixin(object):
 
 class SolvedProblemMixin(object):
     def get_completed_problems(self):
-        if self.in_contest:
-            return contest_completed_ids(self.profile.current_contest)
-        else:
-            return user_completed_ids(self.profile) if self.profile is not None else ()
+        return user_completed_ids(self.profile) if self.profile is not None else ()
 
     def get_attempted_problems(self):
-        if self.in_contest:
-            return contest_attempted_ids(self.profile.current_contest)
-        else:
-            return user_attempted_ids(self.profile) if self.profile is not None else ()
+        return user_attempted_ids(self.profile) if self.profile is not None else ()
 
     @cached_property
     def in_contest(self):
@@ -294,40 +288,39 @@ class ProblemList(QueryStringSortMixin, TitleMixin, SolvedProblemMixin, ListView
                       allow_empty_first_page=True, **kwargs):
         paginator = DiggPaginator(queryset, per_page, body=6, padding=2, orphans=orphans,
                                   allow_empty_first_page=allow_empty_first_page, **kwargs)
-        if not self.in_contest:
-            # Get the number of pages and then add in this magic.
-            # noinspection PyStatementEffect
-            paginator.num_pages
+        # Get the number of pages and then add in this magic.
+        # noinspection PyStatementEffect
+        paginator.num_pages
 
-            queryset = queryset.add_i18n_name(self.request.LANGUAGE_CODE)
-            sort_key = self.order.lstrip('-')
-            if sort_key in self.sql_sort:
-                queryset = queryset.order_by(self.order, 'id')
-            elif sort_key == 'name':
-                queryset = queryset.order_by('i18n_name', self.order, 'name', 'id')
-            elif sort_key == 'group':
-                queryset = queryset.order_by(self.order + '__name', 'name', 'id')
-            elif sort_key == 'solved':
-                if self.request.user.is_authenticated:
-                    profile = self.request.profile
-                    solved = user_completed_ids(profile)
-                    attempted = user_attempted_ids(profile)
+        queryset = queryset.add_i18n_name(self.request.LANGUAGE_CODE)
+        sort_key = self.order.lstrip('-')
+        if sort_key in self.sql_sort:
+            queryset = queryset.order_by(self.order, 'id')
+        elif sort_key == 'name':
+            queryset = queryset.order_by('i18n_name', self.order, 'name', 'id')
+        elif sort_key == 'group':
+            queryset = queryset.order_by(self.order + '__name', 'name', 'id')
+        elif sort_key == 'solved':
+            if self.request.user.is_authenticated:
+                profile = self.request.profile
+                solved = user_completed_ids(profile)
+                attempted = user_attempted_ids(profile)
 
-                    def _solved_sort_order(problem):
-                        if problem.id in solved:
-                            return 1
-                        if problem.id in attempted:
-                            return 0
-                        return -1
+                def _solved_sort_order(problem):
+                    if problem.id in solved:
+                        return 1
+                    if problem.id in attempted:
+                        return 0
+                    return -1
 
-                    queryset = list(queryset)
-                    queryset.sort(key=_solved_sort_order, reverse=self.order.startswith('-'))
-            elif sort_key == 'type':
-                if self.show_types:
-                    queryset = list(queryset)
-                    queryset.sort(key=lambda problem: problem.types_list[0] if problem.types_list else '',
-                                  reverse=self.order.startswith('-'))
-            paginator.object_list = queryset
+                queryset = list(queryset)
+                queryset.sort(key=_solved_sort_order, reverse=self.order.startswith('-'))
+        elif sort_key == 'type':
+            if self.show_types:
+                queryset = list(queryset)
+                queryset.sort(key=lambda problem: problem.types_list[0] if problem.types_list else '',
+                                reverse=self.order.startswith('-'))
+        paginator.object_list = queryset
         return paginator
 
     @cached_property
@@ -335,26 +328,6 @@ class ProblemList(QueryStringSortMixin, TitleMixin, SolvedProblemMixin, ListView
         if not self.request.user.is_authenticated:
             return None
         return self.request.profile
-
-    def get_contest_queryset(self):
-        queryset = self.profile.current_contest.contest.contest_problems.select_related('problem__group') \
-            .defer('problem__description').order_by('problem__code') \
-            .order_by('order')
-        queryset = TranslatedProblemForeignKeyQuerySet.add_problem_i18n_name(queryset, 'i18n_name',
-                                                                             self.request.LANGUAGE_CODE,
-                                                                             'problem__name')
-
-        return [{
-            'id': p['problem_id'],
-            'code': p['problem__code'],
-            'name': p['problem__name'],
-            'i18n_name': p['i18n_name'],
-            'group': {'full_name': p['problem__group__full_name']},
-            'points': p['points'],
-            'partial': p['partial'],
-            'user_count': p['problem__user_count'],
-        } for p in queryset.values('problem_id', 'problem__code', 'problem__name', 'i18n_name',
-                                   'problem__group__full_name', 'points', 'partial', 'problem__user_count')]
 
     def get_normal_queryset(self):
         filter = Q(is_public=True)
@@ -394,16 +367,13 @@ class ProblemList(QueryStringSortMixin, TitleMixin, SolvedProblemMixin, ListView
         return queryset.distinct()
 
     def get_queryset(self):
-        if self.in_contest:
-            return self.get_contest_queryset()
-        else:
-            return self.get_normal_queryset()
+        return self.get_normal_queryset()
 
     def get_context_data(self, **kwargs):
         context = super(ProblemList, self).get_context_data(**kwargs)
-        context['hide_solved'] = 0 if self.in_contest else int(self.hide_solved)
-        context['show_types'] = 0 if self.in_contest else int(self.show_types)
-        context['full_text'] = 0 if self.in_contest else int(self.full_text)
+        context['hide_solved'] = int(self.hide_solved)
+        context['show_types'] = int(self.show_types)
+        context['full_text'] = int(self.full_text)
         context['category'] = self.category
         context['categories'] = ProblemGroup.objects.all()
         if self.show_types:
@@ -415,14 +385,9 @@ class ProblemList(QueryStringSortMixin, TitleMixin, SolvedProblemMixin, ListView
         context['attempted_problems'] = self.get_attempted_problems()
 
         context.update(self.get_sort_paginate_context())
-        if not self.in_contest:
-            context.update(self.get_sort_context())
-            context['hot_problems'] = hot_problems(timedelta(days=1), settings.DMOJ_PROBLEM_HOT_PROBLEM_COUNT)
-            context['point_start'], context['point_end'], context['point_values'] = self.get_noui_slider_points()
-        else:
-            context['hot_problems'] = None
-            context['point_start'], context['point_end'], context['point_values'] = 0, 0, {}
-            context['hide_contest_scoreboard'] = self.contest.hide_scoreboard
+        context.update(self.get_sort_context())
+        context['hot_problems'] = hot_problems(timedelta(days=1), settings.DMOJ_PROBLEM_HOT_PROBLEM_COUNT)
+        context['point_start'], context['point_end'], context['point_values'] = self.get_noui_slider_points()
         return context
 
     def get_noui_slider_points(self):

--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -221,7 +221,7 @@ class SubmissionsListBase(DiggPaginatorMixin, TitleMixin, ListView):
 
     @cached_property
     def in_contest(self):
-        return self.request.user.is_authenticated and self.request.profile.current_contest is not None
+        return False
 
     @cached_property
     def contest(self):
@@ -269,7 +269,7 @@ class SubmissionsListBase(DiggPaginatorMixin, TitleMixin, ListView):
         return None
 
     def get_all_submissions_page(self):
-        if hasattr(self, 'contest'):
+        if self.in_contest and hasattr(self, 'contest'):
             return reverse('contest_all_submissions', kwargs={'contest': self.contest.key})
         return reverse('all_submissions')
 
@@ -556,7 +556,7 @@ class ForceContestMixin(object):
 
 class AllContestSubmissions(ForceContestMixin, AllSubmissions):
     def get_content_title(self):
-        return format_html(_('All submissions in<a href="{1}">{0}</a>'),
+        return format_html(_('All submissions in <a href="{1}">{0}</a>'),
                            self.contest.name, reverse("contest_view", args=[self.contest.key]))
 
     def get_my_submissions_page(self):

--- a/judge/views/user.py
+++ b/judge/views/user.py
@@ -484,11 +484,6 @@ class FixedContestRanking(ContestRanking):
 
 
 def users(request):
-    if request.user.is_authenticated:
-        participation = request.profile.current_contest
-        if participation is not None:
-            contest = participation.contest
-            return FixedContestRanking.as_view(contest=contest)(request, contest=contest.key)
     return user_list_view(request)
 
 

--- a/templates/contest/contest-tabs.html
+++ b/templates/contest/contest-tabs.html
@@ -15,6 +15,7 @@
         {% else %}
             {{ make_tab('ranking', 'fa-bar-chart', None, _('Hidden Rankings')) }}
         {% endif %}
+        {{ make_tab('submissions', 'fa-bar-chart', url('contest_all_submissions', contest.key), _('Submissions')) }}
     {% endif %}
     {% if can_edit %}
         {% if perms.judge.moss_contest and has_moss_api_key %}

--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -74,6 +74,7 @@
     </div>
 
     {% if contest.ended or request.user.is_superuser or is_organizer %}
+        {% set in_contest = contest.is_in_contest(request.user) %}
         <hr>
         <div class="contest-problems">
             <h2 style="margin-bottom: 0.2em"><i class="fa fa-fw fa-question-circle"></i>{{ _('Problems') }} </h2>
@@ -93,7 +94,7 @@
                 {% for problem in contest_problems %}
                     <tr>
                         <td>
-                            {% if problem.is_public or request.user.is_superuser or is_organizer %}
+                            {% if in_contest or problem.is_public or request.user.is_superuser or is_organizer %}
                                 <a href="{{ url('problem_detail', problem.code) }}">{{ problem.i18n_name or problem.name }}</a>
                             {% else %}
                                 {{ problem.i18n_name or problem.name }}

--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -73,8 +73,8 @@
         {% endcache %}
     </div>
 
-    {% if contest.ended or request.user.is_superuser or is_organizer %}
-        {% set in_contest = contest.is_in_contest(request.user) %}
+    {% set in_contest = contest.is_in_contest(request.user) %}
+    {% if in_contest or contest.ended or request.user.is_superuser or is_organizer %}
         <hr>
         <div class="contest-problems">
             <h2 style="margin-bottom: 0.2em"><i class="fa fa-fw fa-question-circle"></i>{{ _('Problems') }} </h2>

--- a/templates/problem/list.html
+++ b/templates/problem/list.html
@@ -8,30 +8,28 @@
         }
         </style>
     </noscript>
-    {% if not request.in_contest %}
-        <style>
-            #problem-table th {
-                padding: 0;
-            }
+    <style>
+        #problem-table th {
+            padding: 0;
+        }
 
-            a.hot-problem-link:hover > .hot-problem-count {
-                visibility: visible;
-            }
+        a.hot-problem-link:hover > .hot-problem-count {
+            visibility: visible;
+        }
 
-            span.hot-problem-count {
-                color: #555;
-                font-size: 0.75em;
-                vertical-align: super;
-                visibility: hidden;
-                padding-left: 0.25em;
-                position: relative;
-            }
+        span.hot-problem-count {
+            color: #555;
+            font-size: 0.75em;
+            vertical-align: super;
+            visibility: hidden;
+            padding-left: 0.25em;
+            position: relative;
+        }
 
-            ul.problem-list {
-                padding: 0 !important;
-            }
-        </style>
-    {% endif %}
+        ul.problem-list {
+            padding: 0 !important;
+        }
+    </style>
 {% endblock %}
 
 {% block js_media %}
@@ -128,38 +126,6 @@
             });
         </script>
     {% endcompress %}
-    {% if request.in_contest %}
-        {% compress js %}
-            <script src="{{ static('libs/tablesorter.js') }}" type="text/javascript"></script>
-            <script type="text/javascript">
-                $(function () {
-                    $.tablesorter.addParser({
-                        id: 'solvedsort',
-                        is: function (s) {
-                            return false;
-                        },
-                        format: function (s, table, cell, cellIndex) {
-                            return $(cell).attr('solved');
-                        },
-                        type: 'numeric'
-                    });
-
-                    $('#problem-table').tablesorter({
-                        headers: {
-                            0: {
-                                sorter: 'solvedsort'
-                            }
-                        },
-                        textExtraction: function (node) {
-                            node = $(node);
-                            var text = node.text().replace(/^\s+|\s+$/g, '');
-                            return (node.hasClass('p') ? text.replace(/p$/, '') : text);
-                        }
-                    });
-                });
-            </script>
-        {% endcompress %}
-    {% endif %}
 {% endblock %}
 
 {% block title_ruler %}{% endblock %}
@@ -179,69 +145,56 @@
 
     <div id="common-content">
         {% block before_table %}{% endblock %}
-        {% if not request.in_contest %}
-            <div id="content-right" class="problems">
-                <div class="info-float">
-                    {% include "problem/search-form.html" %}
-                    {% if hot_problems %}
-                        <div class="sidebox">
-                            <h3>{{ _('Hot problems') }} <i class="fa fa-fire"></i></h3>
-                            <div class="sidebox-content">
-                                <ul class="problem-list">{% for problem in hot_problems %}
-                                    <li><a href="{{ url('problem_detail', problem.code) }}" class="hot-problem-link">
-                                        {{ problem.name }}
-                                    </a></li>
-                                {% endfor %}</ul>
-                            </div>
+        <div id="content-right" class="problems">
+            <div class="info-float">
+                {% include "problem/search-form.html" %}
+                {% if hot_problems %}
+                    <div class="sidebox">
+                        <h3>{{ _('Hot problems') }} <i class="fa fa-fire"></i></h3>
+                        <div class="sidebox-content">
+                            <ul class="problem-list">{% for problem in hot_problems %}
+                                <li><a href="{{ url('problem_detail', problem.code) }}" class="hot-problem-link">
+                                    {{ problem.name }}
+                                </a></li>
+                            {% endfor %}</ul>
                         </div>
-                    {% endif %}
-                </div>
+                    </div>
+                {% endif %}
             </div>
-        {% endif %}
+        </div>
         <div id="content-left" class="problems h-scrollable-table">
             <table id="problem-table" class="table striped">
                 <thead>
                 <tr>
-                    {% if request.in_contest %}
-                        {% if request.user.is_authenticated %}
-                            <th class="solved"><i class="fa fa-check"></i></th>
-                        {% endif %}
-                        <th class="problem-code">{{ _('ID') }}</th>
-                        <th class="problem-name">{{ _('Problem') }}</th>
-                        <th class="category">{{ _('Category') }}</th>
-                        <th class="points">{{ _('Points') }}</th>
-                        <th class="users">{{ _('# AC') }}</th>
-                    {% else %}
-                        {% if request.user.is_authenticated %}
-                            <th class="solved">
-                                <a href="{{ sort_links.solved }}"><i class="fa fa-check"></i>{{ sort_order.solved }}
-                                </a>
-                            </th>
-                        {% endif %}
-                        <th class="problem-code">
-                            <a href="{{ sort_links.code }}">{{ _('ID') }}{{ sort_order.code}}</a>
-                        </th>
-                        <th class="problem-name">
-                            <a href="{{ sort_links.name }}">{{ _('Problem') }}{{ sort_order.name }}</a>
-                        </th>
-                        <th class="category">
-                            <a href="{{ sort_links.group }}">{{ _('Category') }}{{ sort_order.group }}</a>
-                        </th>
-                        {% if show_types %}
-                            <th>
-                                <a href="{{ sort_links.type }}">{{ _('Types') }}{{ sort_order.type }}</a>
-                            </th>
-                        {% endif %}
-                        <th class="points">
-                            <a href="{{ sort_links.points }}">{{ _('Points') }}{{ sort_order.points }}</a>
-                        </th>
-                        <th class="ac-rate">
-                            <a href="{{ sort_links.ac_rate }}">{{ _('%% AC') }}{{ sort_order.ac_rate }}</a>
-                        </th>
-                        <th class="users">
-                            <a href="{{ sort_links.user_count }}">{{ _('# AC') }}{{ sort_order.user_count }}</a>
+                    {% if request.user.is_authenticated %}
+                        <th class="solved">
+                            <a href="{{ sort_links.solved }}"><i class="fa fa-check"></i>{{ sort_order.solved }}
+                            </a>
                         </th>
                     {% endif %}
+                    <th class="problem-code">
+                        <a href="{{ sort_links.code }}">{{ _('ID') }}{{ sort_order.code}}</a>
+                    </th>
+                    <th class="problem-name">
+                        <a href="{{ sort_links.name }}">{{ _('Problem') }}{{ sort_order.name }}</a>
+                    </th>
+                    <th class="category">
+                        <a href="{{ sort_links.group }}">{{ _('Category') }}{{ sort_order.group }}</a>
+                    </th>
+                    {% if show_types %}
+                        <th>
+                            <a href="{{ sort_links.type }}">{{ _('Types') }}{{ sort_order.type }}</a>
+                        </th>
+                    {% endif %}
+                    <th class="points">
+                        <a href="{{ sort_links.points }}">{{ _('Points') }}{{ sort_order.points }}</a>
+                    </th>
+                    <th class="ac-rate">
+                        <a href="{{ sort_links.ac_rate }}">{{ _('%% AC') }}{{ sort_order.ac_rate }}</a>
+                    </th>
+                    <th class="users">
+                        <a href="{{ sort_links.user_count }}">{{ _('# AC') }}{{ sort_order.user_count }}</a>
+                    </th>
                 </tr>
                 </thead>
                 <tbody>
@@ -251,7 +204,7 @@
                             {% if problem.id in completed_problem_ids %}
                                 <td solved="1">
                                     <a href="{{ url('user_submissions', problem.code, request.user.username) }}">
-                                        {% if problem.is_public or request.in_contest %}
+                                        {% if problem.is_public %}
                                             <i class="solved-problem-color fa fa-check-circle"></i>
                                         {% else %}
                                             <i class="solved-problem-color fa fa-lock"></i>
@@ -261,7 +214,7 @@
                             {% elif problem.id in attempted_problems %}
                                 <td solved="0">
                                     <a href="{{ url('user_submissions', problem.code, request.user.username) }}">
-                                        {% if problem.is_public or request.in_contest %}
+                                        {% if problem.is_public %}
                                             <i class="attempted-problem-color fa fa-frown-o"></i>
                                         {% else %}
                                             <i class="attempted-problem-color fa fa-lock"></i>
@@ -270,7 +223,7 @@
                                 </td>
                             {% else %}
                                 <td solved="-1">
-                                    {% if problem.is_public or request.in_contest %}
+                                    {% if problem.is_public %}
                                         <i class="unsolved-problem-color fa"></i>
                                     {% else %}
                                         <i class="unsolved-problem-color fa fa-lock"></i>
@@ -293,16 +246,10 @@
                             </td>
                         {% endif %}
                         <td class="p">{{ problem.points|floatformat }}{% if problem.partial %}{% endif %}</td>
-                        {% if not request.in_contest %}
-                            <td class="ac-rate">{{ problem.ac_rate|floatformat(1) }}%</td>
-                        {% endif %}
+                        <td class="ac-rate">{{ problem.ac_rate|floatformat(1) }}%</td>
                         <td class="users">
                             <a href="{{ url('ranked_submissions', problem.code) }}">
-                                {% if not request.in_contest or not hide_contest_scoreboard %}
-                                    {{ problem.user_count }}
-                                {% else %}
-                                    ???
-                                {% endif %}
+                                {{ problem.user_count }}
                             </a>
                         </td>
                     </tr>


### PR DESCRIPTION
Base on the suggestions of many users and the issue https://github.com/VNOI-Admin/OJ/issues/22, I decided to rework the contests' UI:
- Users can access the problems via the contest page instead of going to the [problems page](https://oj.vnoi.info/problems/).
- Now, when the user is in a contest, the [problems page](https://oj.vnoi.info/problems/), [submissions page](https://oj.vnoi.info/submissions/), [users ranking page](https://oj.vnoi.info/users/) remain the same. 