### PR TITLE
Block comments during contest

### DIFF
--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -233,7 +233,7 @@ class ContestDetail(ContestMixin, TitleMixin, CommentedDetailView):
     def is_comment_locked(self):
         if self.object.use_clarifications:
             now = timezone.now()
-            if self.object.is_in_contest(self.request.user) or  \
+            if self.object.is_in_contest(self.request.user) or \
                     (self.object.start_time <= now and now <= self.object.end_time):
                 return True
 

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -230,6 +230,15 @@ class ContestMixin(object):
 class ContestDetail(ContestMixin, TitleMixin, CommentedDetailView):
     template_name = 'contest/contest.html'
 
+    def is_comment_locked(self):
+        if self.object.use_clarifications:
+            now = timezone.now()
+            if self.object.is_in_contest(self.request.user) or  \
+                    (self.object.start_time <= now and now <= self.object.end_time):
+                return True
+
+        return super(ContestDetail, self).is_comment_locked()
+
     def get_comment_page(self):
         return 'c:%s' % self.object.key
 

--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -155,17 +155,24 @@ class ProblemDetail(ProblemMixin, SolvedProblemMixin, CommentedDetailView):
     context_object_name = 'problem'
     template_name = 'problem/problem.html'
 
+    def is_comment_locked(self):
+        if self.contest_problem and self.contest_problem.contest.use_clarifications:
+            return True
+
+        return super(ProblemDetail, self).is_comment_locked()
+
     def get_comment_page(self):
         return 'p:%s' % self.object.code
 
     def get_context_data(self, **kwargs):
-        context = super(ProblemDetail, self).get_context_data(**kwargs)
         user = self.request.user
         authed = user.is_authenticated
+        self.contest_problem = contest_problem = (None if not authed or user.profile.current_contest is None else
+                                                  get_contest_problem(self.object, user.profile))
+
+        context = super(ProblemDetail, self).get_context_data(**kwargs)
         context['has_submissions'] = authed and Submission.objects.filter(user=user.profile,
                                                                           problem=self.object).exists()
-        contest_problem = (None if not authed or user.profile.current_contest is None else
-                           get_contest_problem(self.object, user.profile))
         context['contest_problem'] = contest_problem
         if contest_problem:
             clarifications = self.object.clarifications

--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -8,11 +8,6 @@
     {% include "contest/contest-tabs.html" %}
 {% endblock %}
 
-{%
-    set hide_comments = contest.use_clarifications and
-    (contest.is_in_contest(request.user) or (contest.start_time <= now and now <= contest.end_time))
-%}
-
 {% block content_js_media %}
     <script type="text/javascript">
         $(document).ready(function () {
@@ -22,13 +17,13 @@
         });
     </script>
     {% include "contest/media-js.html" %}
-    {% if not hide_comments %}
+    {% if not comment_lock %}
         {% include "comments/media-js.html" %}
     {% endif %}
 {% endblock %}
 
 {% block content_media %}
-    {% if not hide_comments %}
+    {% if not comment_lock %}
         {% include "comments/media-css.html" %}
     {% else %}
         <style>
@@ -206,7 +201,7 @@
         {{ post_to_twitter(request, SITE_NAME + ':', contest, '<i class="fa fa-twitter"></i>') }}
     </span>
 
-    {% if not hide_comments %}
+    {% if not comment_lock %}
         {% include "comments/list.html" %}
     {% endif %}
 {% endblock %}
@@ -215,7 +210,7 @@
 
 {% block bodyend %}
     {{ super() }}
-    {% if not hide_comments %}
+    {% if not comment_lock %}
         {% include "comments/math.html" %}
     {% endif %}
 {% endblock %}

--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -8,6 +8,11 @@
     {% include "contest/contest-tabs.html" %}
 {% endblock %}
 
+{%
+    set hide_comments = contest.use_clarifications and
+    (contest.is_in_contest(request.user) or (contest.start_time <= now and now <= contest.end_time))
+%}
+
 {% block content_js_media %}
     <script type="text/javascript">
         $(document).ready(function () {
@@ -17,11 +22,21 @@
         });
     </script>
     {% include "contest/media-js.html" %}
-    {% include "comments/media-js.html" %}
+    {% if not hide_comments %}
+        {% include "comments/media-js.html" %}
+    {% endif %}
 {% endblock %}
 
 {% block content_media %}
-    {% include "comments/media-css.html" %}
+    {% if not hide_comments %}
+        {% include "comments/media-css.html" %}
+    {% else %}
+        <style>
+            #content-body {
+                overflow: auto;
+            }
+        </style>
+    {% endif %}
 {% endblock %}
 
 {% block body %}
@@ -191,12 +206,16 @@
         {{ post_to_twitter(request, SITE_NAME + ':', contest, '<i class="fa fa-twitter"></i>') }}
     </span>
 
-    {% include "comments/list.html" %}
+    {% if not hide_comments %}
+        {% include "comments/list.html" %}
+    {% endif %}
 {% endblock %}
 
 {% block description_end %}{% endblock %}
 
 {% block bodyend %}
     {{ super() }}
-    {% include "comments/math.html" %}
+    {% if not hide_comments %}
+        {% include "comments/math.html" %}
+    {% endif %}
 {% endblock %}

--- a/templates/problem/problem.html
+++ b/templates/problem/problem.html
@@ -1,6 +1,8 @@
 {% extends "common-content.html" %}
 {% block content_media %}
-    {% include "comments/media-css.html" %}
+    {% if not comment_lock %}
+        {% include "comments/media-css.html" %}
+    {% endif %}
     <style>
         .title-state {
             font-size: 2em;
@@ -45,7 +47,9 @@
 {% endblock %}
 
 {% block content_js_media %}
-    {% include "comments/media-js.html" %}
+    {% if not comment_lock %}
+        {% include "comments/media-js.html" %}
+    {% endif %}
 {% endblock %}
 
 {% block title_row %}
@@ -328,7 +332,7 @@
 {% block post_description_end %}
     {% if request.user.is_authenticated and not request.profile.mute %}
         <a href="{{ url('new_problem_ticket', problem.code) }}" class="button clarify">
-            {%- if contest_problem and contest_problem.contest.use_clarifications and request.profile.current_contest.live -%}
+            {%- if comment_lock and request.profile.current_contest.live -%}
                 {{ _('Request clarification') }}
             {%- else -%}
                 {{ _('Report an issue') }}
@@ -338,7 +342,7 @@
 {% endblock %}
 
 {% block comments %}
-    {% if contest_problem and contest_problem.contest.use_clarifications %}
+    {% if comment_lock %}
         <div class="clarifications-area">
             <h2><i class="fa fa-question-circle"></i> {{ _('Clarifications') }}</h2>
             {% if has_clarifications %}
@@ -361,5 +365,7 @@
 
 {% block bodyend %}
     {{ super() }}
-    {% include "comments/math.html" %}
+    {% if not comment_lock %}
+        {% include "comments/math.html" %}
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
Currently, the "No comments" option is only applied to contest problems, not contest detail. This PR fixes that by hiding the comment section in contest detail during the contest (including virtual participation).

Also block comments in backend (for both contest detail and contest problem).

Before:

![image](https://user-images.githubusercontent.com/17219541/129297485-c72ec708-596f-4b13-aecd-9b18e618e5cd.png)

After:

![image](https://user-images.githubusercontent.com/17219541/129297537-2716249a-0f67-4e94-b0f1-e79e8dbe66f7.png)

