### PR TITLE
Submission feedback

### DIFF
--- a/resources/submission.scss
+++ b/resources/submission.scss
@@ -276,6 +276,7 @@ label[for="language"], label[for="status"] {
     .case-output {
         margin: 0;
         margin-right: 1em;
+        word-break: break-all;
     }
 
     table td {

--- a/templates/submission/status-testcases.html
+++ b/templates/submission/status-testcases.html
@@ -95,26 +95,24 @@
 
             {% if print_case_output or case.extended_feedback %}
                 <tr id="{{ case.id }}-output" style="display:none" class="case-feedback toggled">
-                    {% if print_case_output and request.user.is_superuser %}
-                        <td colspan="5" class="case-output">
-                            <div class="case-info">
-                                <strong>{{ _('Your output (clipped)') }}</strong>
-                                {% if prefix_length is none %}
-                                    <pre class="case-output">{{ case.output|linebreaksbr }}</pre>
-                                {% else %}
-                                    <pre class="case-output">{{ case.output[:prefix_length]|linebreaksbr }}</pre>
-                                {% endif %}
-                            </div>
-                        </td>
-                    {% endif %}
-                    {% if case.extended_feedback and not request.in_contest %}
-                        <td colspan="5" class="case-ext-feedback">
-                            <div class="case-info">
-                                <strong>{{ _('Judge feedback') }}</strong>
-                                <pre class="case-output">{{ case.extended_feedback|linebreaksbr }}</pre>
-                            </div>
-                        </td>
-                    {% endif %}
+                    <td colspan="5" class="case-output">
+                        {% if print_case_output and request.user.is_superuser %}
+                        <div class="case-info">
+                            <strong>{{ _('Your output (clipped)') }}</strong>
+                            {% if prefix_length is none %}
+                                <pre class="case-output">{{ case.output|linebreaksbr }}</pre>
+                            {% else %}
+                                <pre class="case-output">{{ case.output[:prefix_length]|linebreaksbr }}</pre>
+                            {% endif %}
+                        </div>
+                        {% endif %}
+                        {% if case.extended_feedback and not request.in_contest %}
+                        <div class="case-info">
+                            <strong>{{ _('Judge feedback') }}</strong>
+                            <pre class="case-output">{{ case.extended_feedback|linebreaksbr }}</pre>
+                        </div>
+                        {% endif %}
+                    </td>
                 </tr>
             {% endif %}
         {% endfor %}

--- a/templates/submission/status-testcases.html
+++ b/templates/submission/status-testcases.html
@@ -95,24 +95,26 @@
 
             {% if print_case_output or case.extended_feedback %}
                 <tr id="{{ case.id }}-output" style="display:none" class="case-feedback toggled">
-                    <td colspan="5" class="case-output">
-                        {% if print_case_output and request.user.is_superuser %}
-                        <div class="case-info">
-                            <strong>{{ _('Your output (clipped)') }}</strong>
-                            {% if prefix_length is none %}
-                                <pre class="case-output">{{ case.output|linebreaksbr }}</pre>
-                            {% else %}
-                                <pre class="case-output">{{ case.output[:prefix_length]|linebreaksbr }}</pre>
-                            {% endif %}
-                        </div>
-                        {% endif %}
-                        {% if case.extended_feedback and not request.in_contest %}
-                        <div class="case-info">
-                            <strong>{{ _('Judge feedback') }}</strong>
-                            <pre class="case-output">{{ case.extended_feedback|linebreaksbr }}</pre>
-                        </div>
-                        {% endif %}
-                    </td>
+                    {% if print_case_output and request.user.is_superuser %}
+                        <td colspan="5" class="case-output">
+                            <div class="case-info">
+                                <strong>{{ _('Your output (clipped)') }}</strong>
+                                {% if prefix_length is none %}
+                                    <pre class="case-output">{{ case.output|linebreaksbr }}</pre>
+                                {% else %}
+                                    <pre class="case-output">{{ case.output[:prefix_length]|linebreaksbr }}</pre>
+                                {% endif %}
+                            </div>
+                        </td>
+                    {% endif %}
+                    {% if case.extended_feedback and not request.in_contest %}
+                        <td colspan="5" class="case-ext-feedback">
+                            <div class="case-info">
+                                <strong>{{ _('Judge feedback') }}</strong>
+                                <pre class="case-output">{{ case.extended_feedback|linebreaksbr }}</pre>
+                            </div>
+                        </td>
+                    {% endif %}
                 </tr>
             {% endif %}
         {% endfor %}

--- a/templates/submission/status-testcases.html
+++ b/templates/submission/status-testcases.html
@@ -95,7 +95,7 @@
 
             {% if print_case_output or case.extended_feedback %}
                 <tr id="{{ case.id }}-output" style="display:none" class="case-feedback toggled">
-                    {% if print_case_output %}
+                    {% if print_case_output and request.user.is_superuser %}
                         <td colspan="5" class="case-output">
                             <div class="case-info">
                                 <strong>{{ _('Your output (clipped)') }}</strong>
@@ -107,7 +107,7 @@
                             </div>
                         </td>
                     {% endif %}
-                    {% if case.extended_feedback %}
+                    {% if case.extended_feedback and not request.in_contest %}
                         <td colspan="5" class="case-ext-feedback">
                             <div class="case-info">
                                 <strong>{{ _('Judge feedback') }}</strong>


### PR DESCRIPTION
Only admins can see the case output. Normal users can read judge feedback outside of contests.
Also rearrange the feedback to prevent UI overflow.