### PR TITLE
Reload ranking during contest every 10 seconds

### DIFF
--- a/dmoj/urls.py
+++ b/dmoj/urls.py
@@ -245,7 +245,6 @@ urlpatterns = [
         url(r'^/announce', contests.ContestAnnounce.as_view(), name='contest_announce'),
         url(r'^/clone$', contests.ContestClone.as_view(), name='contest_clone'),
         url(r'^/ranking/$', contests.ContestRanking.as_view(), name='contest_ranking'),
-        url(r'^/ranking/ajax$', contests.contest_ranking_ajax, name='contest_ranking_ajax'),
         url(r'^/official_ranking/$', contests.ContestOfficialRanking.as_view(), name='contest_official_ranking'),
         url(r'^/join$', contests.ContestJoin.as_view(), name='contest_join'),
         url(r'^/leave$', contests.ContestLeave.as_view(), name='contest_leave'),

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -828,6 +828,17 @@ class ContestRankingBase(ContestMixin, TitleMixin, DetailView):
         context['tab'] = self.tab
         return context
 
+    def get(self, request, *args, **kwargs):
+        if 'raw' in request.GET:
+            self.object = self.get_object()
+
+            if not self.object.can_see_own_scoreboard(self.request.user):
+                raise Http404()
+
+            return HttpResponse(self.get_rendered_ranking_table(), content_type='text/plain')
+
+        return super().get(request, *args, **kwargs)
+
 
 class ContestRanking(ContestRankingBase):
     tab = 'ranking'

--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -145,6 +145,28 @@
                 };
 
                 install_tooltips();
+
+                // Auto reload every 10 seconds
+                var ranking_outdated = false;
+                function update_ranking() {
+                    if ($('body').hasClass('window-hidden')) {
+                        return ranking_outdated = true;
+                    }
+                    $.ajax({
+                        url: '?raw'
+                    }).done(function (data) {
+                        $('#users-table').html(data);
+                    }).always(function () {
+                        ranking_outdated = false;
+                        setTimeout(update_ranking, 10000);
+                    });
+                }
+                $(window).on('dmoj:window-visible', function () {
+                    if (ranking_outdated) {
+                        update_ranking();
+                    }
+                });
+                setTimeout(update_ranking, 10000);
             });
         </script>
     {% endif %}


### PR DESCRIPTION
# Description

Type of change: enhancement

## What

Reload ranking during contest every 10 seconds. Also remove `contest_ranking_ajax`.

# How Has This Been Tested?

Tested locally

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
