### PR TITLE
Use misc_config to store the discord invite code

### DIFF
--- a/templates/blog/list.html
+++ b/templates/blog/list.html
@@ -196,10 +196,10 @@
                     <span style="margin-right: 10px;">
                         {{ _('Comment stream') }}
                     </span>
-                    {% if misc_config.discord_invite_link %}
+                    {% if misc_config.discord_invite_link and misc_config.discord_invite_shieldio %}
                         <span style="margin: 0.1em 0.3em -6px;">
                             <a href="https://discord.com/invite/{{ misc_config.discord_invite_link }}">
-                                <img style="max-width: none;" src="https://img.shields.io/discord/660930260405190688?color=%237289DA&amp;label=Discord&amp;logo=Discord" alt="Discord">
+                                <img style="max-width: none;" src="{{ misc_config.discord_invite_shieldio }}" alt="Discord">
                             </a>
                         </span>
                     {% endif %}

--- a/templates/blog/list.html
+++ b/templates/blog/list.html
@@ -196,11 +196,13 @@
                     <span style="margin-right: 10px;">
                         {{ _('Comment stream') }}
                     </span>
-                    <span style="margin: 0.1em 0.3em -6px;">
-                        <a href="https://discord.com/invite/TDyYVyd">
-                            <img style="max-width: none;" src="https://img.shields.io/discord/660930260405190688?color=%237289DA&amp;label=Discord&amp;logo=Discord" alt="Discord">
-                        </a>
-                    </span>
+                    {% if misc_config.discord_invite_link %}
+                        <span style="margin: 0.1em 0.3em -6px;">
+                            <a href="https://discord.com/invite/{{ misc_config.discord_invite_link }}">
+                                <img style="max-width: none;" src="https://img.shields.io/discord/660930260405190688?color=%237289DA&amp;label=Discord&amp;logo=Discord" alt="Discord">
+                            </a>
+                        </span>
+                    {% endif %}
                 </h3>
                 <div class="sidebox-content">
                     <ul>

--- a/templates/blog/list.html
+++ b/templates/blog/list.html
@@ -198,7 +198,7 @@
                     </span>
                     {% if misc_config.discord_invite_link and misc_config.discord_invite_shieldio %}
                         <span style="margin: 0.1em 0.3em -6px;">
-                            <a href="https://discord.com/invite/{{ misc_config.discord_invite_link }}">
+                            <a href="{{ misc_config.discord_invite_link }}">
                                 <img style="max-width: none;" src="{{ misc_config.discord_invite_shieldio }}" alt="Discord">
                             </a>
                         </span>

--- a/templates/registration/activation_email.html
+++ b/templates/registration/activation_email.html
@@ -16,4 +16,4 @@
 
 {{ _('See you soon!') }}
 <br>
-{{ _('If you have problems activating your account, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link %}<a href="{{ misc_config.discord_invite_link }}"><img src = "https://img.shields.io/discord/660930260405190688?color=%237289DA&label=Discord&logo=Discord"></a>{% endif %}
+{{ _('If you have problems activating your account, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link and misc_config.discord_invite_shieldio %}<a href="{{ misc_config.discord_invite_link }}"><img src = "{{ misc_config.discord_invite_shieldio }}"></a>{% endif %}

--- a/templates/registration/activation_email.html
+++ b/templates/registration/activation_email.html
@@ -16,4 +16,4 @@
 
 {{ _('See you soon!') }}
 <br>
-{{ _('If you have problems activating your account, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link %}<a href="https://discord.gg/{{ misc_config.discord_invite_link }}"><img src = "https://img.shields.io/discord/660930260405190688?color=%237289DA&label=Discord&logo=Discord"></a>{% endif %}
+{{ _('If you have problems activating your account, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link %}<a href="{{ misc_config.discord_invite_link }}"><img src = "https://img.shields.io/discord/660930260405190688?color=%237289DA&label=Discord&logo=Discord"></a>{% endif %}

--- a/templates/registration/activation_email.html
+++ b/templates/registration/activation_email.html
@@ -16,4 +16,4 @@
 
 {{ _('See you soon!') }}
 <br>
-{{ _('If you have problems activating your account, feel free to shoot us a message at: ') }} <a href="https://discord.gg/TDyYVyd"><img src = "https://img.shields.io/discord/660930260405190688?color=%237289DA&label=Discord&logo=Discord"></a>
+{{ _('If you have problems activating your account, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link %}<a href="https://discord.gg/{{ misc_config.discord_invite_link }}"><img src = "https://img.shields.io/discord/660930260405190688?color=%237289DA&label=Discord&logo=Discord"></a>{% endif %}

--- a/templates/registration/activation_email.html
+++ b/templates/registration/activation_email.html
@@ -7,7 +7,7 @@
       <a href="http://{{ site.domain }}/accounts/activate/{{ activation_key }}/">http://{{ site.domain }}/accounts/activate/{{ activation_key }}</a>
 </p>
 
-{{ _('Alternatively, you can reply to this message to activate your account.') }} 
+{{ _('Alternatively, you can reply to this message to activate your account.') }}
 {{ _('Your reply must keep the following text intact for this to work:') }}
 
 <pre style="margin-left:1em">
@@ -16,4 +16,4 @@
 
 {{ _('See you soon!') }}
 <br>
-{{ _('If you have problems activating your account, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link and misc_config.discord_invite_shieldio %}<a href="{{ misc_config.discord_invite_link }}"><img src = "{{ misc_config.discord_invite_shieldio }}"></a>{% endif %}
+{{ _('If you have problems activating your account, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link and misc_config.discord_invite_shieldio %}<a href="{{ misc_config.discord_invite_link }}"><img src="{{ misc_config.discord_invite_shieldio }}"></a>{% endif %}

--- a/templates/registration/password_reset_done.html
+++ b/templates/registration/password_reset_done.html
@@ -3,5 +3,5 @@
 {% block body %}
     <p>{{ _("We've emailed you instructions for setting your password. You should be receiving them shortly.") }}</p>
     <p>{{ _("If you don't receive an email, please make sure you've entered the address you registered with, and check your spam folder.") }}</p>
-    <p>{{ _('See you soon! If you have problems resetting your password, feel free to shoot us a message at: ') }} <a href="https://discord.gg/TDyYVyd"><img src = "https://img.shields.io/discord/660930260405190688?color=%237289DA&label=Discord&logo=Discord"></a></p>
+    <p>{{ _('See you soon! If you have problems resetting your password, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link %}<a href="https://discord.gg/{{ misc_config.discord_invite_link }}"><img src = "https://img.shields.io/discord/660930260405190688?color=%237289DA&label=Discord&logo=Discord"></a>{% endif %}</p>
 {% endblock %}

--- a/templates/registration/password_reset_done.html
+++ b/templates/registration/password_reset_done.html
@@ -3,5 +3,5 @@
 {% block body %}
     <p>{{ _("We've emailed you instructions for setting your password. You should be receiving them shortly.") }}</p>
     <p>{{ _("If you don't receive an email, please make sure you've entered the address you registered with, and check your spam folder.") }}</p>
-    <p>{{ _('See you soon! If you have problems resetting your password, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link %}<a href="https://discord.gg/{{ misc_config.discord_invite_link }}"><img src = "https://img.shields.io/discord/660930260405190688?color=%237289DA&label=Discord&logo=Discord"></a>{% endif %}</p>
+    <p>{{ _('See you soon! If you have problems resetting your password, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link %}<a href="{{ misc_config.discord_invite_link }}"><img src = "https://img.shields.io/discord/660930260405190688?color=%237289DA&label=Discord&logo=Discord"></a>{% endif %}</p>
 {% endblock %}

--- a/templates/registration/password_reset_done.html
+++ b/templates/registration/password_reset_done.html
@@ -3,5 +3,5 @@
 {% block body %}
     <p>{{ _("We've emailed you instructions for setting your password. You should be receiving them shortly.") }}</p>
     <p>{{ _("If you don't receive an email, please make sure you've entered the address you registered with, and check your spam folder.") }}</p>
-    <p>{{ _('See you soon! If you have problems resetting your password, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link and misc_config.discord_invite_shieldio %}<a href="{{ misc_config.discord_invite_link }}"><img src = "{{ misc_config.discord_invite_shieldio }}"></a>{% endif %}</p>
+    <p>{{ _('See you soon! If you have problems resetting your password, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link and misc_config.discord_invite_shieldio %}<a href="{{ misc_config.discord_invite_link }}"><img src="{{ misc_config.discord_invite_shieldio }}"></a>{% endif %}</p>
 {% endblock %}

--- a/templates/registration/password_reset_done.html
+++ b/templates/registration/password_reset_done.html
@@ -3,5 +3,5 @@
 {% block body %}
     <p>{{ _("We've emailed you instructions for setting your password. You should be receiving them shortly.") }}</p>
     <p>{{ _("If you don't receive an email, please make sure you've entered the address you registered with, and check your spam folder.") }}</p>
-    <p>{{ _('See you soon! If you have problems resetting your password, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link %}<a href="{{ misc_config.discord_invite_link }}"><img src = "https://img.shields.io/discord/660930260405190688?color=%237289DA&label=Discord&logo=Discord"></a>{% endif %}</p>
+    <p>{{ _('See you soon! If you have problems resetting your password, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link and misc_config.discord_invite_shieldio %}<a href="{{ misc_config.discord_invite_link }}"><img src = "{{ misc_config.discord_invite_shieldio }}"></a>{% endif %}</p>
 {% endblock %}

--- a/templates/registration/password_reset_email.html
+++ b/templates/registration/password_reset_email.html
@@ -8,5 +8,5 @@ To reset the password for your account "{{ username }}", click the button below.
 <p align="center">
 <a href="{{ protocol }}://{{ domain }}{{ url('password_reset_confirm', uidb64=uid, token=token) }}" style="cursor: pointer;display:block;text-align: center;padding: 4px 2px 5px;color: white;border: 1px solid #666;border-radius: 1px;background: #2980b9;background: linear-gradient(180deg, #00aee0, #2980b9);text-decoration: none;line-height:2em;font-size:1em;width:12em;">Reset password</a>
 </p>
-{{ _('See you soon! If you have problems resetting your password, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link %}<a href="{{ misc_config.discord_invite_link }}"><img src = "https://img.shields.io/discord/660930260405190688?color=%237289DA&label=Discord&logo=Discord"></a>{% endif %}
+{{ _('See you soon! If you have problems resetting your password, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link and misc_config.discord_invite_shieldio %}<a href="{{ misc_config.discord_invite_link }}"><img src = "{{ misc_config.discord_invite_shieldio }}"></a>{% endif %}
 </div>

--- a/templates/registration/password_reset_email.html
+++ b/templates/registration/password_reset_email.html
@@ -8,5 +8,5 @@ To reset the password for your account "{{ username }}", click the button below.
 <p align="center">
 <a href="{{ protocol }}://{{ domain }}{{ url('password_reset_confirm', uidb64=uid, token=token) }}" style="cursor: pointer;display:block;text-align: center;padding: 4px 2px 5px;color: white;border: 1px solid #666;border-radius: 1px;background: #2980b9;background: linear-gradient(180deg, #00aee0, #2980b9);text-decoration: none;line-height:2em;font-size:1em;width:12em;">Reset password</a>
 </p>
-{{ _('See you soon! If you have problems resetting your password, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link %}<a href="https://discord.gg/{{ misc_config.discord_invite_link }}"><img src = "https://img.shields.io/discord/660930260405190688?color=%237289DA&label=Discord&logo=Discord"></a>{% endif %}
+{{ _('See you soon! If you have problems resetting your password, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link %}<a href="{{ misc_config.discord_invite_link }}"><img src = "https://img.shields.io/discord/660930260405190688?color=%237289DA&label=Discord&logo=Discord"></a>{% endif %}
 </div>

--- a/templates/registration/password_reset_email.html
+++ b/templates/registration/password_reset_email.html
@@ -8,5 +8,5 @@ To reset the password for your account "{{ username }}", click the button below.
 <p align="center">
 <a href="{{ protocol }}://{{ domain }}{{ url('password_reset_confirm', uidb64=uid, token=token) }}" style="cursor: pointer;display:block;text-align: center;padding: 4px 2px 5px;color: white;border: 1px solid #666;border-radius: 1px;background: #2980b9;background: linear-gradient(180deg, #00aee0, #2980b9);text-decoration: none;line-height:2em;font-size:1em;width:12em;">Reset password</a>
 </p>
-{{ _('See you soon! If you have problems resetting your password, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link and misc_config.discord_invite_shieldio %}<a href="{{ misc_config.discord_invite_link }}"><img src = "{{ misc_config.discord_invite_shieldio }}"></a>{% endif %}
+{{ _('See you soon! If you have problems resetting your password, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link and misc_config.discord_invite_shieldio %}<a href="{{ misc_config.discord_invite_link }}"><img src="{{ misc_config.discord_invite_shieldio }}"></a>{% endif %}
 </div>

--- a/templates/registration/password_reset_email.html
+++ b/templates/registration/password_reset_email.html
@@ -8,5 +8,5 @@ To reset the password for your account "{{ username }}", click the button below.
 <p align="center">
 <a href="{{ protocol }}://{{ domain }}{{ url('password_reset_confirm', uidb64=uid, token=token) }}" style="cursor: pointer;display:block;text-align: center;padding: 4px 2px 5px;color: white;border: 1px solid #666;border-radius: 1px;background: #2980b9;background: linear-gradient(180deg, #00aee0, #2980b9);text-decoration: none;line-height:2em;font-size:1em;width:12em;">Reset password</a>
 </p>
-{{ _('See you soon! If you have problems resetting your password, feel free to shoot us a message at: ') }} <a href="https://discord.gg/TDyYVyd"><img src = "https://img.shields.io/discord/660930260405190688?color=%237289DA&label=Discord&logo=Discord"></a>
+{{ _('See you soon! If you have problems resetting your password, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link %}<a href="https://discord.gg/{{ misc_config.discord_invite_link }}"><img src = "https://img.shields.io/discord/660930260405190688?color=%237289DA&label=Discord&logo=Discord"></a>{% endif %}
 </div>

--- a/templates/registration/registration_complete.html
+++ b/templates/registration/registration_complete.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
 {% block body %}
     <p>{{ _('You have successfully been registered. An email has been sent to the email address you provided to confirm your registration.') }}</p>
-    <p>{{ _('See you soon! If you have problems activating your account, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link and misc_config.discord_invite_shieldio %}<a href="{{ misc_config.discord_invite_link }}"><img src = "{{ misc_config.discord_invite_shieldio }}"></a>{% endif %}</p>
+    <p>{{ _('See you soon! If you have problems activating your account, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link and misc_config.discord_invite_shieldio %}<a href="{{ misc_config.discord_invite_link }}"><img src="{{ misc_config.discord_invite_shieldio }}"></a>{% endif %}</p>
 {% endblock %}

--- a/templates/registration/registration_complete.html
+++ b/templates/registration/registration_complete.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
 {% block body %}
     <p>{{ _('You have successfully been registered. An email has been sent to the email address you provided to confirm your registration.') }}</p>
-    <p>{{ _('See you soon! If you have problems activating your account, feel free to shoot us a message at: ') }} <a href="https://discord.gg/TDyYVyd"><img src = "https://img.shields.io/discord/660930260405190688?color=%237289DA&label=Discord&logo=Discord"></a></p>
+    <p>{{ _('See you soon! If you have problems activating your account, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link %}<a href="https://discord.gg/{{ misc_config.discord_invite_link }}"><img src = "https://img.shields.io/discord/660930260405190688?color=%237289DA&label=Discord&logo=Discord"></a>{% endif %}</p>
 {% endblock %}

--- a/templates/registration/registration_complete.html
+++ b/templates/registration/registration_complete.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
 {% block body %}
     <p>{{ _('You have successfully been registered. An email has been sent to the email address you provided to confirm your registration.') }}</p>
-    <p>{{ _('See you soon! If you have problems activating your account, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link %}<a href="https://discord.gg/{{ misc_config.discord_invite_link }}"><img src = "https://img.shields.io/discord/660930260405190688?color=%237289DA&label=Discord&logo=Discord"></a>{% endif %}</p>
+    <p>{{ _('See you soon! If you have problems activating your account, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link %}<a href="{{ misc_config.discord_invite_link }}"><img src = "https://img.shields.io/discord/660930260405190688?color=%237289DA&label=Discord&logo=Discord"></a>{% endif %}</p>
 {% endblock %}

--- a/templates/registration/registration_complete.html
+++ b/templates/registration/registration_complete.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
 {% block body %}
     <p>{{ _('You have successfully been registered. An email has been sent to the email address you provided to confirm your registration.') }}</p>
-    <p>{{ _('See you soon! If you have problems activating your account, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link %}<a href="{{ misc_config.discord_invite_link }}"><img src = "https://img.shields.io/discord/660930260405190688?color=%237289DA&label=Discord&logo=Discord"></a>{% endif %}</p>
+    <p>{{ _('See you soon! If you have problems activating your account, feel free to shoot us a message at: ') }} {% if misc_config.discord_invite_link and misc_config.discord_invite_shieldio %}<a href="{{ misc_config.discord_invite_link }}"><img src = "{{ misc_config.discord_invite_shieldio }}"></a>{% endif %}</p>
 {% endblock %}


### PR DESCRIPTION
Admins can now set the discord_invite_link and discord_invite_shieldio config in misc_config to show the discord invite link on site.
Both of the config should be set to make this work.