### PR TITLE
Allow selecting multiple private contestants. Add testers to problem form

### DIFF
--- a/judge/forms.py
+++ b/judge/forms.py
@@ -136,7 +136,8 @@ class ProblemEditForm(ModelForm):
             self.fields.pop('is_public')
         else:
             self.fields['testers'].label = _('Private users')
-            self.fields['testers'].help_text = _('If private, only these users may see the problem.')
+            self.fields['testers'].help_text = _('If private, only these users may see the problem. '
+                                                 'You can paste a list of usernames into this box.')
             self.fields['testers'].widget.data_view = None
             self.fields['testers'].widget.data_url = reverse('organization_profile_select2',
                                                              args=(org_pk, ))
@@ -177,6 +178,8 @@ class ProblemEditForm(ModelForm):
             'points': _('Points awarded for problem completion. From 0 to 2. '
                         'You can approximate: 0.5 is as hard as Problem 1 of VOI; 1 = Problem 2 of VOI; '
                         '1.5 = Problem 3 of VOI.'),
+            'testers': _('These users will be able to view the private problem, but not edit it. '
+                         'You can paste a list of usernames into this box.'),
         }
 
 
@@ -522,4 +525,9 @@ class ContestForm(ModelForm):
                 data_view='profile_select2',
                 attrs={'style': 'width: 100%'},
             ),
+        }
+
+        help_texts = {
+            'private_contestants': _('If private, only these users may see the contest. '
+                                     'You can paste a list of usernames into this box.'),
         }

--- a/judge/forms.py
+++ b/judge/forms.py
@@ -141,7 +141,9 @@ class ProblemEditForm(ModelForm):
             self.fields['testers'].widget.data_url = reverse('organization_profile_select2',
                                                              args=(org_pk, ))
 
-        self.fields['testers'].help_text = str(self.fields['testers'].help_text) + ' ' + str(_('You can paste a list of usernames into this box.'))
+        self.fields['testers'].help_text = \
+            str(self.fields['testers'].help_text) + ' ' + \
+            str(_('You can paste a list of usernames into this box.'))
 
     def clean(self):
         cleaned_data = super(ProblemEditForm, self).clean()
@@ -497,7 +499,9 @@ class ContestForm(ModelForm):
             self.fields['private_contestants'].widget.data_view = None
             self.fields['private_contestants'].widget.data_url = reverse('organization_profile_select2',
                                                                          args=(org_pk, ))
-            self.fields['private_contestants'].help_text = str(self.fields['private_contestants'].help_text) + ' ' + str(_('You can paste a list of usernames into this box.'))
+            self.fields['private_contestants'].help_text = \
+                str(self.fields['private_contestants'].help_text) + ' ' + \
+                str(_('You can paste a list of usernames into this box.'))
         else:
             self.fields.pop('private_contestants')
             self.fields.pop('is_private')

--- a/judge/forms.py
+++ b/judge/forms.py
@@ -136,11 +136,12 @@ class ProblemEditForm(ModelForm):
             self.fields.pop('is_public')
         else:
             self.fields['testers'].label = _('Private users')
-            self.fields['testers'].help_text = _('If private, only these users may see the problem. '
-                                                 'You can paste a list of usernames into this box.')
+            self.fields['testers'].help_text = _('If private, only these users may see the problem.')
             self.fields['testers'].widget.data_view = None
             self.fields['testers'].widget.data_url = reverse('organization_profile_select2',
                                                              args=(org_pk, ))
+
+        self.fields['testers'].help_text = str(self.fields['testers'].help_text) + ' ' + str(_('You can paste a list of usernames into this box.'))
 
     def clean(self):
         cleaned_data = super(ProblemEditForm, self).clean()
@@ -178,8 +179,6 @@ class ProblemEditForm(ModelForm):
             'points': _('Points awarded for problem completion. From 0 to 2. '
                         'You can approximate: 0.5 is as hard as Problem 1 of VOI; 1 = Problem 2 of VOI; '
                         '1.5 = Problem 3 of VOI.'),
-            'testers': _('These users will be able to view the private problem, but not edit it. '
-                         'You can paste a list of usernames into this box.'),
         }
 
 
@@ -498,6 +497,7 @@ class ContestForm(ModelForm):
             self.fields['private_contestants'].widget.data_view = None
             self.fields['private_contestants'].widget.data_url = reverse('organization_profile_select2',
                                                                          args=(org_pk, ))
+            self.fields['private_contestants'].help_text = str(self.fields['private_contestants'].help_text) + ' ' + str(_('You can paste a list of usernames into this box.'))
         else:
             self.fields.pop('private_contestants')
             self.fields.pop('is_private')
@@ -525,9 +525,4 @@ class ContestForm(ModelForm):
                 data_view='profile_select2',
                 attrs={'style': 'width: 100%'},
             ),
-        }
-
-        help_texts = {
-            'private_contestants': _('If private, only these users may see the contest. '
-                                     'You can paste a list of usernames into this box.'),
         }

--- a/judge/forms.py
+++ b/judge/forms.py
@@ -134,6 +134,10 @@ class ProblemEditForm(ModelForm):
         # Only allow to public/private problem in organization
         if org_pk is None:
             self.fields.pop('is_public')
+        else:
+            self.fields['testers'].widget.data_view = None
+            self.fields['testers'].widget.data_url = reverse('organization_profile_select2',
+                                                             args=(org_pk, ))
 
     def clean(self):
         cleaned_data = super(ProblemEditForm, self).clean()
@@ -150,11 +154,15 @@ class ProblemEditForm(ModelForm):
     class Meta:
         model = Problem
         fields = ['is_public', 'code', 'name', 'time_limit', 'memory_limit', 'points',
-                  'statement_file', 'source', 'types', 'group', 'description']
+                  'statement_file', 'source', 'types', 'group', 'description', 'testers']
         widgets = {
             'types': Select2MultipleWidget,
             'group': Select2Widget,
             'description': MartorWidget(attrs={'data-markdownfy-url': reverse_lazy('problem_preview')}),
+            'testers': HeavySelect2MultipleWidget(
+                data_view='profile_select2',
+                attrs={'style': 'width: 100%'},
+            ),
         }
         help_texts = {
             'is_public': _(

--- a/judge/forms.py
+++ b/judge/forms.py
@@ -1,7 +1,6 @@
 import json
 import os
 from operator import attrgetter, itemgetter
-from django.shortcuts import get_object_or_404
 
 import pyotp
 import webauthn
@@ -14,7 +13,8 @@ from django.core.validators import FileExtensionValidator, RegexValidator
 from django.db.models import Q
 from django.forms import BooleanField, CharField, ChoiceField, DateInput, Form, ModelForm, MultipleChoiceField, \
     inlineformset_factory
-from django.forms.widgets import DateTimeInput, TextInput
+from django.forms.widgets import DateTimeInput
+from django.shortcuts import get_object_or_404
 from django.template.defaultfilters import filesizeformat
 from django.urls import reverse, reverse_lazy
 from django.utils.translation import gettext_lazy as _

--- a/judge/forms.py
+++ b/judge/forms.py
@@ -135,6 +135,8 @@ class ProblemEditForm(ModelForm):
         if org_pk is None:
             self.fields.pop('is_public')
         else:
+            self.fields['testers'].label = _('Private users')
+            self.fields['testers'].help_text = _('If private, only these users may see the problem.')
             self.fields['testers'].widget.data_view = None
             self.fields['testers'].widget.data_url = reverse('organization_profile_select2',
                                                              args=(org_pk, ))

--- a/judge/forms.py
+++ b/judge/forms.py
@@ -14,7 +14,6 @@ from django.db.models import Q
 from django.forms import BooleanField, CharField, ChoiceField, DateInput, Form, ModelForm, MultipleChoiceField, \
     inlineformset_factory
 from django.forms.widgets import DateTimeInput
-from django.shortcuts import get_object_or_404
 from django.template.defaultfilters import filesizeformat
 from django.urls import reverse, reverse_lazy
 from django.utils.translation import gettext_lazy as _
@@ -474,36 +473,20 @@ class ProposeContestProblemFormSet(
 
 class ContestForm(ModelForm):
     required_css_class = 'required'
-    private_contestants_plain_text = CharField(required=False)
-
-    def clean_private_contestants_plain_text(self):
-        contestants = self.cleaned_data['private_contestants_plain_text']
-        if not contestants:
-            return
-        usernames = set(x.strip() for x in self.cleaned_data['private_contestants_plain_text'].split(','))
-        qs = get_object_or_404(Organization, pk=self.org_pk).members.filter(user__username__in=usernames)
-
-        not_found = usernames ^ set(qs.values_list('user__username', flat=True))
-
-        if not_found:
-            raise ValidationError(_("Users %(user)s not found in organization") % {'user': not_found})
-
-        self.cleaned_data['private_contestants'] = self.cleaned_data['private_contestants'].union(qs)
 
     def __init__(self, *args, **kwargs):
-        self.org_pk = kwargs.pop('org_pk', None)
+        org_pk = kwargs.pop('org_pk', None)
         super(ContestForm, self).__init__(*args, **kwargs)
 
         # cannot use fields[].widget = ...
         # because it will remove the old values
         # just update the data url is fine
-        if self.org_pk:
+        if org_pk:
             self.fields['private_contestants'].widget.data_view = None
             self.fields['private_contestants'].widget.data_url = reverse('organization_profile_select2',
-                                                                         args=(self.org_pk, ))
+                                                                         args=(org_pk, ))
         else:
             self.fields.pop('private_contestants')
-            self.fields.pop('private_contestants_plain_text')
             self.fields.pop('is_private')
 
     class Meta:

--- a/judge/migrations/0088_private_contests.py
+++ b/judge/migrations/0088_private_contests.py
@@ -27,7 +27,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='contest',
             name='private_contestants',
-            field=models.ManyToManyField(blank=True, help_text='If private, only these users may see the contest', related_name='_contest_private_contestants_+', to='judge.Profile', verbose_name='private contestants'),
+            field=models.ManyToManyField(blank=True, help_text='If private, only these users may see the contest.', related_name='_contest_private_contestants_+', to='judge.Profile', verbose_name='private contestants'),
         ),
         migrations.AlterField(
             model_name='contest',

--- a/judge/models/contest.py
+++ b/judge/models/contest.py
@@ -102,7 +102,7 @@ class Contest(models.Model):
                                           related_name='rate_exclude+')
     is_private = models.BooleanField(verbose_name=_('private to specific users'), default=False)
     private_contestants = models.ManyToManyField(Profile, blank=True, verbose_name=_('private contestants'),
-                                                 help_text=_('If private, only these users may see the contest'),
+                                                 help_text=_('If private, only these users may see the contest.'),
                                                  related_name='private_contestants+')
     hide_problem_tags = models.BooleanField(verbose_name=_('hide problem tags'),
                                             help_text=_('Whether problem tags should be hidden by default.'),

--- a/judge/views/select2.py
+++ b/judge/views/select2.py
@@ -47,6 +47,21 @@ class Select2View(BaseListView):
 
 
 class UserSelect2View(Select2View):
+    def get(self, request, *args, **kwargs):
+        if 'multiple_terms[]' not in request.GET:
+            return super().get(request, args, kwargs)
+
+        terms = request.GET.getlist('multiple_terms[]')
+        qs = Profile.objects.filter(user__username__in=terms).annotate(username=F('user__username')).only('id')
+
+        return JsonResponse({
+            'results': [
+                {
+                    'text': smart_text(self.get_name(obj)),
+                    'id': obj.pk,
+                } for obj in qs],
+        })
+
     def get_queryset(self):
         return _get_user_queryset(self.term).annotate(username=F('user__username')).only('id')
 

--- a/judge/views/select2.py
+++ b/judge/views/select2.py
@@ -55,6 +55,24 @@ class UserSelect2View(Select2View):
 
 
 class OrganizationUserSelect2View(Select2View):
+    def get(self, request, *args, **kwargs):
+        if 'multiple_terms[]' not in request.GET:
+            return super().get(request, args, kwargs)
+
+        terms = request.GET.getlist('multiple_terms[]')
+        qs = get_object_or_404(Organization, pk=self.org_pk).members \
+            .filter(user__username__in=terms) \
+            .annotate(username=F('user__username'), name=F('user__first_name')) \
+            .only('id')
+
+        return JsonResponse({
+            'results': [
+                {
+                    'text': smart_text(self.get_name(obj)),
+                    'id': obj.pk,
+                } for obj in qs],
+        })
+
     def dispatch(self, request, *args, **kwargs):
         if 'pk' not in kwargs:
             raise ImproperlyConfigured('Must pass a pk')

--- a/templates/contest/edit.html
+++ b/templates/contest/edit.html
@@ -25,6 +25,14 @@
                 prefix: '{{ contest_problem_formset.prefix }}'
             });
 
+            var noResults = function () {
+                return '{{ _('Press Enter to select multiple users...') }}';
+            };
+
+            $(document).one('click', '#id_private_contestants + .select2', function (e) {
+                $('#id_private_contestants').data().select2.options.get('translations').dict['noResults'] = noResults;
+            });
+
             $(document).on('keyup', '#id_private_contestants + .select2 .select2-search__field', function (e) {
                 if (e.keyCode === 13) {
                     var $id_private_contestants = $('#id_private_contestants');

--- a/templates/contest/edit.html
+++ b/templates/contest/edit.html
@@ -36,7 +36,7 @@
             $(document).on('keyup', '#id_private_contestants + .select2 .select2-search__field', function (e) {
                 if (e.keyCode === 13) {
                     var $id_private_contestants = $('#id_private_contestants');
-                    var contestants = $(this).val().split(',').map(s => s.trim()).filter(s => s != '');
+                    var contestants = $(this).val().split(/[\s,]+/);
                     if (contestants.length <= 1) {
                         // Skip to let select2 handle this
                         return;

--- a/templates/contest/edit.html
+++ b/templates/contest/edit.html
@@ -40,7 +40,7 @@
                         data: {
                             multiple_terms: contestants,
                         },
-                        success: function(response) {
+                        success: function (response) {
                             for (const contestant of response.results) {
                                 $id_private_contestants.select2('trigger', 'select', {
                                     data: contestant,

--- a/templates/contest/edit.html
+++ b/templates/contest/edit.html
@@ -180,7 +180,13 @@
                 {% endfor %}
             </tbody>
         </table>
-        <div style="display: flex; justify-content: flex-end;"><button class="submit-bar" type="submit">{{ _('Create') }}</button></div>
+        <div style="display: flex; justify-content: flex-end;"><button class="submit-bar" type="submit">
+            {% if request.resolver_match.url_name == 'contest_edit' %}
+                {{ _('Update') }}
+            {% else %}
+                {{ _('Create') }}
+            {% endif %}
+        </button></div>
     </form>
 </div>
 {% endblock %}

--- a/templates/contest/edit.html
+++ b/templates/contest/edit.html
@@ -24,6 +24,33 @@
             $('#form_set tr').formset({
                 prefix: '{{ contest_problem_formset.prefix }}'
             });
+
+            $(document).on('keyup', '#id_private_contestants + .select2 .select2-search__field', function (e) {
+                var $id_private_contestants = $('#id_private_contestants');
+                if (e.keyCode === 13) {
+                    var contestants = $(this).val().split(',').map(s => s.trim());
+
+                    function process(contestant) {
+                        $id_private_contestants.data().select2.dataAdapter.query(
+                            { term: contestant },
+                            function (b) {
+                                for (const r of b.results) {
+                                    if (r.text === contestant) {
+                                        $id_private_contestants.select2('trigger', 'select', {
+                                            data: r,
+                                        });
+                                    }
+                                }
+                                if (contestants.length > 0) {
+                                    process(contestants.shift());
+                                }
+                            }
+                        )
+                    }
+
+                    process(contestants.shift());
+                }
+            });
         })
     </script>
     {{ form.media.js }}
@@ -90,7 +117,7 @@
             visibility: visible;
             content: "{{ _("Add new problem") }}";
         }
-        
+
         .delete-row {
             color: white;
             background-color: red;

--- a/templates/contest/edit.html
+++ b/templates/contest/edit.html
@@ -26,29 +26,28 @@
             });
 
             $(document).on('keyup', '#id_private_contestants + .select2 .select2-search__field', function (e) {
-                var $id_private_contestants = $('#id_private_contestants');
                 if (e.keyCode === 13) {
-                    var contestants = $(this).val().split(',').map(s => s.trim());
-
-                    function process(contestant) {
-                        $id_private_contestants.data().select2.dataAdapter.query(
-                            { term: contestant },
-                            function (b) {
-                                for (const r of b.results) {
-                                    if (r.text === contestant) {
-                                        $id_private_contestants.select2('trigger', 'select', {
-                                            data: r,
-                                        });
-                                    }
-                                }
-                                if (contestants.length > 0) {
-                                    process(contestants.shift());
-                                }
-                            }
-                        )
+                    var $id_private_contestants = $('#id_private_contestants');
+                    var contestants = $(this).val().split(',').map(s => s.trim()).filter(s => s != '');
+                    if (contestants.length <= 1) {
+                        // Skip to let select2 handle this
+                        return;
                     }
 
-                    process(contestants.shift());
+                    $.ajax({
+                        type: 'GET',
+                        url: $id_private_contestants.data().select2.dataAdapter.ajaxOptions.url,
+                        data: {
+                            multiple_terms: contestants,
+                        },
+                        success: function(response) {
+                            for (const contestant of response.results) {
+                                $id_private_contestants.select2('trigger', 'select', {
+                                    data: contestant,
+                                });
+                            }
+                        },
+                    });
                 }
             });
         })

--- a/templates/problem/editor.html
+++ b/templates/problem/editor.html
@@ -16,8 +16,8 @@
             $(document).on('keyup', '#id_testers + .select2 .select2-search__field', function (e) {
                 if (e.keyCode === 13) {
                     var $id_testers = $('#id_testers');
-                    var contestants = $(this).val().split(',').map(s => s.trim()).filter(s => s != '');
-                    if (contestants.length <= 1) {
+                    var testers = $(this).val().split(/[\s,]+/);
+                    if (testers.length <= 1) {
                         // Skip to let select2 handle this
                         return;
                     }
@@ -26,12 +26,12 @@
                         type: 'GET',
                         url: $id_testers.data().select2.dataAdapter.ajaxOptions.url,
                         data: {
-                            multiple_terms: contestants,
+                            multiple_terms: testers,
                         },
                         success: function (response) {
-                            for (const contestant of response.results) {
+                            for (const tester of response.results) {
                                 $id_testers.select2('trigger', 'select', {
-                                    data: contestant,
+                                    data: tester,
                                 });
                             }
                         },

--- a/templates/problem/editor.html
+++ b/templates/problem/editor.html
@@ -5,6 +5,14 @@
 
     <script>
         $(function() {
+            var noResults = function () {
+                return '{{ _('Press Enter to select multiple users...') }}';
+            };
+
+            $(document).one('click', '#id_testers + .select2', function (e) {
+                $('#id_testers').data().select2.options.get('translations').dict['noResults'] = noResults;
+            });
+
             $(document).on('keyup', '#id_testers + .select2 .select2-search__field', function (e) {
                 if (e.keyCode === 13) {
                     var $id_testers = $('#id_testers');

--- a/templates/problem/editor.html
+++ b/templates/problem/editor.html
@@ -2,6 +2,36 @@
 
 {% block js_media %}
     {{ form.media.js }}
+
+    <script>
+        $(function() {
+            $(document).on('keyup', '#id_testers + .select2 .select2-search__field', function (e) {
+                if (e.keyCode === 13) {
+                    var $id_testers = $('#id_testers');
+                    var contestants = $(this).val().split(',').map(s => s.trim()).filter(s => s != '');
+                    if (contestants.length <= 1) {
+                        // Skip to let select2 handle this
+                        return;
+                    }
+
+                    $.ajax({
+                        type: 'GET',
+                        url: $id_testers.data().select2.dataAdapter.ajaxOptions.url,
+                        data: {
+                            multiple_terms: contestants,
+                        },
+                        success: function (response) {
+                            for (const contestant of response.results) {
+                                $id_testers.select2('trigger', 'select', {
+                                    data: contestant,
+                                });
+                            }
+                        },
+                    });
+                }
+            });
+        })
+    </script>
 {% endblock %}
 
 {% block media %}


### PR DESCRIPTION
Now we can enter multiple usernames separated by commas (e.g., `vanctb,dangtiendung1201,thanhthuy,hathaictb,anhduc5a1tp`):

![image](https://user-images.githubusercontent.com/17219541/131300827-c30e133b-d5ec-4de8-a6bc-6749800f431f.png)

Also add testers field to problem create/edit form:

![image](https://user-images.githubusercontent.com/17219541/131300886-7b28ac33-6b4d-474f-8b4e-0df2235fd0dd.png)

