### PR TITLE
Reduce rendering time of testdata page

### DIFF
--- a/templates/problem/data.html
+++ b/templates/problem/data.html
@@ -14,6 +14,20 @@
                     $select.val(file).trigger('change');
             }
 
+            var valid_files_options = window.valid_files.map(function (file) {
+                return {id: file, text: file};
+            });
+
+            var select2_settings = {
+                ajax: {
+                    transport: function (params, success) {
+                        success({results: valid_files_options});
+                    },
+                },
+                allowClear: true,
+                placeholder: ''
+            };
+
             var $table = $('#case-table');
             $table.on('add-row', function (e, $tr) {
                 $tr.find('input').filter('[id$=file]').each(function () {
@@ -22,11 +36,8 @@
                         name: $(this).attr('name'),
                         style: 'width: 100%'
                     })).val();
-                    $select.select2({
-                        data: window.valid_files,
-                        allowClear: true,
-                        placeholder: ''
-                    }).val(val).trigger('change').on('change', function () {
+                    var option = new Option(val, val, true, true);
+                    $select.select2(select2_settings).append(option).trigger('change').on('change', function () {
                         var val = $select.val();
                         if (val) {
                             if ($select.attr('id').endsWith('input_file'))

--- a/templates/problem/data.html
+++ b/templates/problem/data.html
@@ -11,7 +11,7 @@
         $(function () {
             function autofill_if_exists($select, file) {
                 if (!$select.val() && ~window.valid_files.indexOf(file))
-                    $select.val(file).trigger('change');
+                    $select.append(new Option(file, file, true, true)).change();
             }
 
             var valid_files_options = window.valid_files.map(function (file) {
@@ -37,7 +37,7 @@
                         style: 'width: 100%'
                     })).val();
                     var option = new Option(val, val, true, true);
-                    $select.select2(select2_settings).append(option).trigger('change').on('change', function () {
+                    $select.select2(select2_settings).append(option).change().on('change', function () {
                         var val = $select.val();
                         if (val) {
                             if ($select.attr('id').endsWith('input_file'))
@@ -372,8 +372,8 @@
                 }
                 // fill cases
                 for (var i = 0; i < n_test; i++) {
-                    $("#id_cases-" + i + "-input_file").val(inFiles[i]).change();
-                    $("#id_cases-" + i + "-output_file").val(outFiles[i]).change();
+                    $("#id_cases-" + i + "-input_file").append(new Option(inFiles[i], inFiles[i], true, true)).change();
+                    $("#id_cases-" + i + "-output_file").append(new Option(outFiles[i], outFiles[i], true, true)).change();
                     $("#id_cases-" + i + "-points").val("1").change();
                 }
                 $("#fill-test-case-noti").show();


### PR DESCRIPTION
# Description

Type of change: improvement

## What

Reduce rendering time of testdata page

## Why

Let N be the number of test cases. The current code needs O(N^2) time to render the testdata page. This is because select2 creates DOM elements for every option even if it's hidden.

This PR fixes that by dynamically rendering options.

# How Has This Been Tested?

Tested with 200 test cases

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
