### PR TITLE
Add more information on failed login

### DIFF
--- a/judge/forms.py
+++ b/judge/forms.py
@@ -6,6 +6,7 @@ import webauthn
 from django import forms
 from django.conf import settings
 from django.contrib.auth.forms import AuthenticationForm
+from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.db.models import Q
@@ -163,6 +164,16 @@ class CustomAuthenticationForm(AuthenticationForm):
     def _has_social_auth(self, key):
         return (getattr(settings, 'SOCIAL_AUTH_%s_KEY' % key, None) and
                 getattr(settings, 'SOCIAL_AUTH_%s_SECRET' % key, None))
+
+    def clean(self):
+        username = self.cleaned_data.get('username')
+        try:
+            user = User.objects.get(username=username)
+        except User.DoesNotExist:
+            user = None
+        if user is not None:
+            super(CustomAuthenticationForm, self).confirm_login_allowed(user)
+        return super(CustomAuthenticationForm, self).clean()
 
 
 class NoAutoCompleteCharField(forms.CharField):

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -31,8 +31,11 @@
         <form action="" method="post" class="form-area">
             {% csrf_token %}
             {% if form.errors %}
-                <div id="form-errors">
+                <div id="form-errors" style="max-width: fit-content;">
                     <p class="error">{{ _('Invalid username or password.') }}</p>
+                    {% for error in form.non_field_errors() %}
+                        <p class="error">{{error}}</p>
+                    {% endfor %}
                 </div>
             {% endif %}
             <table border="0" style="text-align:left">


### PR DESCRIPTION
If users haven't activated their account, the login form will tell them about that instead of showing "Invalid username or password", whic could lead them to reset their password
![image](https://user-images.githubusercontent.com/23715841/119268711-671e1e80-bc1e-11eb-9abd-6ed36227eaf5.png)
