### PR TITLE
Hide unlisted organizations in users and contest ranking table

### DIFF
--- a/judge/models/profile.py
+++ b/judge/models/profile.py
@@ -179,7 +179,7 @@ class Profile(models.Model):
     @cached_property
     def organization(self):
         # We do this to take advantage of prefetch_related
-        orgs = self.organizations.all()
+        orgs = self.organizations.filter(is_unlisted=False)
         return orgs[0] if orgs else None
 
     @cached_property

--- a/judge/models/tests/util.py
+++ b/judge/models/tests/util.py
@@ -305,6 +305,7 @@ class CommonDataMixin:
         self.organizations = {
             'open': create_organization(
                 name='open',
+                is_unlisted=False,
                 admins=('staff_organization_admin',),
             ),
         }

--- a/templates/user/base-users-table.html
+++ b/templates/user/base-users-table.html
@@ -35,7 +35,7 @@
             <div style="float:right; text-align: right;">
                 {% block personal_info_data scoped %}
                     <em style="font-size: 0.75em; color:grey;">
-                        {% for organization in user.organizations.all() %}
+                        {% for organization in user.organizations.filter(is_unlisted=False) %}
                             <a style="color:grey;" href="{{ organization.get_absolute_url() }}">{{ organization.name }}</a>{% if not loop.last %} | {% endif %}
                         {% endfor %}
                     </em>


### PR DESCRIPTION
# Description

Hide unlisted organizations in users and contest ranking table

Type of change: bug fix

## What

Filter unlisted organizations in `base-users-table.html` and `Profile.organization`

## Why

Fix bug

# Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [ ] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
