### PR TITLE
Fix translation not appear on .po file

### DIFF
--- a/locale/vi/LC_MESSAGES/django.po
+++ b/locale/vi/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dmoj\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-16 09:11+0000\n"
+"POT-Creation-Date: 2021-05-16 09:21+0000\n"
 "PO-Revision-Date: 2020-08-23 18:59\n"
 "Last-Translator: \n"
 "Language-Team: Vietnamese\n"
@@ -3738,13 +3738,43 @@ msgstr "Tham gia kỳ thi"
 msgid "Log in to participate"
 msgstr "Đăng nhập để tham gia"
 
+#: templates/contest/contest.html:33
+#, python-format
+msgid "Spectating, contest ends in %(countdown)s."
+msgstr "Đang theo dõi, kỳ thi sẽ kết thúc trong %(countdown)s."
+
+#: templates/contest/contest.html:35
+#, python-format
+msgid "Participating virtually, %(countdown)s remaining."
+msgstr "Đang tham gia ảo, còn lại %(countdown)s thời gian."
+
 #: templates/contest/contest.html:37
 msgid "Participating virtually."
-msgstr "Tham gia ảo"
+msgstr "Đang tham gia ảo"
+
+#: templates/contest/contest.html:41 templates/contest/list.html:243
+#, python-format
+msgid "Starting in %(countdown)s."
+msgstr "Bắt đầu trong %(countdown)s."
 
 #: templates/contest/contest.html:43
 msgid "Contest is over."
 msgstr "Kỳ thi đã kết thúc."
+
+#: templates/contest/contest.html:47
+#, python-format
+msgid "Your time is up! Contest ends in %(countdown)s."
+msgstr "Thời gian làm bài của bạn đã hết! Kỳ thi sẽ kết thúc sau %(countdown)s."
+
+#: templates/contest/contest.html:49
+#, python-format
+msgid "You have %(countdown)s remaining."
+msgstr "Bạn còn lại %(countdown)s thời gian."
+
+#: templates/contest/contest.html:52
+#, python-format
+msgid "Contest ends in %(countdown)s"
+msgstr "Kỳ thi sẽ kết thúc sau %(countdown)s."
 
 #: templates/contest/contest.html:59 templates/contest/contest.html:63
 msgid "F j, Y, G:i T"
@@ -3853,11 +3883,6 @@ msgstr "Bắt đầu trong %(countdown)s."
 #: templates/contest/list.html:226
 msgid "Upcoming Contests"
 msgstr "Các kỳ thi sắp tới"
-
-#: templates/contest/list.html:243
-#, python-format
-msgid "Starting in %(countdown)s."
-msgstr "Bắt đầu trong %(countdown)s."
 
 #: templates/contest/list.html:254
 msgid "There are no scheduled contests at this time."

--- a/locale/vi/LC_MESSAGES/django.po
+++ b/locale/vi/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dmoj\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-16 09:30+0000\n"
+"POT-Creation-Date: 2021-05-16 09:42+0000\n"
 "PO-Revision-Date: 2020-08-23 18:59\n"
 "Last-Translator: \n"
 "Language-Team: Vietnamese\n"
@@ -3479,9 +3479,21 @@ msgstr "Chưa có làm rõ nào được đưa ra ở thời điểm này."
 msgid "Ongoing contests"
 msgstr "Kỳ thi đang diễn ra"
 
+#: templates/blog/list.html:173 templates/contest/list.html:170
+#: templates/contest/list.html:209
+#, python-format
+msgid "Ends in %(countdown)s"
+msgstr "Kết thúc trong %(countdown)s."
+
 #: templates/blog/list.html:183
 msgid "Upcoming contests"
 msgstr "Kỳ thi sắp tới"
+
+#: templates/blog/list.html:191 templates/contest/contest.html:41
+#: templates/contest/list.html:243
+#, python-format
+msgid "Starting in %(countdown)s."
+msgstr "Bắt đầu trong %(countdown)s."
 
 #: templates/blog/list.html:207
 msgid "Comment stream"
@@ -3752,11 +3764,6 @@ msgstr "Đang tham gia ảo, còn lại %(countdown)s thời gian."
 msgid "Participating virtually."
 msgstr "Đang tham gia ảo"
 
-#: templates/contest/contest.html:41 templates/contest/list.html:243
-#, python-format
-msgid "Starting in %(countdown)s."
-msgstr "Bắt đầu trong %(countdown)s."
-
 #: templates/contest/contest.html:43
 msgid "Contest is over."
 msgstr "Kỳ thi đã kết thúc."
@@ -3875,11 +3882,6 @@ msgstr "Thành viên"
 #, python-format
 msgid "Window ends in %(countdown)s"
 msgstr "Thời gian làm bài kết thúc trong %(countdown)s."
-
-#: templates/contest/list.html:170 templates/contest/list.html:209
-#, python-format
-msgid "Ends in %(countdown)s"
-msgstr "Kết thúc trong %(countdown)s."
 
 #: templates/contest/list.html:189
 msgid "Ongoing Contests"

--- a/locale/vi/LC_MESSAGES/django.po
+++ b/locale/vi/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dmoj\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-16 08:33+0000\n"
+"POT-Creation-Date: 2021-05-16 08:41+0000\n"
 "PO-Revision-Date: 2020-08-23 18:59\n"
 "Last-Translator: \n"
 "Language-Team: Vietnamese\n"
@@ -3721,7 +3721,7 @@ msgstr ""
 msgid "Leave contest"
 msgstr "Rời khỏi kỳ thi"
 
-#: templates/contest/contest-tabs.html:46 templates/contest/list.html:300
+#: templates/contest/contest-tabs.html:46 templates/contest/list.html:296
 msgid "Virtual join"
 msgstr "Tham gia ảo"
 
@@ -3816,51 +3816,46 @@ msgid "rated"
 msgstr ""
 
 #: templates/contest/list.html:122
-msgid ""
-"\n"
-"        This contest has %(count)s virtual participation\n"
-"        "
-msgid_plural ""
-"\n"
-"        This contest has %(count)s virtual participations\n"
-"        "
-msgstr[0] ""
+#, python-format
+msgid "This contest has %(count)s virtual participation"
+msgid_plural "This contest has %(count)s virtual participations"
+msgstr[0] "Kỳ thi này có %(count)s lượt tham gia ảo"
 
-#: templates/contest/list.html:137
+#: templates/contest/list.html:133
 msgid "Spectate"
 msgstr "Theo dõi"
 
-#: templates/contest/list.html:143
+#: templates/contest/list.html:139
 msgid "Join"
 msgstr "Tham gia"
 
-#: templates/contest/list.html:153
+#: templates/contest/list.html:149
 msgid "Active Contests"
 msgstr "Các kỳ thi đang diễn ra"
 
-#: templates/contest/list.html:157 templates/contest/list.html:199
-#: templates/contest/list.html:237 templates/contest/list.html:274
+#: templates/contest/list.html:153 templates/contest/list.html:195
+#: templates/contest/list.html:233 templates/contest/list.html:270
 msgid "Contest"
 msgstr "Kỳ thi"
 
-#: templates/contest/list.html:158 templates/contest/list.html:200
-#: templates/contest/list.html:277
+#: templates/contest/list.html:154 templates/contest/list.html:196
+#: templates/contest/list.html:273
 msgid "Users"
 msgstr "Thành viên"
 
-#: templates/contest/list.html:195
+#: templates/contest/list.html:191
 msgid "Ongoing Contests"
 msgstr "Kỳ thi đang diễn ra"
 
-#: templates/contest/list.html:232
+#: templates/contest/list.html:228
 msgid "Upcoming Contests"
 msgstr "Các kỳ thi sắp tới"
 
-#: templates/contest/list.html:260
+#: templates/contest/list.html:256
 msgid "There are no scheduled contests at this time."
 msgstr "Chưa có kỳ thi được lên lịch trong tương lai."
 
-#: templates/contest/list.html:266
+#: templates/contest/list.html:262
 msgid "Past Contests"
 msgstr "Các kỳ thi đã qua"
 

--- a/locale/vi/LC_MESSAGES/django.po
+++ b/locale/vi/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dmoj\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-16 08:41+0000\n"
+"POT-Creation-Date: 2021-05-16 09:09+0000\n"
 "PO-Revision-Date: 2020-08-23 18:59\n"
 "Last-Translator: \n"
 "Language-Team: Vietnamese\n"
@@ -512,12 +512,12 @@ msgstr "đã đăng {time}"
 msgid "commented {time}"
 msgstr "đã bình luận {time}"
 
-#: judge/custom_translations.py:31
+#: judge/custom_translations.py:31 templates/contest/list.html:110
 #, python-format
 msgid "%(duration)s long"
 msgstr "Thời gian làm bài: %(duration)s"
 
-#: judge/custom_translations.py:32
+#: judge/custom_translations.py:32 templates/contest/list.html:109
 #, python-format
 msgid "%(time_limit)s window"
 msgstr ""
@@ -3721,7 +3721,7 @@ msgstr ""
 msgid "Leave contest"
 msgstr "Rời khỏi kỳ thi"
 
-#: templates/contest/contest-tabs.html:46 templates/contest/list.html:296
+#: templates/contest/contest-tabs.html:46 templates/contest/list.html:294
 msgid "Virtual join"
 msgstr "Tham gia ảo"
 
@@ -3815,47 +3815,58 @@ msgstr "riêng tư"
 msgid "rated"
 msgstr ""
 
-#: templates/contest/list.html:122
+#: templates/contest/list.html:120
 #, python-format
 msgid "This contest has %(count)s virtual participation"
 msgid_plural "This contest has %(count)s virtual participations"
 msgstr[0] "Kỳ thi này có %(count)s lượt tham gia ảo"
 
-#: templates/contest/list.html:133
+#: templates/contest/list.html:131
 msgid "Spectate"
 msgstr "Theo dõi"
 
-#: templates/contest/list.html:139
+#: templates/contest/list.html:137
 msgid "Join"
 msgstr "Tham gia"
 
-#: templates/contest/list.html:149
+#: templates/contest/list.html:147
 msgid "Active Contests"
 msgstr "Các kỳ thi đang diễn ra"
 
-#: templates/contest/list.html:153 templates/contest/list.html:195
-#: templates/contest/list.html:233 templates/contest/list.html:270
+#: templates/contest/list.html:151 templates/contest/list.html:193
+#: templates/contest/list.html:231 templates/contest/list.html:268
 msgid "Contest"
 msgstr "Kỳ thi"
 
-#: templates/contest/list.html:154 templates/contest/list.html:196
-#: templates/contest/list.html:273
+#: templates/contest/list.html:152 templates/contest/list.html:194
+#: templates/contest/list.html:271
 msgid "Users"
 msgstr "Thành viên"
 
-#: templates/contest/list.html:191
+#: templates/contest/list.html:189
 msgid "Ongoing Contests"
 msgstr "Kỳ thi đang diễn ra"
 
-#: templates/contest/list.html:228
+#: templates/contest/list.html:209
+#, fuzzy, python-format
+#| msgid "Starting in %(countdown)s."
+msgid "Ends in %(countdown)s"
+msgstr "Bắt đầu trong %(countdown)s."
+
+#: templates/contest/list.html:226
 msgid "Upcoming Contests"
 msgstr "Các kỳ thi sắp tới"
 
-#: templates/contest/list.html:256
+#: templates/contest/list.html:243
+#, python-format
+msgid "Starting in %(countdown)s."
+msgstr "Bắt đầu trong %(countdown)s."
+
+#: templates/contest/list.html:254
 msgid "There are no scheduled contests at this time."
 msgstr "Chưa có kỳ thi được lên lịch trong tương lai."
 
-#: templates/contest/list.html:262
+#: templates/contest/list.html:260
 msgid "Past Contests"
 msgstr "Các kỳ thi đã qua"
 

--- a/locale/vi/LC_MESSAGES/django.po
+++ b/locale/vi/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dmoj\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-16 09:21+0000\n"
+"POT-Creation-Date: 2021-05-16 09:30+0000\n"
 "PO-Revision-Date: 2020-08-23 18:59\n"
 "Last-Translator: \n"
 "Language-Team: Vietnamese\n"
@@ -3764,7 +3764,8 @@ msgstr "Kỳ thi đã kết thúc."
 #: templates/contest/contest.html:47
 #, python-format
 msgid "Your time is up! Contest ends in %(countdown)s."
-msgstr "Thời gian làm bài của bạn đã hết! Kỳ thi sẽ kết thúc sau %(countdown)s."
+msgstr ""
+"Thời gian làm bài của bạn đã hết! Kỳ thi sẽ kết thúc sau %(countdown)s."
 
 #: templates/contest/contest.html:49
 #, python-format
@@ -3858,7 +3859,7 @@ msgstr "Tham gia"
 
 #: templates/contest/list.html:147
 msgid "Active Contests"
-msgstr "Các kỳ thi đang diễn ra"
+msgstr "Các kỳ thi đang tham gia"
 
 #: templates/contest/list.html:151 templates/contest/list.html:193
 #: templates/contest/list.html:231 templates/contest/list.html:268
@@ -3870,15 +3871,19 @@ msgstr "Kỳ thi"
 msgid "Users"
 msgstr "Thành viên"
 
+#: templates/contest/list.html:168
+#, python-format
+msgid "Window ends in %(countdown)s"
+msgstr "Thời gian làm bài kết thúc trong %(countdown)s."
+
+#: templates/contest/list.html:170 templates/contest/list.html:209
+#, python-format
+msgid "Ends in %(countdown)s"
+msgstr "Kết thúc trong %(countdown)s."
+
 #: templates/contest/list.html:189
 msgid "Ongoing Contests"
-msgstr "Kỳ thi đang diễn ra"
-
-#: templates/contest/list.html:209
-#, fuzzy, python-format
-#| msgid "Starting in %(countdown)s."
-msgid "Ends in %(countdown)s"
-msgstr "Bắt đầu trong %(countdown)s."
+msgstr "Các kỳ thi đang diễn ra"
 
 #: templates/contest/list.html:226
 msgid "Upcoming Contests"

--- a/locale/vi/LC_MESSAGES/django.po
+++ b/locale/vi/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dmoj\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-16 09:09+0000\n"
+"POT-Creation-Date: 2021-05-16 09:11+0000\n"
 "PO-Revision-Date: 2020-08-23 18:59\n"
 "Last-Translator: \n"
 "Language-Team: Vietnamese\n"
@@ -639,8 +639,7 @@ msgstr "id kỳ thi phải bao gồm ^[a-z0-9_] + $"
 msgid "Contest with key already exists."
 msgstr "Mã kỳ thi đã tồn tại."
 
-#: judge/jinja2/datetime.py:26 templates/blog/content.html:27
-#: templates/blog/dashboard.html:21
+#: judge/jinja2/datetime.py:26 templates/blog/dashboard.html:21
 msgid "N j, Y, g:i a"
 msgstr "j, M, Y, g:i a"
 
@@ -3432,15 +3431,13 @@ msgid "Edit"
 msgstr "Soạn thảo"
 
 #: templates/blog/content.html:27
+msgid "N j, Y, G:i"
+msgstr "j, M, Y, G:i"
+
+#: templates/blog/content.html:27
 #, python-format
-msgid ""
-"\n"
-"                    posted on %(time)s\n"
-"                "
-msgstr ""
-"\n"
-"                    đăng vào lúc %(time)s\n"
-"                "
+msgid "posted on %(time)s"
+msgstr "đã đăng vào %(time)s"
 
 #: templates/blog/dashboard.html:21
 #, python-format
@@ -5521,3 +5518,12 @@ msgstr "Số bài"
 #: templates/widgets/select_all.html:8
 msgid "Check all"
 msgstr "Chọn tất cả"
+
+#~ msgid ""
+#~ "\n"
+#~ "                    posted on %(time)s\n"
+#~ "                "
+#~ msgstr ""
+#~ "\n"
+#~ "                    đăng vào lúc %(time)s\n"
+#~ "                "

--- a/templates/blog/content.html
+++ b/templates/blog/content.html
@@ -24,9 +24,9 @@
                 {% endif %}
             {% endwith %}
             <span class="post-time">
-                {% trans time=post.publish_on|date(_("N j, Y, g:i a")) %}
+                {%- trans time=post.publish_on|date(_("N j, Y, G:i")) -%}
                     posted on {{ time }}
-                {% endtrans %}
+                {%- endtrans -%}
             </span>
         </div>
         <div class="body content-description">

--- a/templates/blog/list.html
+++ b/templates/blog/list.html
@@ -170,7 +170,7 @@
                                     <a href="{{ url('contest_view', contest.key) }}">{{ contest.name }}</a>
                                 </div>
                                 <div class="time">
-                                    {{ _('Ends in %(countdown)s.', countdown=contest.time_before_end|as_countdown) }}
+                                    {%- trans countdown=contest.time_before_end|as_countdown -%} Ends in {{countdown}} {%- endtrans -%}
                                 </div>
                             </div>
                         {% endfor %}
@@ -188,7 +188,7 @@
                                     <a href="{{ url('contest_view', contest.key) }}">{{ contest.name }}</a>
                                 </div>
                                 <div class="time">
-                                    {{ _('Starting in %(countdown)s.', countdown=contest.time_before_start|as_countdown) }}
+                                    {%- trans countdown=contest.time_before_start|as_countdown -%} Starting in {{countdown}}. {%- endtrans -%}
                                 </div>
                             </div>
                         {% endfor %}

--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -30,26 +30,26 @@
                 {{- contest.start_time|utc|date('Y-m-d\TH:i:s') }}" class="date">
             {%- if contest.is_in_contest(request.user) and not request.participation.live -%}
                 {% if request.participation.spectate %}
-                    {{- _('Spectating, contest ends in %(countdown)s.', countdown=contest.time_before_end|as_countdown) -}}
+                    {%- trans countdown=contest.time_before_end|as_countdown -%} Spectating, contest ends in {{countdown}}. {%- endtrans -%}
                 {% elif request.participation.end_time %}
-                    {{- _('Participating virtually, %(countdown)s remaining.', countdown=request.participation.time_remaining|as_countdown) -}}
+                    {%- trans countdown=request.participation.time_remaining|as_countdown -%} Participating virtually, {{countdown}} remaining. {%- endtrans -%}
                 {% else %}
                     {{- _('Participating virtually.') -}}
                 {% endif %}
             {%- else -%}
                 {% if contest.start_time > now %}
-                    {{- _('Starting in %(countdown)s', countdown=contest.time_before_start|as_countdown) -}}
+                    {%- trans countdown=contest.time_before_start|as_countdown -%} Starting in {{countdown}}. {%- endtrans -%}
                 {% elif contest.end_time < now %}
                     {{- _('Contest is over.') -}}
                 {% else %}
                     {%- if has_joined -%}
                         {% if live_participation.ended %}
-                            {{- _('Your time is up! Contest ends in %(countdown)s.', countdown=contest.time_before_end|as_countdown) -}}
+                            {%- trans countdown=contest.time_before_end|as_countdown -%} Your time is up! Contest ends in {{countdown}}. {%- endtrans -%}
                         {% else %}
-                            {{- _('You have %(countdown)s remaining.', countdown=live_participation.time_remaining|as_countdown) -}}
+                            {%- trans countdown=live_participation.time_remaining|as_countdown -%} You have {{countdown}} remaining. {%- endtrans -%}
                         {% endif %}
                     {%- else -%}
-                        {{ _('Contest ends in %(countdown)s.', countdown=contest.time_before_end|as_countdown) }}
+                        {%- trans countdown=contest.time_before_end|as_countdown -%} Contest ends in {{countdown}} {%- endtrans -%}
                     {%- endif -%}
                 {% endif %}
             {%- endif -%}

--- a/templates/contest/list.html
+++ b/templates/contest/list.html
@@ -106,9 +106,9 @@
         {% endif %}
         <br>
         {% if contest.time_limit %}
-            {{ _('%(time_limit)s window', time_limit=contest.time_limit|timedelta('localized-no-seconds')) }}
+            {%- trans time_limit=contest.time_limit|timedelta('localized-no-seconds') -%}{{time_limit}} window{%- endtrans -%}
         {% else %}
-            {{ _('%(duration)s long', duration=contest.contest_window_length|timedelta('localized-no-seconds')) }}
+            {%- trans duration=contest.contest_window_length|timedelta('localized-no-seconds') -%}{{duration}} long{%- endtrans -%}
         {% endif %}
     </div>
 {% endmacro %}
@@ -212,7 +212,7 @@
                                 {% if contest.start_time %}
                                     <br>
                                     {% if contest.time_before_end %}
-                                        <span class="time">{{ _('Ends in %(countdown)s', countdown=contest.time_before_end|as_countdown) }}</span>
+                                        <span class="time">{%- trans countdown=contest.time_before_end|as_countdown -%} Ends in {{countdown}} {%- endtrans -%}</span>
                                     {% endif %}
                                     {{ time_left(contest) }}
                                 {% endif %}
@@ -246,7 +246,7 @@
                                 {% if contest.start_time %}
                                     <br>
                                     {% if contest.time_before_start %}
-                                        <span class="time">{{ _('Starting in %(countdown)s.', countdown=contest.time_before_start|as_countdown) }}</span>
+                                        <span class="time">{%- trans countdown=contest.time_before_start|as_countdown -%} Starting in {{countdown}}. {%- endtrans -%}</span>
                                     {% endif %}
                                     {{ time_left(contest) }}
                                 {% endif %}

--- a/templates/contest/list.html
+++ b/templates/contest/list.html
@@ -119,11 +119,11 @@
     {% else %}
         {{ contest.user_count }}
     {% endif %}
-    <span title="{% trans count=contest.virtual_count %}
+    <span title="{%- trans count=contest.virtual_count -%}
         This contest has {{count}} virtual participation
-        {% pluralize %}
+        {%- pluralize -%}
         This contest has {{count}} virtual participations
-        {% endtrans %}"
+        {%- endtrans -%}"
         style="opacity: 50%;">({{ contest.virtual_count }})</span>
 {% endmacro %}
 

--- a/templates/contest/list.html
+++ b/templates/contest/list.html
@@ -171,9 +171,9 @@
                                     {% if contest.start_time %}
                                         <br>
                                         {% if contest.time_limit %}
-                                            <span class="time">{{ _('Window ends in %(countdown)s', countdown=participation.time_remaining|as_countdown) }}</span>
+                                            <span class="time">{%- trans countdown=participation.time_remaining|as_countdown -%} Window ends in {{countdown}} {%- endtrans -%}</span>
                                         {% elif contest.time_before_end %}
-                                            <span class="time">{{ _('Ends in %(countdown)s', countdown=contest.time_before_end|as_countdown) }}</span>
+                                            <span class="time">{%- trans countdown=contest.time_before_end|as_countdown -%} Ends in {{countdown}} {%- endtrans -%}</span>
                                         {% endif %}
                                         {{ time_left(contest) }}
                                     {% endif %}


### PR DESCRIPTION
I don't really know why but all string with this format will not appear in the po files: ` {{ _('%(x)s.', x=y|z) }}`

So I remove it and use the `{% trans %}` block instead

I also add `-` to the trans block to remove the padding and make the translation works.

