### PR TITLE
Block edit profile in contest mode

### DIFF
--- a/judge/forms.py
+++ b/judge/forms.py
@@ -63,6 +63,11 @@ class ProfileForm(ModelForm):
             'ace_theme': Select2Widget(attrs={'style': 'width:200px'}),
         }
 
+        # Make sure that users cannot change their `about` in contest mode
+        # because the user can put the solution in that profile
+        if settings.VNOJ_OFFICIAL_CONTEST_MODE:
+            fields.remove('about')
+
         has_math_config = bool(settings.MATHOID_URL)
         if has_math_config:
             fields.append('math_engine')
@@ -104,6 +109,10 @@ class UserForm(ModelForm):
     class Meta:
         model = User
         fields = ['first_name']
+        # In contest mode, we don't want user to change
+        # their name.
+        if settings.VNOJ_OFFICIAL_CONTEST_MODE:
+            fields.remove('first_name')
 
 
 class ProposeProblemSolutionForm(ModelForm):

--- a/judge/forms.py
+++ b/judge/forms.py
@@ -109,8 +109,8 @@ class UserForm(ModelForm):
     class Meta:
         model = User
         fields = ['first_name']
-        # In contest mode, we don't want user to change
-        # their name.
+
+        # In contest mode, we don't want user to change their name.
         if settings.VNOJ_OFFICIAL_CONTEST_MODE:
             fields.remove('first_name')
 

--- a/templates/user/edit-profile.html
+++ b/templates/user/edit-profile.html
@@ -280,19 +280,23 @@ You will not be able to view your scratch codes after you leave this page!') }}"
             {% endif %}
 
             {% csrf_token %}
-            <table>
-                <tr>
-                    <td><div class="block-header">{{ _('Full name') }}:</div></td>
-                </tr>
-                <tr>
-                    <td>{{ form_user.first_name }}</td>
-                </tr>
-            </table>
-            <hr>
+            {% if form_user.first_name %}
+                <table>
+                    <tr>
+                        <td><div class="block-header">{{ _('Full name') }}:</div></td>
+                    </tr>
+                    <tr>
+                        <td>{{ form_user.first_name }}</td>
+                    </tr>
+                </table>
+                <hr>
+            {% endif %}
 
-            <div style="padding-top:0.5em" class="block-header">{{ _('Self-description') }}:</div>
-            {{ form.about }}
-            <hr>
+            {% if form.about %}
+                <div style="padding-top:0.5em" class="block-header">{{ _('Self-description') }}:</div>
+                    {{ form.about }}
+                <hr>
+            {% endif %}
 
             <div class="settings" style="padding-top:0.7em">
                 <div class="pane" style="vertical-align:top">


### PR DESCRIPTION
 Make sure that users cannot change their `about` in contest mode
 because the user can put the solution in that profile

Also, disallow them to change their name as well

![image](https://user-images.githubusercontent.com/23715841/132491102-6622bf32-9d45-4091-bf1c-501e603b88f9.png)
