### PR TITLE
UI form: allow limit number of submissions in contest

### DIFF
--- a/judge/forms.py
+++ b/judge/forms.py
@@ -477,7 +477,7 @@ class ProposeContestProblemForm(ModelForm):
         verbose_name = _('Problem')
         verbose_name_plural = 'Problems'
         fields = (
-            'problem', 'points', 'order',
+            'problem', 'points', 'order', 'max_submissions',
         )
 
         widgets = {

--- a/templates/contest/edit.html
+++ b/templates/contest/edit.html
@@ -81,6 +81,7 @@
         <td>{{ form.id }} {{ form.problem.errors }}{{ form.problem }}</td>
         <td class="points-column">{{ form.points.errors }}{{ form.points }}</td>
         <td>{{ form.order.errors }}{{ form.order }}</td>
+        <td>{{ form.max_submissions.errors }}{{ form.max_submissions }}</td>
         <td>
         {% if contest_problem_formset.can_delete and form.instance.pk %}
             {{ form.DELETE }}
@@ -110,9 +111,18 @@
         <table class="table">
             <thead>
                 <tr>
-                    <th class="problem-column"> {{ _('Problems') }} </th>
+                    <th class="problem-column" style="width: 20em;"> {{ _('Problems') }} </th>
                     <th class="points-column"> {{ _('Points') }} </th>
                     <th> {{ _('Order in contest') }} </th>
+                    <th>
+                        {{ _('Max submission') }}
+                        <br>
+                        <span class="helptext">
+                            {{ _('Maximum number of submissions') }}
+                            <br>
+                            {{_('or leave blank for no limit.') }}
+                        </span>
+                    </th>
                     <th> {{ _('Delete') }} </th>
                 </tr>
             </thead>


### PR DESCRIPTION
# Description

Allow contest author to limit the number of submissions that a user can submit in a contest.

Type of change: new feature

## What

- Add `max_submissions` field to ProposeContestProblemForm.
- Add help text.

![image](https://user-images.githubusercontent.com/23715841/136685823-c2563d88-84a1-48f4-a3df-0b47583b4b2a.png)

## Why

Why this PR is needed: requested by users :( 

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [x] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
