### PR TITLE
Show alert if there is no statuses

### DIFF
--- a/templates/submission/status-testcases.html
+++ b/templates/submission/status-testcases.html
@@ -44,6 +44,12 @@
                 <span class="fa fa-spinner fa-pulse"></span>
             {% endif %}
             <br><br>
+        {% else %}
+            <div>
+                <div class="alert alert-warning comment-lock">
+                    {{ _('Your submission is successfully stored. Currently, there are no tests available, or this is an offline task, so please consider waiting for further evaluation.') }}
+                </div>
+            </div>
         {% endif %}
         {% set test_case_id = counter() %}
         {% set test_case_counter = counter() %}
@@ -132,7 +138,7 @@
         {% if batch.id %}</div>{% endif %}
             <br>
         {% endfor %}
-        {% if submission.is_graded %}
+        {% if statuses and submission.is_graded %}
             <br>
             {% if submission.result != "AB" %}
                 <b>{{ _('Resources:') }}</b>


### PR DESCRIPTION
For those problems with no test cases, the status will show an alert instead of empty status.

Old:
![image](https://user-images.githubusercontent.com/52038546/131637948-dce8a9b9-2403-43a7-81de-7ba524b66487.png)
New:
![image](https://user-images.githubusercontent.com/52038546/131637984-86b2f9e0-a981-4142-9c13-9b03b032eeff.png)
