### PR TITLE
Fix exporting ranking as CSV

### DIFF
--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -277,12 +277,13 @@
                         if ($col.hasClass('rating-column')) {
                             // Skip rating
                             return;
-                        } else if ($col.hasClass('personal-info')) {
-                            // Full name
-                            header.push('Full name');
-                        } else if ($col.hasClass('username') || $col.hasClass('rank')) {
-                            // Username or rank
+                        } else if ($col.hasClass('rank')) {
+                            // Rank
                             header.push(clean_text($col.text()));
+                        } else if ($col.hasClass('username')) {
+                            // Username and Full name
+                            header.push(clean_text('{{ _('Username') }}'));
+                            header.push(clean_text('{{ _('Full Name') }}'));
                         } else {
                             // Point
                             var name = $col.find('.problem-code').text();
@@ -303,9 +304,10 @@
                         if ($col.hasClass('rating-column')) {
                             // Skip rating
                             return;
-                        } else if ($col.hasClass('user-name') || $col.hasClass('personal-info')) {
-                            // Username or Full name
-                            row_data.push(clean_text($col.children().first().text()));
+                        } else if ($col.hasClass('user-name')) {
+                            // Username and Full name
+                            row_data.push(clean_text($col.find('.rating').first().text()));
+                            row_data.push(clean_text($col.find('.personal-info').first().text()));
                         } else {
                             // Point or rank
                             row_data.push(clean_text($col.ignore('.solving-time').text()));


### PR DESCRIPTION
# Description

Type of change: bug fix

## What

Fix exporting ranking as CSV

## Why

This feature is currently broken due to https://github.com/VNOI-Admin/OJ/commit/732ac6734df52d880f0b23711a7c30942199d6e0

# How Has This Been Tested?

Tested on default contest format

[ranking_cbn001_2021-11-19-11-49-27.csv](https://github.com/VNOI-Admin/OJ/files/7567813/ranking_cbn001_2021-11-19-11-49-27.csv)

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
