### PR TITLE
Only store project.json for Scratch submissions

### DIFF
--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import shutil
+import zipfile
 from datetime import timedelta
 from operator import itemgetter
 from random import randrange
@@ -656,6 +657,14 @@ class ProblemSubmit(LoginRequiredMixin, ProblemMixin, TitleMixin, SingleObjectFo
 
             submission_file = form.files.get('submission_file', None)
             if submission_file is not None:
+                if self.new_submission.language.key == 'SCRATCH':
+                    try:
+                        archive = zipfile.ZipFile(submission_file.file)
+                        submission_file.file = archive.open('project.json')
+                        submission_file.name = 'dummy.json'
+                    except (zipfile.BadZipFile, KeyError):
+                        pass
+
                 source_url = submission_uploader(
                     submission_file=submission_file,
                     problem_code=self.new_submission.problem.code,


### PR DESCRIPTION
# Description

Type of change: enhancement

## What

Only store `project.json` instead of the original `sb3` file.

## Why

To save space. `sb3` file is ~50KB, while `project.json` is ~5kb. scratch-run can run `project.json` just fine.

# How Has This Been Tested?

Tested locally.

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
