### PR TITLE
Add ip logger in official contest mode

### DIFF
--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -519,6 +519,7 @@ class RandomProblem(ProblemList):
 
 
 user_logger = logging.getLogger('judge.user')
+user_submit_ip_logger = logging.getLogger('judge.user_submit_ip_logger')
 
 
 class ProblemSubmit(LoginRequiredMixin, ProblemMixin, TitleMixin, SingleObjectFormView):
@@ -655,6 +656,18 @@ class ProblemSubmit(LoginRequiredMixin, ProblemMixin, TitleMixin, SingleObjectFo
         # Save a query.
         self.new_submission.source = source
         self.new_submission.judge(force_judge=True, judge_id=form.cleaned_data['judge'])
+
+        # In contest mode, we should log the ip
+        if settings.VNOJ_OFFICIAL_CONTEST_MODE:
+            ip = self.request.META['REMOTE_ADDR']
+            # I didn't log the timestamp here because
+            # the logger can handle it.
+            user_submit_ip_logger.info(
+                '%s,%s,%s',
+                self.request.user.username,
+                ip,
+                self.new_submission.problem.code,
+            )
 
         return super().form_valid(form)
 


### PR DESCRIPTION
In contest mode, we might want to get the IP + username of who submitted the problem.

The default log will look like this:
```
leduykhongngu,127.0.0.1,bgame
```

To add the timestamp like this:
```
2021-09-07 15:56:33,leduykhongngu,127.0.0.1,bgame
```

You can config the logger like this:



```python
LOGGING = {
    'formatters': {
        'ip_log_formatter': {
            'format': '%(asctime)s,%(message)s',
            'datefmt':'%Y-%m-%d %H:%M:%S',
        },
    },
    'handlers': {
        'ip_logger': {
            'level': 'DEBUG',
            'class': 'logging.handlers.RotatingFileHandler',
            'filename': '<path_to_log_file>',
            'maxBytes': 10 * 1024 * 1024,
            'backupCount': 10,
            'formatter': 'ip_log_formatter',
        },
    },
    'loggers': {
        'judge.user_submit_ip_logger': {
            'handlers': ['ip_logger'],
            'level': 'INFO',
            'propagate': False,
        },
    },
}
```