### PR TITLE
Rework discord webhook

### DIFF
--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -132,8 +132,10 @@ OJAPI_CACHE_TIMEOUT = 3600  # Cache timeout for OJAPI data
 # Urls of discord webhook.
 # https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks
 DISCORD_WEBHOOK = {
+    'default': None, # use this link if the specific link not found
     'on_new_ticket': None,
     'on_new_comment': None,
+    'on_new_problem': None,
     'on_new_suggested_problem': None,
     'on_new_tag_problem': None,
     'on_new_tag': None,

--- a/judge/models/problem.py
+++ b/judge/models/problem.py
@@ -482,7 +482,12 @@ class Problem(models.Model):
                 pass
             else:
                 problem_data._update_code(self.__original_code, self.code)
-        if self.points != self.__original_points:
+
+        # self.__original_points will be None if:
+        #   - create new instance (should ignore)
+        #   - The `points` field got deferred (not sure about this?)
+        # in both cases, we don't rescore submissions.
+        if self.__original_points is not None and self.points != self.__original_points:
             self._rescore()
 
     save.alters_data = True

--- a/judge/tasks/webhook.py
+++ b/judge/tasks/webhook.py
@@ -1,3 +1,4 @@
+import pytz
 from celery import shared_task
 from discord_webhook import DiscordEmbed, DiscordWebhook
 from django.conf import settings
@@ -5,17 +6,43 @@ from django.contrib.contenttypes.models import ContentType
 
 
 from judge.jinja2.gravatar import gravatar
-from judge.models import Comment, Problem, Tag, TagProblem, Ticket
+from judge.models import Comment, Contest, Problem, Tag, TagProblem, Ticket
 
-__all__ = ('on_new_ticket', 'on_new_comment', 'on_new_suggested_problem')
+__all__ = ('on_new_ticket', 'on_new_comment', 'on_new_problem', 'on_new_tag_problem', 'on_new_tag', 'on_new_contest')
+
+
+def get_webhook_url(event_name):
+    default = settings.DISCORD_WEBHOOK.get('default', None)
+    webhook = settings.DISCORD_WEBHOOK.get(event_name, default)
+    return webhook
+
+
+def send_webhook(webhook, title, description, author, color='03b2f8'):
+    webhook = DiscordWebhook(url=webhook)
+
+    embed = DiscordEmbed(
+        title=title,
+        description=description,
+        color=color,
+    )
+
+    if author is not None:
+        embed.set_author(
+            name=author.user.username,
+            url=settings.SITE_FULL_URL + '/user/' + author.user.username,
+            icon_url=gravatar(author),
+        )
+
+    webhook.add_embed(embed)
+    webhook.execute()
 
 
 @shared_task
 def on_new_ticket(ticket_id, content_type_id, object_id, message):
-    webhook = settings.DISCORD_WEBHOOK.get('on_new_ticket', None)
-    site_url = settings.SITE_FULL_URL
-    if webhook is None or site_url is None:
+    webhook = get_webhook_url('on_new_ticket')
+    if webhook is None or settings.SITE_FULL_URL is None:
         return
+
     ticket = Ticket.objects.get(pk=ticket_id)
     obj = ContentType.objects.get_for_id(content_type_id).get_object_for_this_type(
         pk=object_id,
@@ -23,105 +50,77 @@ def on_new_ticket(ticket_id, content_type_id, object_id, message):
     url = obj.get_absolute_url()
     # for internal links, we add the site url
     if url[0] == '/':
-        url = site_url + url
-    webhook = DiscordWebhook(url=webhook)
-    ticket_url = site_url + '/ticket/' + str(ticket_id)
+        url = settings.SITE_FULL_URL + url
+
+    ticket_url = settings.SITE_FULL_URL + '/ticket/' + str(ticket_id)
     title = f'Title: [{ticket.title}]({ticket_url})'
     message = f'Message: {message}'
-    embed = DiscordEmbed(
-        title=f'New ticket on {url}',
-        description=title + '\n' + message[:100],  # Should not too long
-        color='03b2f8',
-    )
-    embed.set_author(
-        name=ticket.user.user.username,
-        url=site_url + '/user/' + ticket.user.user.username,
-        icon_url=gravatar(ticket.user),
-    )
-    webhook.add_embed(embed)
-    webhook.execute()
+    send_webhook(webhook, f'New ticket on {url}', title + '\n' + message[:100], ticket.user)
 
 
 @shared_task
 def on_new_comment(comment_id):
-    webhook = settings.DISCORD_WEBHOOK.get('on_new_comment', None)
-    site_url = settings.SITE_FULL_URL
-    if webhook is None or site_url is None:
+    webhook = get_webhook_url('on_new_comment')
+    if webhook is None or settings.SITE_FULL_URL is None:
         return
 
     comment = Comment.objects.get(pk=comment_id)
-    url = site_url + comment.get_absolute_url()
-
-    webhook = DiscordWebhook(url=webhook)
-    embed = DiscordEmbed(
-        title=f'New comment {url}',
-        description=comment.body[:200],  # should not too long
-        color='03b2f8',
-    )
-    embed.set_author(
-        name=comment.author.user.username,
-        url=site_url + '/user/' + comment.author.user.username,
-        icon_url=gravatar(comment.author),
-    )
-    webhook.add_embed(embed)
-    webhook.execute()
+    url = settings.SITE_FULL_URL + comment.get_absolute_url()
+    send_webhook(webhook, f'New comment {url}', comment.body[:200], comment.author)
 
 
 @shared_task
-def on_new_suggested_problem(problem_code):
-    webhook = settings.DISCORD_WEBHOOK.get('on_new_suggested_problem', None)
-    site_url = settings.SITE_FULL_URL
-    if webhook is None or site_url is None:
+def on_new_problem(problem_code, is_suggested=False):
+    event_name = 'on_new_suggested_problem' if is_suggested else 'on_new_problem'
+    webhook = get_webhook_url(event_name)
+    if webhook is None or settings.SITE_FULL_URL is None:
         return
 
     problem = Problem.objects.get(code=problem_code)
-    url = site_url + problem.get_absolute_url()
-    description = f'Title: {problem.name}\n'
-    description += f'Statement: {problem.description[:100]}...'
+    author = problem.suggester or problem.authors.first()
 
-    webhook = DiscordWebhook(url=webhook)
-    embed = DiscordEmbed(
-        title=f'New suggested problem {url}',
-        description=description,
-        color='03b2f8',
-    )
-    embed.set_author(
-        name=problem.suggester.user.username,
-        url=site_url + '/user/' + problem.suggester.user.username,
-        icon_url=gravatar(problem.suggester),
-    )
-    webhook.add_embed(embed)
-    webhook.execute()
+    url = settings.SITE_FULL_URL + problem.get_absolute_url()
+    title = f'New {"suggested" if is_suggested else "organization"} problem {url}'
+
+    description = [
+        ('Title', problem.name),
+        ('Statement', problem.description[:100] + '...\n'),
+        ('Time limit', problem.time_limit),
+        ('Memory limit (MB)', problem.memory_limit / 1024),
+        ('Points', problem.points),
+    ]
+
+    if problem.is_organization_private:
+        orgs_link = [
+            f'[{org.name}]({settings.SITE_FULL_URL + org.get_absolute_url()})'
+            for org in problem.organizations.all()
+        ]
+
+        description.append(('Organizations', ' '.join(orgs_link)))
+
+    description = '\n'.join(f'{opt}: {val}' for opt, val in description)
+
+    send_webhook(webhook, title, description, author)
 
 
 @shared_task
 def on_new_tag_problem(problem_code):
-    webhook = settings.DISCORD_WEBHOOK.get('on_new_tag_problem', None)
-    site_url = settings.SITE_FULL_URL
-    if webhook is None or site_url is None:
+    webhook = get_webhook_url('on_new_tag_problem')
+    if webhook is None or settings.SITE_FULL_URL is None:
         return
 
     problem = TagProblem.objects.get(code=problem_code)
-    url = site_url + problem.get_absolute_url()
+    url = settings.SITE_FULL_URL + problem.get_absolute_url()
     description = f'Title: {problem.name}\n'
     description += f'Judge: {problem.judge}'
 
-    webhook = DiscordWebhook(url=webhook)
-    embed = DiscordEmbed(
-        title=f'New tag problem {url}',
-        description=description,
-        color='03b2f8',
-    )
-
-    webhook.add_embed(embed)
-    webhook.execute()
+    send_webhook(webhook, f'New tag problem {url}', description, None)
 
 
 @shared_task
 def on_new_tag(problem_code, tag_list):
-    webhook = settings.DISCORD_WEBHOOK.get('on_new_tag', None)
-    site_url = settings.SITE_FULL_URL
-    if webhook is None or site_url is None:
+    webhook = get_webhook_url('on_new_tag')
+    if webhook is None or settings.SITE_FULL_URL is None:
         return
 
     problem = TagProblem.objects.get(code=problem_code)
@@ -130,17 +129,43 @@ def on_new_tag(problem_code, tag_list):
     for tag in tag_list:
         tags.append(Tag.objects.get(code=tag).name)
 
-    url = site_url + problem.get_absolute_url()
+    url = settings.SITE_FULL_URL + problem.get_absolute_url()
 
     description = f'Title: {problem.name}\n'
     description += f'New tag: {", ".join(tags)}'
 
-    webhook = DiscordWebhook(url=webhook)
-    embed = DiscordEmbed(
-        title=f'New tag added for problem {url}',
-        description=description,
-        color='03b2f8',
-    )
+    send_webhook(webhook, f'New tag added for problem {url}', description, None)
 
-    webhook.add_embed(embed)
-    webhook.execute()
+
+@shared_task
+def on_new_contest(contest_key):
+    webhook = get_webhook_url('on_new_contest')
+    if webhook is None or settings.SITE_FULL_URL is None:
+        return
+
+    contest = Contest.objects.get(key=contest_key)
+    author = contest.authors.first()
+
+    url = settings.SITE_FULL_URL + contest.get_absolute_url()
+    title = f'New contest {url}'
+
+    tz = pytz.timezone(settings.DEFAULT_USER_TIME_ZONE)
+
+    description = [
+        ('Title', contest.name),
+        ('Statement', contest.description[:100] + '...\n'),
+        ('Start time', contest.start_time.astimezone(tz).strftime('%Y-%m-%d %H:%M')),
+        ('End time', contest.end_time.astimezone(tz).strftime('%Y-%m-%d %H:%M')),
+        ('Duration', contest.end_time - contest.start_time),
+    ]
+    if contest.is_organization_private:
+        orgs_link = [
+            f'[{org.name}]({settings.SITE_FULL_URL + org.get_absolute_url()})'
+            for org in contest.organizations.all()
+        ]
+
+        description.append(('Organizations', ' '.join(orgs_link)))
+
+    description = '\n'.join(f'{opt}: {val}' for opt, val in description)
+
+    send_webhook(webhook, title, description, author)

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -33,7 +33,7 @@ from judge.comments import CommentedDetailView
 from judge.forms import ContestCloneForm, ContestForm, ProposeContestProblemFormSet
 from judge.models import Contest, ContestAnnouncement, ContestMoss, ContestParticipation, ContestProblem, ContestTag, \
     Problem, ProblemClarification, Profile, Submission
-from judge.tasks import run_moss
+from judge.tasks import on_new_contest, run_moss
 from judge.utils.celery import redirect_to_task_status
 from judge.utils.cms import parse_csv_ranking
 from judge.utils.opengraph import generate_opengraph
@@ -970,7 +970,7 @@ class CreateContest(PermissionRequiredMixin, TitleMixin, CreateView):
 
                 revisions.set_comment(_('Created on site'))
                 revisions.set_user(self.request.user)
-
+            on_new_contest.delay(self.object.key)
             return HttpResponseRedirect(self.get_success_url())
         else:
             return self.render_to_response(self.get_context_data(*args, **kwargs))

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -17,6 +17,7 @@ from reversion import revisions
 
 from judge.forms import OrganizationForm
 from judge.models import BlogPost, Comment, Contest, Language, Organization, OrganizationRequest, Problem, Profile
+from judge.tasks import on_new_problem
 from judge.utils.ranker import ranker
 from judge.utils.views import QueryStringSortMixin, TitleMixin, generic_message
 from judge.views.blog import BlogPostCreate, PostListBase
@@ -583,6 +584,7 @@ class ProblemCreateOrganization(CustomAdminOrganizationMixin, ProblemCreate):
             revisions.set_comment(_('Created on site'))
             revisions.set_user(self.request.user)
 
+        on_new_problem.delay(problem.code)
         return HttpResponseRedirect(self.get_success_url())
 
 

--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -30,7 +30,7 @@ from judge.forms import ProblemCloneForm, ProblemEditForm, ProblemSubmitForm, Pr
 from judge.models import ContestSubmission, Judge, Language, Problem, ProblemGroup, \
     ProblemTranslation, ProblemType, RuntimeVersion, Solution, Submission, SubmissionSource
 from judge.pdf_problems import DefaultPdfMaker, HAS_PDF
-from judge.tasks import on_new_suggested_problem
+from judge.tasks import on_new_problem
 from judge.template_context import misc_config
 from judge.utils.diggpaginator import DiggPaginator
 from judge.utils.opengraph import generate_opengraph
@@ -811,7 +811,7 @@ class ProblemSuggest(ProblemCreate):
             revisions.set_comment(_('Created on site'))
             revisions.set_user(self.request.user)
 
-        on_new_suggested_problem.delay(problem.code)
+        on_new_problem.delay(problem.code, is_suggested=True)
         return HttpResponseRedirect(self.get_success_url())
 
 

--- a/judge/views/tag.py
+++ b/judge/views/tag.py
@@ -17,7 +17,7 @@ from reversion import revisions
 from judge.comments import CommentedDetailView
 from judge.forms import TagProblemAssignForm, TagProblemCreateForm
 from judge.models import Tag, TagData, TagGroup, TagProblem
-from judge.tasks.webhook import on_new_tag, on_new_tag_problem
+from judge.tasks import on_new_tag, on_new_tag_problem
 from judge.utils.diggpaginator import DiggPaginator
 from judge.utils.judge_api import APIError, OJAPI
 from judge.utils.views import SingleObjectFormView, TitleMixin, generic_message, paginate_query_context


### PR DESCRIPTION
- If the webhook link is not found, it will try to get the default link from `DISCORD_WEBHOOK`.
- Add on_new_contest event
- Show more information for on_new_problem
- Refactor code
- Send webhook on new organization problem

![image](https://user-images.githubusercontent.com/23715841/135274456-7f132fbe-fed7-4fb3-b8fa-dc4994705251.png)
