### PR TITLE
Tag project fixes

### DIFF
--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -83,8 +83,8 @@ OJ_PROBLEM_PRESET = [
         'judge': 'Codeforces',
     },
     {
-        'regex': r'^https://atcoder.jp/contests/(?P<contestId>\w+)/tasks/(?P<index>\w+)$',
-        'codename': 'AC_%s_%s',
+        'regex': r'^^https://atcoder.jp/contests/(?:\w*)/tasks/(?P<codename>\w+)$',
+        'codename': 'AC_%s',
         'judge': 'Atcoder',
     },
     {

--- a/judge/utils/judge_api.py
+++ b/judge/utils/judge_api.py
@@ -84,12 +84,12 @@ class OJAPI:
             if problemset_data is None:
                 return None
 
-            code_template = "AC_%s_%s"  # I.e.: index = abc064_c
+            code_template = "AC_%s"  # I.e.: index = abc064_c
 
             problemset = {}
 
             for problem in problemset_data:
-                code = code_template % (problem['contest_id'], problem["id"])
+                code = code_template % (problem["id"])
                 if code in problemset:
                     raise ValueError("Problem code %s appeared twice in the problemset." % code)
                 problemset[code] = {

--- a/judge/views/tag.py
+++ b/judge/views/tag.py
@@ -24,7 +24,7 @@ from judge.utils.views import SingleObjectFormView, TitleMixin, generic_message,
 
 class TagAllowingMixin(object):
     def dispatch(self, request, *args, **kwargs):
-        if request.user.is_authenticated and not request.profile.allow_tagging:
+        if request.user.is_authenticated and not request.profile.allow_tagging and not request.user.is_superuser:
             return generic_message(request, _('Cannot tag'),
                                    _('You are not allowed to tag problem.'))
         return super(TagAllowingMixin, self).dispatch(request, *args, **kwargs)

--- a/judge/views/tag.py
+++ b/judge/views/tag.py
@@ -24,7 +24,7 @@ from judge.utils.views import SingleObjectFormView, TitleMixin, generic_message,
 
 class TagAllowingMixin(object):
     def dispatch(self, request, *args, **kwargs):
-        if request.user.is_authenticated and not request.profile.allow_tagging and not request.user.is_superuser:
+        if not request.user.is_authenticated or (not request.profile.allow_tagging and not request.user.is_superuser):
             return generic_message(request, _('Cannot tag'),
                                    _('You are not allowed to tag problem.'))
         return super(TagAllowingMixin, self).dispatch(request, *args, **kwargs)

--- a/templates/tag/problem.html
+++ b/templates/tag/problem.html
@@ -73,7 +73,7 @@
             <h2>{{ content_title }}</h2>
             <span class="spacer"></span>
             <ul>
-                {% if request.user.is_authenticated and request.profile.allow_tagging %}
+                {% if request.user.is_authenticated and (request.profile.allow_tagging or request.user.is_superuser) %}
                     <li class="tab">
                         <a href="{{ url('tagproblem_assign', problem.code) }}"><i class="tab-icon fa fa-plus"></i>{{ _('Assign new tag') }}</a>
                     </li>

--- a/templates/tag/tag-list-tabs.html
+++ b/templates/tag/tag-list-tabs.html
@@ -1,7 +1,7 @@
 {% extends "tabs-base.html" %}
 
 {% block tabs %}
-    {% if request.user.is_authenticated and request.profile.allow_tagging %}
+    {% if request.user.is_authenticated and (request.profile.allow_tagging or request.user.is_superuser) %}
         {{ make_tab('create', 'fa-plus', url('tagproblem_create'), _('Create new tag problem')) }}
     {% endif %}
     {{ make_tab('list', 'fa-list', url('tagproblem_list'), _('List')) }}


### PR DESCRIPTION
These are some minor changes for the tag project:
- Change the Atcoder codename from `AC_contestId_Id` to `AC_Id`.
- Superusers can now add tag problem without `allow_tagging == True`.