### PR TITLE
Add button for rescoring contest problems

### DIFF
--- a/templates/admin/judge/contest/change_form.html
+++ b/templates/admin/judge/contest/change_form.html
@@ -8,6 +8,9 @@
             $('.rejudge-link').click(function () {
                 return confirm('{{ _('Are you sure you want to rejudge ALL the submissions?') }}');
             });
+            $('.rescore-link').click(function () {
+                return confirm('{{ _('Are you sure you want to rescore ALL the submissions?') }}');
+            });
             $('.resend-link').click(function () {
                 return confirm('{{ _('Are you sure you want to resend this announcement?') }}');
             });


### PR DESCRIPTION
# Description

## What

Add button for rescoring contest problems

## Why

Currently, if problem point in contest is changed, the contest ranking is not updated accordingly. Automatic rescoring is not ideal, so this PR adds a button for manually rescoring.

# How Has This Been Tested?

Tested locally: ranking is updated after manual rescoring.

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
