### PR TITLE
Combine publishing problems and setting publish time to now

### DIFF
--- a/judge/admin/problem.py
+++ b/judge/admin/problem.py
@@ -196,10 +196,6 @@ class ProblemAdmin(NoBatchDeleteMixin, VersionAdmin):
                                             '%d problems successfully marked as public.',
                                             count) % count)
 
-        self.message_user(request, ngettext("%d problem's publish date successfully updated.",
-                                            "%d problems' publish date successfully updated.",
-                                            count) % count)
-
     make_public_and_update_publish_date.short_description = _('Mark problems as public and set publish date to now')
 
     def make_private(self, request, queryset):


### PR DESCRIPTION
# Description

## What

This PR combines the two functionalities of "publishing problems" and "set publish time to now".

## Why

Most of the time, they are both used simultaneously. Therefore, it makes sense to have one option to do both.

# How Has This Been Tested?

Tested on my local machine.

# Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [ ] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
