### PR TITLE
Show problem clarifications in contest view

### DIFF
--- a/judge/views/blog.py
+++ b/judge/views/blog.py
@@ -43,7 +43,6 @@ class PostList(ListView):
                                          .order_by('-date', 'code')[:settings.DMOJ_BLOG_NEW_PROBLEM_COUNT]
         context['page_titles'] = CacheDict(lambda page: Comment.get_page_title(page))
 
-
         context['user_count'] = Profile.objects.count
         context['problem_count'] = Problem.get_public_problems().count
         context['submission_count'] = lambda: Submission.objects.aggregate(max_id=Max('id'))['max_id'] or 0

--- a/judge/views/blog.py
+++ b/judge/views/blog.py
@@ -8,7 +8,7 @@ from django.utils.translation import ugettext as _
 from django.views.generic import ListView
 
 from judge.comments import CommentedDetailView
-from judge.models import BlogPost, Comment, Contest, Language, Problem, ProblemClarification, Profile, Submission, \
+from judge.models import BlogPost, Comment, Contest, Language, Problem, Profile, Submission, \
     Ticket
 from judge.utils.cachedict import CacheDict
 from judge.utils.diggpaginator import DiggPaginator
@@ -43,13 +43,6 @@ class PostList(ListView):
                                          .order_by('-date', 'code')[:settings.DMOJ_BLOG_NEW_PROBLEM_COUNT]
         context['page_titles'] = CacheDict(lambda page: Comment.get_page_title(page))
 
-        context['has_clarifications'] = False
-        if self.request.user.is_authenticated:
-            participation = self.request.profile.current_contest
-            if participation:
-                clarifications = ProblemClarification.objects.filter(problem__in=participation.contest.problems.all())
-                context['has_clarifications'] = clarifications.count() > 0
-                context['clarifications'] = clarifications.order_by('-date')
 
         context['user_count'] = Profile.objects.count
         context['problem_count'] = Problem.get_public_problems().count

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -32,7 +32,7 @@ from judge import event_poster as event
 from judge.comments import CommentedDetailView
 from judge.forms import ContestCloneForm
 from judge.models import Contest, ContestMoss, ContestParticipation, ContestProblem, ContestTag, \
-    Problem, Profile, Submission
+    Problem, ProblemClarification, Profile, Submission
 from judge.tasks import run_moss
 from judge.utils.celery import redirect_to_task_status
 from judge.utils.opengraph import generate_opengraph
@@ -252,6 +252,10 @@ class ContestDetail(ContestMixin, TitleMixin, CommentedDetailView):
         context['contest_has_public_editorials'] = any(
             problem.is_public and problem.has_public_editorial for problem in context['contest_problems']
         )
+
+        clarifications = ProblemClarification.objects.filter(problem__in=self.object.problems.all())
+        context['has_clarifications'] = clarifications.count() > 0
+        context['clarifications'] = clarifications.order_by('-date')
         return context
 
 

--- a/templates/blog/list.html
+++ b/templates/blog/list.html
@@ -44,11 +44,6 @@
             margin-left: 1em;
         }
 
-        .no-clarifications-message {
-            font-style: italic;
-            text-align: center;
-        }
-
         table.bottom td.left {
             text-align: left;
             border-right: none !important;
@@ -136,30 +131,6 @@
         </div>
 
         <div class="blog-sidebar">
-            {% if request.in_contest and request.participation.contest.use_clarifications %}
-                <div class="blog-sidebox sidebox">
-                    <h3>{{ _('Clarifications') }} <i class="fa fa-question-circle"></i></h3>
-                    <div class="sidebox-content">
-                        {% if has_clarifications %}
-                            <ul>
-                                {% for clarification in clarifications %}
-                                    <li class="clarification">
-                                        <a href="{{ url('problem_detail', clarification.problem.code) }}"
-                                           class="problem">
-                                            {{ clarification.problem.name }}
-                                        </a>
-                                        <span class="time">{{ relative_time(clarification.date) }}</span>
-                                    </li>
-                                {% endfor %}
-                            </ul>
-                        {% else %}
-                            <p class="no-clarifications-message">
-                                {{ _('No clarifications have been made at this time.') }}
-                            </p>
-                        {% endif %}
-                    </div>
-                </div>
-            {% endif %}
             {% if current_contests %}
                 <div class="blog-sidebox sidebox">
                     <h3>{{ _('Ongoing contests') }} <i class="fa fa-trophy"></i></h3>

--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -117,6 +117,36 @@
                 </tbody>
             </table>
         </div>
+        {% if has_clarifications %}
+        <div class="contest-clartifications">
+            <h2><i class="fa fa-question-circle"></i> {{ _('Clarifications') }}</h2>
+            <table id="contest-clartifications" class="table">
+                <thead>
+                    <tr>
+                        <th>{{ _('When') }}</th>
+                        <th>{{ _('Problem') }}</th>
+                        <th>{{ _('Description') }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for clarification in clarifications %}
+                    <tr>
+                        <td class="when">{{ clarification.date|date(_("F j, Y, G:i")) }}</td>
+                        <td>
+                            <a href="{{ url('problem_detail', clarification.problem.code) }}"
+                                class="problem">
+                                {{ clarification.problem.name }}
+                            </a>
+                        </td>
+                        <td class="body">
+                            {{ clarification.description|markdown('problem', MATH_ENGINE)|reference }}
+                        </td> 
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% endif %}
     {% endif %}
 
     <hr>

--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -81,6 +81,7 @@
             <table id="contest-problems" class="table">
                 <thead>
                 <tr>
+                    <th>#</th>
                     <th>{{ _('Problem') }}</th>
                     <th>{{ _('Points') }}</th>
                     <th>{{ _('AC Rate') }}</th>
@@ -93,7 +94,8 @@
                 <tbody>
                 {% for problem in contest_problems %}
                     <tr>
-                        <td>
+                        <td style="width: 1em;">{{loop.index}}</td>
+                        <td style="text-align: left; padding-left: 2em;">
                             {% if in_contest or problem.is_public or request.user.is_superuser or is_editor or is_tester %}
                                 <a href="{{ url('problem_detail', problem.code) }}">{{ problem.i18n_name or problem.name }}</a>
                             {% else %}

--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -119,7 +119,7 @@
         </div>
         {% if has_clarifications %}
         <div class="contest-clartifications">
-            <h2><i class="fa fa-question-circle"></i> {{ _('Clarifications') }}</h2>
+            <h2 style="margin-bottom: 0.2em"><i class="fa fa-question-circle"></i> {{ _('Clarifications') }}</h2>
             <table id="contest-clartifications" class="table">
                 <thead>
                     <tr>
@@ -131,14 +131,14 @@
                 <tbody>
                 {% for clarification in clarifications %}
                     <tr>
-                        <td class="when">{{ clarification.date|date(_("F j, Y, G:i")) }}</td>
-                        <td>
+                        <td style="width: 15%;">{{ clarification.date|date(_("F j, Y, G:i")) }}</td>
+                        <td style="width: 20%; text-align: left; padding-left: 2em;">
                             <a href="{{ url('problem_detail', clarification.problem.code) }}"
                                 class="problem">
                                 {{ clarification.problem.name }}
                             </a>
                         </td>
-                        <td class="body">
+                        <td style="text-align: left; padding-left: 2em;">
                             {{ clarification.description|markdown('problem', MATH_ENGINE)|reference }}
                         </td> 
                     </tr>

--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -119,7 +119,7 @@
         </div>
         {% if has_clarifications %}
         <div class="contest-clartifications">
-            <h2 style="margin-bottom: 0.2em"><i class="fa fa-question-circle"></i> {{ _('Clarifications') }}</h2>
+            <h2 style="margin-bottom: 0.2em"><i class="fa fa-check"></i> {{ _('Clarifications') }}</h2>
             <table id="contest-clartifications" class="table">
                 <thead>
                     <tr>


### PR DESCRIPTION
This fix #59 

Now problem clarifications will show under the problems table in contest view.:
![image](https://user-images.githubusercontent.com/23715841/118614249-bf51bc80-b7e9-11eb-80ed-336d78527f07.png)

Problem name in contest table is aligned to the left:
![image](https://user-images.githubusercontent.com/23715841/118622808-db595c00-b7f1-11eb-906b-d0f24c5e7776.png)
