### PR TITLE
Show correctly float points

### DIFF
--- a/judge/admin/submission.py
+++ b/judge/admin/submission.py
@@ -181,7 +181,7 @@ class SubmissionAdmin(admin.ModelAdmin):
                            .only('points', 'case_points', 'case_total', 'problem__partial', 'problem__points'))
         for submission in submissions:
             submission.points = round(submission.case_points / submission.case_total * submission.problem.points
-                                      if submission.case_total else 0, 1)
+                                      if submission.case_total else 0, 3)
             if not submission.problem.partial and submission.points < submission.problem.points:
                 submission.points = 0
             submission.save()

--- a/judge/admin/submission.py
+++ b/judge/admin/submission.py
@@ -180,8 +180,8 @@ class SubmissionAdmin(admin.ModelAdmin):
         submissions = list(queryset.defer(None).select_related(None).select_related('problem')
                            .only('points', 'case_points', 'case_total', 'problem__partial', 'problem__points'))
         for submission in submissions:
-            submission.points = round(submission.case_points / submission.case_total * submission.problem.points
-                                      if submission.case_total else 0, 3)
+            submission.points = round(submission.case_points / submission.case_total
+                                      if submission.case_total else 0, 3) * submission.problem.points
             if not submission.problem.partial and submission.points < submission.problem.points:
                 submission.points = 0
             submission.save()

--- a/judge/tasks/submission.py
+++ b/judge/tasks/submission.py
@@ -44,7 +44,7 @@ def rescore_problem(self, problem_id):
         rescored = 0
         for submission in submissions.iterator():
             submission.points = round(submission.case_points / submission.case_total * problem.points
-                                      if submission.case_total else 0, 1)
+                                      if submission.case_total else 0, 3)
             if not problem.partial and submission.points < problem.points:
                 submission.points = 0
             submission.save(update_fields=['points'])

--- a/judge/tasks/submission.py
+++ b/judge/tasks/submission.py
@@ -43,8 +43,8 @@ def rescore_problem(self, problem_id):
     with Progress(self, submissions.count(), stage=_('Modifying submissions')) as p:
         rescored = 0
         for submission in submissions.iterator():
-            submission.points = round(submission.case_points / submission.case_total * problem.points
-                                      if submission.case_total else 0, 3)
+            submission.points = round(submission.case_points / submission.case_total
+                                      if submission.case_total else 0, 3) * problem.points
             if not problem.partial and submission.points < problem.points:
                 submission.points = 0
             submission.save(update_fields=['points'])

--- a/templates/submission/status-testcases.html
+++ b/templates/submission/status-testcases.html
@@ -151,8 +151,8 @@
                               total=contest.problem.points|floatformat(-1)) }})
                     {% endwith %}
                 {% else %}
-                    ({{ _('%(points)s/%(total)s points', points=submission.points|roundfloat(3),
-                          total=submission.problem.points|floatformat(-1)) }})
+                    ({{ _('%(points)s/%(total)s points', points=submission.points|floatformat(3),
+                          total=submission.problem.points|floatformat(3)) }})
                 {% endif %}
                 {% if is_pretest and submission.result == "AC" %}
                     <br>

--- a/templates/user/user-base.html
+++ b/templates/user/user-base.html
@@ -48,7 +48,7 @@
             <div>
                 <b class="semibold">{{ _('Total points:') }}</b>
                 <span title="{{ user.performance_points|floatformat(2) }}">
-                    {{ user.performance_points|floatformat(0) }}
+                    {{ user.performance_points|floatformat(2) }}
                 </span>
             </div>
 


### PR DESCRIPTION
DMOJ rounding problem point to 1 digit after the decimal point, this can cause some error if the problem point is smaller than 0.1. For example, if a problem has a 0.04 point, it will be 0 after rounding. 

User point now displays with 2 digits after the decimal point.