### PR TITLE
Add send message to discord webhook on error

### DIFF
--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -124,6 +124,7 @@ DISCORD_WEBHOOK = {
     'on_new_suggested_problem': None,
     'on_new_tag_problem': None,
     'on_new_tag': None,
+    'on_error': None,
 }
 
 SITE_FULL_URL = None  # ie 'https://oj.vnoi.info', please remove the last / if needed

--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -148,6 +148,7 @@ DMOJ_PROBLEM_HOT_PROBLEM_COUNT = 7
 DMOJ_PROBLEM_STATEMENT_DISALLOWED_CHARACTERS = {'“', '”', '‘', '’'}
 DMOJ_RATING_COLORS = True
 DMOJ_EMAIL_THROTTLING = (10, 60)
+VNOJ_DISCORD_WEBHOOK_THROTTLING = (10, 60) # Max 10 messages in 60 seconds
 DMOJ_STATS_LANGUAGE_THRESHOLD = 10
 DMOJ_SUBMISSIONS_REJUDGE_LIMIT = 10
 # Maximum number of submissions a single user can queue without the `spam_submission` permission

--- a/dmoj/throttle_discord_webhook.py
+++ b/dmoj/throttle_discord_webhook.py
@@ -1,0 +1,85 @@
+import logging
+import traceback
+from copy import copy
+
+from discord_webhook import DiscordWebhook
+from django.conf import settings
+from django.core.cache import cache
+from django.views.debug import ExceptionReporter
+
+
+def new_webhook():
+    cache.add('error_discord_webhook_throttle', 0, settings.VNOJ_DISCORD_WEBHOOK_THROTTLING[1])
+    return cache.incr('error_discord_webhook_throttle')
+
+
+class ThrottledDiscordWebhookHandler(logging.Handler):
+    """An exception log handler that send log entries to discord webhook.
+
+    If the request is passed as the first argument to the log record,
+    request data will be provided in the message report.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Send at most (VNOJ_DISCORD_WEBHOOK_THROTTLING[0]) message in
+        # (VNOJ_DISCORD_WEBHOOK_THROTTLING[1]) seconds
+        self.throttle = settings.VNOJ_DISCORD_WEBHOOK_THROTTLING[0]
+
+    def emit(self, record):
+        # Adapt from `dmoj.throttle_mail.ThrottledEmailHandler`
+        try:
+            count = new_webhook()
+        except Exception:
+            traceback.print_exc()
+        else:
+            if count >= self.throttle:
+                return
+
+        # Adapt from `django.utils.log.AdminEmailHandler`
+        try:
+            request = record.request
+            subject = '%s (%s IP): %s' % (
+                record.levelname,
+                ('internal' if request.META.get('REMOTE_ADDR') in settings.INTERNAL_IPS
+                 else 'EXTERNAL'),
+                record.getMessage(),
+            )
+        except Exception:
+            subject = '%s: %s' % (
+                record.levelname,
+                record.getMessage(),
+            )
+            request = None
+        subject = self.format_subject(subject)
+
+        # Since we add a nicely formatted traceback on our own, create a copy
+        # of the log record without the exception data.
+        no_exc_record = copy(record)
+        no_exc_record.exc_info = None
+        no_exc_record.exc_text = None
+
+        if record.exc_info:
+            exc_info = record.exc_info
+        else:
+            exc_info = (None, record.getMessage(), None)
+
+        reporter = ExceptionReporter(request, is_email=True, *exc_info)
+        message = "%s\n\n%s" % (self.format(no_exc_record), reporter.get_traceback_text())
+        self.send_webhook(subject, message)
+
+    def send_webhook(self, subject, message):
+        webhook = settings.DISCORD_WEBHOOK.get('on_error', None)
+        if webhook is None:
+            return
+        webhook = DiscordWebhook(url=webhook, content=subject)
+        # Discord has a limit 8 MB file size for normal server (without boost)
+        # Use 7MB just for safe.
+        webhook.add_file(file=message[:7 * 1024 * 1024], filename='log.txt')
+        webhook.execute()
+
+    def format_subject(self, subject):
+        """
+        Escape CR and LF characters.
+        """
+        return subject.replace('\n', '\\n').replace('\r', '\\r')

--- a/dmoj/throttle_discord_webhook.py
+++ b/dmoj/throttle_discord_webhook.py
@@ -51,7 +51,6 @@ class ThrottledDiscordWebhookHandler(logging.Handler):
                 record.getMessage(),
             )
             request = None
-        subject = self.format_subject(subject)
 
         # Since we add a nicely formatted traceback on our own, create a copy
         # of the log record without the exception data.
@@ -77,9 +76,3 @@ class ThrottledDiscordWebhookHandler(logging.Handler):
         # Use 7MB just for safe.
         webhook.add_file(file=message[:7 * 1024 * 1024], filename='log.txt')
         webhook.execute()
-
-    def format_subject(self, subject):
-        """
-        Escape CR and LF characters.
-        """
-        return subject.replace('\n', '\\n').replace('\r', '\\r')


### PR DESCRIPTION
Currently, the site is able to send emails to admins on error.
This commit makes it able to send messages to a discord channel (via webhook) on error:

![image](https://user-images.githubusercontent.com/23715841/133096843-1a3f107c-9ee3-429c-ab72-5ffd14b21251.png)


To set up, add 'on_error' on the webhook config dict and use this logging setting:
```python
LOGGING = {
    'handlers': {
        'discord_webhook_admin': {
            'level': 'ERROR',
            'class': 'dmoj.throttle_discord_webhook.ThrottledDiscordWebhookHandler',
        },
    },
    'loggers': {
       # Site 500 error mails.
        'django.request': {
            'handlers': ['discord_webhook_admin'],
            'level': 'ERROR',
            'propagate': False,
        },
        # Judging logs as received by bridged.
        'judge.bridge': {
            'handlers': ['discord_webhook_admin'],
            'level': 'INFO',
            'propagate': True,
        },
    },
}
```