### PR TITLE
submission view permission for all suggesters

### DIFF
--- a/judge/jinja2/submission.py
+++ b/judge/jinja2/submission.py
@@ -23,6 +23,9 @@ def submission_layout(submission, profile_id, user, completed_problem_ids, edita
         can_view = True
     elif profile_id == submission.user_id:
         can_view = True
+    elif not submission.problem.is_public and user.has_perm('judge.suggest_new_problem') and \
+            submission.problem.is_suggesting:
+        can_view = True
     elif settings.DMOJ_SUBMISSION_SOURCE_VISIBILITY == 'all':
         can_view = True
     elif submission.contest_object is not None and profile_id in get_editor_ids(submission.contest_object):

--- a/judge/models/submission.py
+++ b/judge/models/submission.py
@@ -138,6 +138,8 @@ class Submission(models.Model):
             return True
         elif user.has_perm('judge.view_all_submission'):
             return True
+        elif not self.problem.is_public and user.has_perm('judge.suggest_new_problem') and self.problem.is_suggesting:
+            return True
         elif self.user_id == profile.id:
             return True
         elif settings.DMOJ_SUBMISSION_SOURCE_VISIBILITY == 'all':


### PR DESCRIPTION
Suggesters can now see submission detail from problems suggested by other suggesters.