### PR TITLE
Improve contest stats

### DIFF
--- a/judge/models/contest.py
+++ b/judge/models/contest.py
@@ -284,7 +284,7 @@ class Contest(models.Model):
 
     def update_user_count(self):
         self.user_count = self.users.filter(virtual=0).count()
-        self.virtual_count = self.users.count()
+        self.virtual_count = self.users.filter(virtual__gt=ContestParticipation.SPECTATE).count()
         self.save()
 
     update_user_count.alters_data = True

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -637,7 +637,7 @@ def base_contest_ranking_list(contest, problems, queryset):
 
 
 def contest_ranking_list(contest, problems):
-    return base_contest_ranking_list(contest, problems, contest.users.filter()
+    return base_contest_ranking_list(contest, problems, contest.users.filter(virtual__gt=ContestParticipation.SPECTATE)
                                      .prefetch_related('user__organizations')
                                      .order_by('is_disqualified', '-score', 'cumtime', 'tiebreaker'))
 

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -247,8 +247,11 @@ class ContestDetail(ContestMixin, TitleMixin, CommentedDetailView):
         # calculate problem AC rate in contest
         contest_problem_fields = self.object.contest_problems.defer('problem__description') \
             .order_by('order') \
-            .annotate(user_count=Count('submission__submission', filter=Q(submission__submission__result='AC'))) \
-            .annotate(submission_count=Count('submission__submission')) \
+            .annotate(user_count=Count('submission__submission',
+                      filter=Q(submission__submission__result='AC') &
+                      Q(submission__submission__date__gt=self.object.start_time))) \
+            .annotate(submission_count=Count('submission__submission',
+                      filter=Q(submission__submission__date__gt=self.object.start_time))) \
             .values('points', 'user_count', 'submission_count')
 
         for p, contest_p in zip(context['contest_problems'], contest_problem_fields):
@@ -540,7 +543,7 @@ class ContestStats(TitleMixin, ContestMixin, DetailView):
         if not (self.object.ended or self.can_edit):
             raise Http404()
 
-        queryset = Submission.objects.filter(contest_object=self.object)
+        queryset = Submission.objects.filter(contest_object=self.object, date__gt=self.object.start_time)
 
         ac_count = Count(Case(When(result='AC', then=Value(1)), output_field=IntegerField()))
         ac_rate = CombinedExpression(ac_count / Count('problem'), '*', Value(100.0), output_field=FloatField())


### PR DESCRIPTION
- Don't count SPECTATE virtual as virtual (SPECTATE is when tests join the contest)
- In contest stats, only calculate the AC rate with submission after the contest start time (since there might be submissions of testers before the contest start)