### PR TITLE
Add teacher roles, remove admin icon

### DIFF
--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -70,6 +70,7 @@ VNOJ_DISPLAY_RANKS = (
     ('staff', _('Staff')),
     ('banned', _('Banned User')),
     ('admin', _('Admin')),
+    ('teacher', _('Teacher')),
 )
 
 # Maximum number of organization a single user can be admin, to be able to

--- a/resources/ranks.scss
+++ b/resources/ranks.scss
@@ -3,12 +3,9 @@
     font-weight: bold !important;
 }
 
-.admin a::before {
-    content: "💪";
-}
-
 .banned a, .banned {
     color: black !important;
+    font-weight: normal !important;
     text-decoration: line-through !important;
 }
 
@@ -32,6 +29,10 @@
 
 .daor a::before {
     content: "🌸";
+}
+
+.teacher a::before {
+    content: "🧑‍🏫";
 }
 
 @mixin rate-svg-color($color) {


### PR DESCRIPTION
Also fixed case that banned user's username got bold if they were rated

Teacher role will have a teacher icon before their name:

![image](https://user-images.githubusercontent.com/23715841/134352180-2717ad1d-73f3-4a8e-8bec-0ef04b29d873.png)

Remove admin icon.

Fixed bug for banned user:
Before:
![image](https://user-images.githubusercontent.com/23715841/134352367-6486a0c4-067b-412a-bf5b-06409a0f7b23.png)

After:
![image](https://user-images.githubusercontent.com/23715841/134352395-8882a9fd-b8cc-4351-a97c-52026e1d1389.png)

