### PR TITLE
Optimize top user query, filter banned users, beautify leaderboard

### DIFF
--- a/judge/views/blog.py
+++ b/judge/views/blog.py
@@ -100,7 +100,8 @@ class PostList(ListView):
             return result
         result = (Profile.objects.order_by('-performance_points')
                   .filter(performance_points__gt=0, is_unlisted=False)
-                  .values_list('user__username', 'performance_points')
+                  .only('user', 'performance_points', 'display_rank', 'rating')
+                  .select_related('user')
                   [:settings.VNOJ_HOMEPAGE_TOP_USERS_COUNT])
         cache.set(key, result, update_interval)
         return result
@@ -112,7 +113,8 @@ class PostList(ListView):
             return result
         result = (Profile.objects.order_by('-contribution_points')
                   .filter(contribution_points__gt=0, is_unlisted=False)
-                  .values_list('user__username', 'contribution_points')
+                  .only('user', 'contribution_points', 'display_rank', 'rating')
+                  .select_related('user')
                   [:settings.VNOJ_HOMEPAGE_TOP_USERS_COUNT])
         cache.set(key, result, update_interval)
         return result

--- a/judge/views/blog.py
+++ b/judge/views/blog.py
@@ -93,31 +93,19 @@ class PostList(ListView):
             context['open_tickets'] = []
         return context
 
-    def get_top_pp_users(self, update_interval=24 * 60 * 60):
-        key = 'homepage_top_pp_users'
-        result = cache.get(key)
-        if result:
-            return result
-        result = (Profile.objects.order_by('-performance_points')
-                  .filter(performance_points__gt=0, is_unlisted=False)
-                  .only('user', 'performance_points', 'display_rank', 'rating')
-                  .select_related('user')
-                  [:settings.VNOJ_HOMEPAGE_TOP_USERS_COUNT])
-        cache.set(key, result, update_interval)
-        return result
+    def get_top_pp_users(self):
+        return (Profile.objects.order_by('-performance_points')
+                .filter(performance_points__gt=0, is_unlisted=False)
+                .only('user', 'performance_points', 'display_rank', 'rating')
+                .select_related('user')
+                [:settings.VNOJ_HOMEPAGE_TOP_USERS_COUNT])
 
-    def get_top_contributors(self, update_interval=24 * 60 * 60):
-        key = 'homepage_top_contributors'
-        result = cache.get(key)
-        if result:
-            return result
-        result = (Profile.objects.order_by('-contribution_points')
-                  .filter(contribution_points__gt=0, is_unlisted=False)
-                  .only('user', 'contribution_points', 'display_rank', 'rating')
-                  .select_related('user')
-                  [:settings.VNOJ_HOMEPAGE_TOP_USERS_COUNT])
-        cache.set(key, result, update_interval)
-        return result
+    def get_top_contributors(self):
+        return (Profile.objects.order_by('-contribution_points')
+                .filter(contribution_points__gt=0, is_unlisted=False)
+                .only('user', 'contribution_points', 'display_rank', 'rating')
+                .select_related('user')
+                [:settings.VNOJ_HOMEPAGE_TOP_USERS_COUNT])
 
 
 class PostView(TitleMixin, CommentedDetailView):

--- a/judge/views/blog.py
+++ b/judge/views/blog.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.core.cache import cache
 from django.db.models import Count, Max
 from django.http import Http404
 from django.urls import reverse

--- a/judge/views/blog.py
+++ b/judge/views/blog.py
@@ -99,7 +99,7 @@ class PostList(ListView):
         if result:
             return result
         result = (Profile.objects.order_by('-performance_points')
-                  .filter(performance_points__gt=0)
+                  .filter(performance_points__gt=0, is_unlisted=False)
                   .values_list('user__username', 'performance_points')
                   [:settings.VNOJ_HOMEPAGE_TOP_USERS_COUNT])
         cache.set(key, result, update_interval)
@@ -111,7 +111,7 @@ class PostList(ListView):
         if result:
             return result
         result = (Profile.objects.order_by('-contribution_points')
-                  .filter(contribution_points__gt=0)
+                  .filter(contribution_points__gt=0, is_unlisted=False)
                   .values_list('user__username', 'contribution_points')
                   [:settings.VNOJ_HOMEPAGE_TOP_USERS_COUNT])
         cache.set(key, result, update_interval)

--- a/templates/blog/top-contrib.html
+++ b/templates/blog/top-contrib.html
@@ -10,17 +10,17 @@
                 </tr>
             </thead>
             <tbody>
-                {% for username, contrib in top_contrib %}
-                    <tr id="user-{{ username }}">
+                {% for user in top_contrib %}
+                    <tr id="user-{{ loop.index }}">
                         <td>{{ loop.index }}</td>
                         <td class="user-name"> 
                             <div style="float:left"> 
-                                <a href="{{ url('user_page', username) }}">{{ username }}</a>
+                                {{ link_user(user) }}
                             </div> 
                         </td>
                         
                         <td class="user-contrib">
-                            {{ contrib }}
+                            {{ user.contribution_points }}
                         </td>
                     </tr>
                 {% endfor %}

--- a/templates/blog/top-pp.html
+++ b/templates/blog/top-pp.html
@@ -10,17 +10,17 @@
                 </tr>
             </thead>
             <tbody>
-                {% for username, pp in top_pp_users %}
-                    <tr id="user-{{ username }}">
+                {% for user in top_pp_users %}
+                    <tr id="user-{{ loop.index }}">
                         <td>{{ loop.index }}</td>
                         <td class="user-name"> 
                             <div style="float:left"> 
-                                <a href="{{ url('user_page', username) }}">{{ username }}</a>
+                                {{ link_user(user) }}
                             </div> 
                         </td>
-                        
+
                         <td class="user-points">
-                            {{ pp|floatformat(2) }}
+                            {{ user.performance_points|floatformat(2) }}
                         </td>
                     </tr>
                 {% endfor %}


### PR DESCRIPTION
reduce SQL query for top users from O(n) to O(1) with select relate.

Also filter out banned user from the leader board (cache 24 hours)

Before:
![image](https://user-images.githubusercontent.com/23715841/132080699-872711a3-d3cd-4fc6-ac42-0a798acc1d0e.png)

After:
![image](https://user-images.githubusercontent.com/23715841/132080708-c0fca38e-24c6-49a2-85ed-1b3dab98768c.png)
