### PR TITLE
Limit available feedback in submission

### DIFF
--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -126,7 +126,11 @@ def group_test_cases(cases):
     buf = []
     max_execution_time = 0.0
     last = None
+    test_case_count = 0
     for case in cases:
+        # Don't use test_case_count = len(cases) because cases is a queryset
+        # `cases` is not a list.
+        test_case_count += 1
         if case.time:
             max_execution_time = max(max_execution_time, case.time)
         if case.batch != last and buf:
@@ -138,7 +142,7 @@ def group_test_cases(cases):
     if buf:
         result.append(make_batch(last, buf))
         status.extend(get_statuses(last, buf))
-    return result, status, max_execution_time
+    return result, status, max_execution_time, test_case_count
 
 
 class SubmissionStatus(SubmissionDetailBase):
@@ -149,7 +153,11 @@ class SubmissionStatus(SubmissionDetailBase):
         submission = self.object
         context['last_msg'] = event.last()
 
-        context['batches'], statuses, context['max_execution_time'] = group_test_cases(submission.test_cases.all())
+        context['batches'], statuses, context['max_execution_time'], test_case_count \
+            = group_test_cases(submission.test_cases.all())
+
+        context['feedback_limit'] = min(3, test_case_count - 1)
+
         context['statuses'] = combine_statuses(statuses, submission)
 
         context['time_limit'] = submission.problem.time_limit

--- a/templates/submission/status-testcases.html
+++ b/templates/submission/status-testcases.html
@@ -46,6 +46,7 @@
             <br><br>
         {% endif %}
         {% set test_case_id = counter() %}
+        {% set test_case_counter = counter() %}
         {% for batch in batches %}
             {% if batch.id %}
                 <b>{{ _('Batch ') }}#{{ test_case_id() }}</b>
@@ -54,10 +55,15 @@
                 <div class="batch-cases">
             {% endif %}
         <table class="submissions-status-table">{% for case in batch.cases %}
-            {% set print_case_output = case.status != 'AC' and case.output and (prefix_length is none or prefix_length > 0) %}
+            {% set current_test_case_count = test_case_counter() %}
+            {% set print_case_output = request.user.is_superuser and case.status != 'AC' and case.output and (prefix_length is none or prefix_length > 0) %}
+            {% set print_case_ext_feedback = case.extended_feedback
+                                             and
+                                             ((not request.in_contest and current_test_case_count <= feedback_limit)
+                                              or request.user.is_superuser) %}
             <tr id="{{ case.id }}" class="case-row toggle closed">
                 <td>
-                    {%- if print_case_output or case.extended_feedback -%}
+                    {%- if print_case_output or print_case_ext_feedback -%}
                         <i class="fa fa-chevron-right fa-fw"></i>
                     {%- endif -%}
                     {%- if batch.id -%}
@@ -93,9 +99,9 @@
                 {% endif %}
             </tr>
 
-            {% if print_case_output or case.extended_feedback %}
+            {% if print_case_output or print_case_ext_feedback %}
                 <tr id="{{ case.id }}-output" style="display:none" class="case-feedback toggled">
-                    {% if print_case_output and request.user.is_superuser %}
+                    {% if print_case_output %}
                         <td colspan="5" class="case-output">
                             <div class="case-info">
                                 <strong>{{ _('Your output (clipped)') }}</strong>
@@ -107,7 +113,7 @@
                             </div>
                         </td>
                     {% endif %}
-                    {% if case.extended_feedback and not request.in_contest %}
+                    {% if print_case_ext_feedback %}
                         <td colspan="5" class="case-ext-feedback">
                             <div class="case-info">
                                 <strong>{{ _('Judge feedback') }}</strong>


### PR DESCRIPTION
Currently, users can view feedback of all test cases if that user is not in a contest. 
That feature's purpose was to help users debug the input/output format. However, some users is use this as a cheat to get all input and output. 

Now users can only view the feedback of the first `min(3, n_test - 1)` test cases. 