### PR TITLE
Disable comments during contests

### DIFF
--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -51,7 +51,7 @@ VNOJ_ORG_PP_STEP = 0.95
 VNOJ_ORG_PP_ENTRIES = 100
 VNOJ_ORG_PP_SCALE = 1
 
-VNOJ_HAS_OFFICIAL_CONTEST = False
+VNOJ_OFFICIAL_CONTEST_MODE = False
 
 # Contribution points function
 # Both should be int

--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -51,6 +51,8 @@ VNOJ_ORG_PP_STEP = 0.95
 VNOJ_ORG_PP_ENTRIES = 100
 VNOJ_ORG_PP_SCALE = 1
 
+VNOJ_HAS_OFFICIAL_CONTEST = False
+
 # Contribution points function
 # Both should be int
 VNOJ_CP_COMMENT = 1  # Each comment vote equals 1 CP

--- a/judge/middleware.py
+++ b/judge/middleware.py
@@ -70,7 +70,7 @@ class ContestMiddleware(object):
         self.get_response = get_response
 
     def __call__(self, request):
-        request.has_official_contest = settings.VNOJ_HAS_OFFICIAL_CONTEST
+        request.has_official_contest = settings.VNOJ_OFFICIAL_CONTEST_MODE
         profile = request.profile
         if profile:
             profile.update_contest()

--- a/judge/middleware.py
+++ b/judge/middleware.py
@@ -70,6 +70,7 @@ class ContestMiddleware(object):
         self.get_response = get_response
 
     def __call__(self, request):
+        request.has_official_contest = settings.VNOJ_HAS_OFFICIAL_CONTEST
         profile = request.profile
         if profile:
             profile.update_contest()

--- a/judge/middleware.py
+++ b/judge/middleware.py
@@ -70,7 +70,7 @@ class ContestMiddleware(object):
         self.get_response = get_response
 
     def __call__(self, request):
-        request.has_official_contest = settings.VNOJ_OFFICIAL_CONTEST_MODE
+        request.official_contest_mode = settings.VNOJ_OFFICIAL_CONTEST_MODE
         profile = request.profile
         if profile:
             profile.update_contest()

--- a/templates/comments/list.html
+++ b/templates/comments/list.html
@@ -1,170 +1,172 @@
-<div id="comments" class="comment-area">
-    <h2><i style="padding-right: 0.3em" class="fa fa-comments"></i>{{ _('Comments') }}</h2>
-    {% if has_comments %}
-        <ul class="comments top-level-comments new-comments">
-            {% set logged_in = request.user.is_authenticated %}
-            {% set profile = request.profile if logged_in else None %}
-            {% for node in mptt_tree(comment_list) recursive %}
-                <li id="comment-{{ node.id }}" data-revision="{{ node.revisions - 1 }}"
-                    data-max-revision="{{ node.revisions - 1 }}"
-                    data-revision-ajax="{{ url('comment_revision_ajax', node.id) }}" class="comment">
-                    <div class="comment-display{% if node.score <= vote_hide_threshold %} bad-comment{% endif %}">
-                        <div class="info">
-                            <div class="vote">
-                                {% if logged_in %}
-                                    <a href="javascript:comment_upvote({{ node.id }})"
-                                       class="upvote-link fa fa-chevron-up fa-fw{% if node.vote_score == 1 %} voted{% endif %}"></a>
-                                {% else %}
-                                    <a href="javascript:alert('{{ _('Please login to vote')|escapejs }}')" title="{{ _('Please login to vote') }}"
-                                       class="upvote-link fa fa-chevron-up fa-fw"></a>
-                                {% endif %}
-                                <br>
-                                <div class="comment-score">{{ node.score }}</div>
-                                {% if logged_in %}
-                                    <a href="javascript:comment_downvote({{ node.id }})"
-                                       class="downvote-link fa fa-chevron-down fa-fw{% if node.vote_score == -1 %} voted{% endif %}"></a>
-                                {% else %}
-                                    <a href="javascript:alert('{{ _('Please login to vote')|escapejs }}')" title="{{ _('Please login to vote') }}"
-                                       class="downvote-link fa fa-chevron-down fa-fw"></a>
-                                {% endif %}
-                            </div>
-                            {% with author=node.author, user=node.author.user %}
-                                <a href="{{ url('user_page', user.username) }}" class="user gravatar-main">
-                                    <img src="{{ gravatar(author, 135) }}" class="gravatar">
-                                </a>
-                            {% endwith %}
-                        </div>
-                        <div class="detail">
-                            <div class="header">
-                                <span>
-                                    {% with author=node.author, user=node.author.user %}
-                                        <a href="{{ url('user_page', user.username) }}" class="user gravatar-mobile">
-                                            <img src="{{ gravatar(author, 135) }}" class="gravatar">
-                                        </a>
-                                    {% endwith %}
-                                    {{ link_user(node.author) }}&nbsp;
-                                </span>
-                                {{ relative_time(node.time, abs=_('commented on {time}'), rel=_('commented {time}')) }}
-                                <span class="comment-spacer"></span>
-                                <span class="comment-operation">
-                                {% if node.revisions > 1 %}
-                                    <span class="comment-edits">
-                                        <a href="javascript:show_revision({{ node.id }}, -1)"
-                                           class="previous-revision">&larr;</a>
-                                        <span class="comment-edit-text">
-                                            {% if node.revisions > 2 %}
-                                                {% trans edits=node.revisions - 1 %}edit {{ edits }}{% endtrans %}
-                                            {% else %}
-                                                {{ _('edited') }}
-                                            {% endif %}
-                                        </span>
-                                        <a href="javascript:show_revision({{ node.id }}, 1)" style="visibility: hidden"
-                                           class="next-revision">&rarr;</a>
-                                    </span>
-                                {% else %}
-                                    <span class="comment-edits"></span>
-                                {% endif %}
-                                    <a href="#comment-{{ node.id }}" title="{{ _('Link') }}" class="comment-link">
-                                    <i class="fa fa-link fa-fw"></i>
-                                </a>
-                                    {% if logged_in and not comment_lock %}
-                                        {% set can_edit = node.author.id == profile.id and not profile.mute %}
-                                        {% if can_edit %}
-                                            <a data-featherlight="{{ url('comment_edit_ajax', node.id) }}"
-                                               href="{{ url('comment_edit', node.id) }}"
-                                               title="{{ _('Edit') }}" class="edit-link">
-                                            <i class="fa fa-pencil fa-fw"></i>
-                                        </a>
-                                        {% else %}
-                                            <a href="javascript:reply_comment({{ node.id }})"
-                                               title="{{ _('Reply') }}">
-                                            <i class="fa fa-reply fa-fw"></i>
-                                        </a>
-                                        {% endif %}
-                                        {% if perms.judge.change_comment %}
-                                            {% if can_edit %}
-                                                <a href="javascript:reply_comment({{ node.id }})"
-                                                   title="{{ _('Reply') }}"><i class="fa fa-reply fa-fw"></i></a>
-                                            {% else %}
-                                                <a data-featherlight="{{ url('comment_edit_ajax', node.id) }}"
-                                                   href="{{ url('comment_edit', node.id) }}" title="{{ _('Edit') }}"
-                                                   class="edit-link"><i class="fa fa-pencil fa-fw"></i></a>
-                                            {% endif %}
-                                            <a data-featherlight="{{ url('comment_votes_ajax', node.id) }}"
-                                               href="javascript:void(0)"
-                                               title="{{ _('Votes') }}" class="votes-link"><i class="fa fa-bar-chart fa-fw"></i></a>
-                                            <a href="javascript:void(0)" title="{{ _('Hide') }}" data-id="{{ node.id }}"
-                                               class="hide-comment"><i class="fa fa-trash fa-fw"></i></a>
-                                            <a href="{{ url('admin:judge_comment_change', node.id) }}"
-                                               title="{{ _('Admin') }}"><i class="fa fa-cog fa-fw"></i></a>
-                                        {% endif %}
+{% if not request.has_official_contest or request.user.is_superuser %}
+    <div id="comments" class="comment-area">
+        <h2><i style="padding-right: 0.3em" class="fa fa-comments"></i>{{ _('Comments') }}</h2>
+        {% if has_comments %}
+            <ul class="comments top-level-comments new-comments">
+                {% set logged_in = request.user.is_authenticated %}
+                {% set profile = request.profile if logged_in else None %}
+                {% for node in mptt_tree(comment_list) recursive %}
+                    <li id="comment-{{ node.id }}" data-revision="{{ node.revisions - 1 }}"
+                        data-max-revision="{{ node.revisions - 1 }}"
+                        data-revision-ajax="{{ url('comment_revision_ajax', node.id) }}" class="comment">
+                        <div class="comment-display{% if node.score <= vote_hide_threshold %} bad-comment{% endif %}">
+                            <div class="info">
+                                <div class="vote">
+                                    {% if logged_in %}
+                                        <a href="javascript:comment_upvote({{ node.id }})"
+                                        class="upvote-link fa fa-chevron-up fa-fw{% if node.vote_score == 1 %} voted{% endif %}"></a>
+                                    {% else %}
+                                        <a href="javascript:alert('{{ _('Please login to vote')|escapejs }}')" title="{{ _('Please login to vote') }}"
+                                        class="upvote-link fa fa-chevron-up fa-fw"></a>
                                     {% endif %}
-                            </span>
-                            </div>
-                            <div class="content content-description">
-                                <div class="comment-body"{% if node.score <= vote_hide_threshold %} style="display:none"{% endif %}>
-                                    {{ node.body|markdown('comment', MATH_ENGINE, True)|reference|str|safe }}
+                                    <br>
+                                    <div class="comment-score">{{ node.score }}</div>
+                                    {% if logged_in %}
+                                        <a href="javascript:comment_downvote({{ node.id }})"
+                                        class="downvote-link fa fa-chevron-down fa-fw{% if node.vote_score == -1 %} voted{% endif %}"></a>
+                                    {% else %}
+                                        <a href="javascript:alert('{{ _('Please login to vote')|escapejs }}')" title="{{ _('Please login to vote') }}"
+                                        class="downvote-link fa fa-chevron-down fa-fw"></a>
+                                    {% endif %}
                                 </div>
-                                {% if node.score <= vote_hide_threshold %}
-                                    <div class="comment-body bad-comment-body">
-                                        <p>
-                                            {% trans id=node.id %}
-                                                This comment is hidden due to too much negative feedback.
-                                                Click <a href="javascript:comment_show_content({{ id }})">here</a> to view it.
-                                            {% endtrans %}
-                                        </p>
+                                {% with author=node.author, user=node.author.user %}
+                                    <a href="{{ url('user_page', user.username) }}" class="user gravatar-main">
+                                        <img src="{{ gravatar(author, 135) }}" class="gravatar">
+                                    </a>
+                                {% endwith %}
+                            </div>
+                            <div class="detail">
+                                <div class="header">
+                                    <span>
+                                        {% with author=node.author, user=node.author.user %}
+                                            <a href="{{ url('user_page', user.username) }}" class="user gravatar-mobile">
+                                                <img src="{{ gravatar(author, 135) }}" class="gravatar">
+                                            </a>
+                                        {% endwith %}
+                                        {{ link_user(node.author) }}&nbsp;
+                                    </span>
+                                    {{ relative_time(node.time, abs=_('commented on {time}'), rel=_('commented {time}')) }}
+                                    <span class="comment-spacer"></span>
+                                    <span class="comment-operation">
+                                    {% if node.revisions > 1 %}
+                                        <span class="comment-edits">
+                                            <a href="javascript:show_revision({{ node.id }}, -1)"
+                                            class="previous-revision">&larr;</a>
+                                            <span class="comment-edit-text">
+                                                {% if node.revisions > 2 %}
+                                                    {% trans edits=node.revisions - 1 %}edit {{ edits }}{% endtrans %}
+                                                {% else %}
+                                                    {{ _('edited') }}
+                                                {% endif %}
+                                            </span>
+                                            <a href="javascript:show_revision({{ node.id }}, 1)" style="visibility: hidden"
+                                            class="next-revision">&rarr;</a>
+                                        </span>
+                                    {% else %}
+                                        <span class="comment-edits"></span>
+                                    {% endif %}
+                                        <a href="#comment-{{ node.id }}" title="{{ _('Link') }}" class="comment-link">
+                                        <i class="fa fa-link fa-fw"></i>
+                                    </a>
+                                        {% if logged_in and not comment_lock %}
+                                            {% set can_edit = node.author.id == profile.id and not profile.mute %}
+                                            {% if can_edit %}
+                                                <a data-featherlight="{{ url('comment_edit_ajax', node.id) }}"
+                                                href="{{ url('comment_edit', node.id) }}"
+                                                title="{{ _('Edit') }}" class="edit-link">
+                                                <i class="fa fa-pencil fa-fw"></i>
+                                            </a>
+                                            {% else %}
+                                                <a href="javascript:reply_comment({{ node.id }})"
+                                                title="{{ _('Reply') }}">
+                                                <i class="fa fa-reply fa-fw"></i>
+                                            </a>
+                                            {% endif %}
+                                            {% if perms.judge.change_comment %}
+                                                {% if can_edit %}
+                                                    <a href="javascript:reply_comment({{ node.id }})"
+                                                    title="{{ _('Reply') }}"><i class="fa fa-reply fa-fw"></i></a>
+                                                {% else %}
+                                                    <a data-featherlight="{{ url('comment_edit_ajax', node.id) }}"
+                                                    href="{{ url('comment_edit', node.id) }}" title="{{ _('Edit') }}"
+                                                    class="edit-link"><i class="fa fa-pencil fa-fw"></i></a>
+                                                {% endif %}
+                                                <a data-featherlight="{{ url('comment_votes_ajax', node.id) }}"
+                                                href="javascript:void(0)"
+                                                title="{{ _('Votes') }}" class="votes-link"><i class="fa fa-bar-chart fa-fw"></i></a>
+                                                <a href="javascript:void(0)" title="{{ _('Hide') }}" data-id="{{ node.id }}"
+                                                class="hide-comment"><i class="fa fa-trash fa-fw"></i></a>
+                                                <a href="{{ url('admin:judge_comment_change', node.id) }}"
+                                                title="{{ _('Admin') }}"><i class="fa fa-cog fa-fw"></i></a>
+                                            {% endif %}
+                                        {% endif %}
+                                </span>
+                                </div>
+                                <div class="content content-description">
+                                    <div class="comment-body"{% if node.score <= vote_hide_threshold %} style="display:none"{% endif %}>
+                                        {{ node.body|markdown('comment', MATH_ENGINE, True)|reference|str|safe }}
                                     </div>
-                                {% endif %}
+                                    {% if node.score <= vote_hide_threshold %}
+                                        <div class="comment-body bad-comment-body">
+                                            <p>
+                                                {% trans id=node.id %}
+                                                    This comment is hidden due to too much negative feedback.
+                                                    Click <a href="javascript:comment_show_content({{ id }})">here</a> to view it.
+                                                {% endtrans %}
+                                            </p>
+                                        </div>
+                                    {% endif %}
+                                </div>
                             </div>
                         </div>
-                    </div>
-                </li>
-                <ul id="comment-{{ node.id }}-reply" class="reply-comment" hidden></ul>
-                {% with children=node.get_children() %}
-                    {% if children %}
-                        <ul id="comment-{{ node.id }}-children" class="comments">{{ loop(children) }}</ul>
-                    {% endif %}
-                {% endwith %}
-            {% endfor %}
-        </ul>
-    {% elif not comment_lock %}
-        <p class="no-comments-message">{{ _('There are no comments at the moment.') }}</p>
-    {% endif %}
+                    </li>
+                    <ul id="comment-{{ node.id }}-reply" class="reply-comment" hidden></ul>
+                    {% with children=node.get_children() %}
+                        {% if children %}
+                            <ul id="comment-{{ node.id }}-children" class="comments">{{ loop(children) }}</ul>
+                        {% endif %}
+                    {% endwith %}
+                {% endfor %}
+            </ul>
+        {% elif not comment_lock %}
+            <p class="no-comments-message">{{ _('There are no comments at the moment.') }}</p>
+        {% endif %}
 
-    {% if request.user.is_authenticated and comment_form and not comment_lock %}
-        <div id="new-comment" class="form-area comment-submit">
-            {% block comment_submit_title %}
-                <h3>{{ _('New comment') }}</h3>
-                <hr>
-            {% endblock %}
-            {% if is_new_user %}
-                <div style="margin-bottom: 0" class="alert alert-info">
-                    {{ _('You need to have solved at least one problem before your voice can be heard.') }}
-                </div>
-            {% else %}
-                <form class="comment-submit-form" action="" method="post">
-                    {% csrf_token %}
-                    {% if comment_form.errors %}
-                        <div id="form-errors">
-                            {{ comment_form.non_field_errors() }}
-                            {{ comment_form.parent.errors }}
-                            {% if comment_form.body.errors %}{{ _('Invalid comment body.') }}{% endif %}
-                        </div>
-                    {% endif %}
-                    {{ comment_form.parent }}
-                    <div class="comment-post-wrapper">
-                        <div id="comment-form-body">{{ comment_form.body }}</div>
-                    </div>
+        {% if request.user.is_authenticated and comment_form and not comment_lock %}
+            <div id="new-comment" class="form-area comment-submit">
+                {% block comment_submit_title %}
+                    <h3>{{ _('New comment') }}</h3>
                     <hr>
-                    <input style="float:right" type="submit" value="{{ _('Post!') }}" class="button">
-                </form>
-            {% endif %}
-        </div>
-    {% endif %}
+                {% endblock %}
+                {% if is_new_user %}
+                    <div style="margin-bottom: 0" class="alert alert-info">
+                        {{ _('You need to have solved at least one problem before your voice can be heard.') }}
+                    </div>
+                {% else %}
+                    <form class="comment-submit-form" action="" method="post">
+                        {% csrf_token %}
+                        {% if comment_form.errors %}
+                            <div id="form-errors">
+                                {{ comment_form.non_field_errors() }}
+                                {{ comment_form.parent.errors }}
+                                {% if comment_form.body.errors %}{{ _('Invalid comment body.') }}{% endif %}
+                            </div>
+                        {% endif %}
+                        {{ comment_form.parent }}
+                        <div class="comment-post-wrapper">
+                            <div id="comment-form-body">{{ comment_form.body }}</div>
+                        </div>
+                        <hr>
+                        <input style="float:right" type="submit" value="{{ _('Post!') }}" class="button">
+                    </form>
+                {% endif %}
+            </div>
+        {% endif %}
 
-    {% if comment_lock %}
-        <div class="alert alert-warning comment-lock">
-            {{ _('Comments are disabled on this page.') }}
-        </div>
-    {% endif %}
-</div>
+        {% if comment_lock %}
+            <div class="alert alert-warning comment-lock">
+                {{ _('Comments are disabled on this page.') }}
+            </div>
+        {% endif %}
+    </div>
+{% endif %}

--- a/templates/comments/list.html
+++ b/templates/comments/list.html
@@ -1,4 +1,4 @@
-{% if not request.has_official_contest or request.user.is_superuser %}
+{% if not request.official_contest_mode or request.user.is_superuser %}
     <div id="comments" class="comment-area">
         <h2><i style="padding-right: 0.3em" class="fa fa-comments"></i>{{ _('Comments') }}</h2>
         {% if has_comments %}


### PR DESCRIPTION
Now users cannot comment or read other comments during the official contest mode. Admins can still see and comment.

Normal users view:
![image](https://user-images.githubusercontent.com/52038546/118419972-c7293800-b6e7-11eb-8a6f-63ccb66817a2.png)
Admins view:
![image](https://user-images.githubusercontent.com/52038546/118420026-eaec7e00-b6e7-11eb-89b0-d00c08c6587c.png)
