### PR TITLE
Bug Fix: Wrong first solved submission on ranking

### DIFF
--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -236,6 +236,11 @@
                 $("a#frozen_alert").click();
             }
 
+            function convertToSeconds(timeString) {
+                time = timeString.split(':').map(Number); // time = [hour, minute, second]
+                return time[0] * 60 * 60 + time[1] * 60 + time[2];
+            }
+
             function timeComparison(sub1, sub2) {
                 if (!sub2) return;
                 return sub1['time'] < sub2['time'];
@@ -266,7 +271,7 @@
 
                         let curSub = {
                             'td': $(this).parent(),
-                            'time': time,
+                            'time': convertToSeconds(time),
                         }
 
                         let fs = firstSolves[problem];

--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -237,7 +237,7 @@
             }
 
             function convertToSeconds(timeString) {
-                time = timeString.split(':').map(Number); // time = [hour, minute, second]
+                const time = timeString.split(':').map(Number); // time = [hour, minute, second]
                 return time[0] * 60 * 60 + time[1] * 60 + time[2];
             }
 


### PR DESCRIPTION
# Description

Recorded submission times are compared as strings. This causes a bug where "131:54:47" < "15:33:07".

![image](https://user-images.githubusercontent.com/68510735/185960797-2ec86e7b-af1f-488d-8e38-46313d1dc57a.png)

[Here's the contest where the bug occurred.](https://oj.vnoi.info/contest/gdi_gen8/ranking/)

## What

This PR aims at fixing the aforementioned bug. The solution is to convert these timestamps into integers (denoting how many seconds have passed, e.g `"15:33:07"` is converted into `55987`).

## Why

The indicator for the first solved submission should be accurate.

# How Has This Been Tested?

This was tested by injecting the updated code via the DevTool console.

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [x] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
