### PR TITLE
Improve problem permission handling

### DIFF
--- a/judge/jinja2/submission.py
+++ b/judge/jinja2/submission.py
@@ -11,6 +11,9 @@ def get_editor_ids(contest):
 
 @registry.function
 def submission_layout(submission, profile_id, user, completed_problem_ids, editable_problem_ids, tester_problem_ids):
+    if not user.is_authenticated:
+        return False, False
+
     problem_id = submission.problem_id
     submission_source_visibility = submission.problem.submission_source_visibility
     can_view = False

--- a/judge/models/problem.py
+++ b/judge/models/problem.py
@@ -221,10 +221,10 @@ class Problem(models.Model):
     def is_editable_by(self, user):
         if not user.is_authenticated:
             return False
-        if user.has_perm('judge.suggest_new_problem') and self.is_suggesting:
-            return True
         if not user.has_perm('judge.edit_own_problem'):
             return False
+        if user.has_perm('judge.suggest_new_problem') and self.is_suggesting:
+            return True
         if user.has_perm('judge.edit_all_problem') or user.has_perm('judge.edit_public_problem') and self.is_public:
             return True
         if user.profile.id in self.editor_ids:
@@ -276,13 +276,13 @@ class Problem(models.Model):
         if self.testers.filter(id=user.profile.id).exists():
             return True
 
-        if self.is_suggesting:
-            return False
-
         return False
 
+    def is_rejudgeable_by(self, user):
+        return user.has_perm('judge.rejudge_submission') and self.is_editable_by(user)
+
     def is_subs_manageable_by(self, user):
-        return user.is_staff and user.has_perm('judge.rejudge_submission') and self.is_editable_by(user)
+        return user.is_staff and self.is_rejudgeable_by(user)
 
     @classmethod
     def get_visible_problems(cls, user):
@@ -296,6 +296,7 @@ class Problem(models.Model):
         #       - not is_public problems
         #           - author or curator or tester
         #           - is_organization_private and admin of organization
+        #           - is_suggesting and user is a suggester
         #       - is_public problems
         #           - not is_organization_private or in organization or `judge.see_organization_problem`
         #           - author or curator or tester
@@ -304,6 +305,7 @@ class Problem(models.Model):
         edit_own_problem = user.has_perm('judge.edit_own_problem')
         edit_public_problem = edit_own_problem and user.has_perm('judge.edit_public_problem')
         edit_all_problem = edit_own_problem and user.has_perm('judge.edit_all_problem')
+        edit_suggesting_problem = edit_own_problem and user.has_perm('judge.suggest_new_problem')
 
         if not (user.has_perm('judge.see_private_problem') or edit_all_problem):
             q = Q(is_public=True)
@@ -313,6 +315,10 @@ class Problem(models.Model):
                     Q(is_organization_private=False) |
                     Q(is_organization_private=True, organizations__in=user.profile.organizations.all())
                 )
+
+            # Suggesters should be able to view suggesting problems
+            if edit_suggesting_problem:
+                q |= Q(suggester__isnull=False, is_public=False)
 
             # Authors, curators, and testers should always have access, so OR at the very end.
             q |= Q(authors=user.profile)
@@ -337,6 +343,8 @@ class Problem(models.Model):
 
         if user.has_perm('judge.edit_public_problem'):
             q |= Q(is_public=True)
+        if user.has_perm('judge.suggest_new_problem'):
+            q |= Q(suggester__isnull=False, is_public=False)
 
         return cls.objects.filter(q)
 

--- a/judge/views/widgets.py
+++ b/judge/views/widgets.py
@@ -30,7 +30,7 @@ def rejudge_submission(request):
     except Submission.DoesNotExist:
         return HttpResponseBadRequest()
 
-    if not submission.problem.is_subs_manageable_by(request.user):
+    if not submission.problem.is_rejudgeable_by(request.user):
         return HttpResponseForbidden()
 
     submission.judge(rejudge=True)

--- a/templates/submission/source.html
+++ b/templates/submission/source.html
@@ -68,7 +68,8 @@
     {% if (request.user == submission.user.user or perms.judge.resubmit_other) and not submission.language.file_only %}
         <div><a href="{{ url('problem_submit', submission.problem.code, submission.id) }}">{{ _('Resubmit') }}</a></div>
     {% endif %}
-    {% if perms.judge.rejudge_submission and not submission.is_locked %}
+    {% set can_edit = submission.problem.is_editable_by(request.user) %}
+    {% if perms.judge.rejudge_submission and can_edit and not submission.is_locked %}
         <div>
             <form action="{{ url('submission_rejudge') }}" method="post">
                 {% csrf_token %}

--- a/templates/submission/status.html
+++ b/templates/submission/status.html
@@ -72,7 +72,8 @@
     {% if (request.user == submission.user.user or perms.judge.resubmit_other) and not submission.language.file_only %}
         <div><a href="{{ url('problem_submit', submission.problem.code, submission.id) }}">{{ _('Resubmit') }}</a></div>
     {% endif %}
-    {% if perms.judge.rejudge_submission and not submission.is_locked %}
+    {% set can_edit = submission.problem.is_editable_by(request.user) %}
+    {% if perms.judge.rejudge_submission and can_edit and not submission.is_locked %}
         <div>
             <form action="{{ url('submission_rejudge') }}" method="post">
                 {% csrf_token %}


### PR DESCRIPTION
- edit_own_problem is the prerequisite for editing any problems
- Allow non-staff users with rejudge permission to rejudge individual submission
- Correctly allow suggesters to edit suggesting problems
- Fix rejudge button showing up when users are actually not allowed to rejudge