### PR TITLE
Add authors param for import_polygon_package.py

### DIFF
--- a/judge/management/commands/import_polygon_package.py
+++ b/judge/management/commands/import_polygon_package.py
@@ -17,7 +17,8 @@ from django.urls import reverse
 from django.utils import translation
 from lxml import etree as ET
 
-from judge.models import Language, Problem, ProblemData, ProblemGroup, ProblemTestCase, ProblemTranslation, ProblemType, Profile
+from judge.models import Language, Problem, ProblemData, ProblemGroup, ProblemTestCase, ProblemTranslation, \
+    ProblemType, Profile
 from judge.utils.problem_data import ProblemDataCompiler
 from judge.views.widgets import django_uploader
 
@@ -512,7 +513,7 @@ class Command(BaseCommand):
                 profile = Profile.objects.get(user__username=username)
             except Profile.DoesNotExist:
                 raise CommandError(f'user {username} does not exist')
-            
+
             problem_authors.append(profile)
 
         # A dictionary to hold all problem information.

--- a/judge/management/commands/import_polygon_package.py
+++ b/judge/management/commands/import_polygon_package.py
@@ -17,7 +17,7 @@ from django.urls import reverse
 from django.utils import translation
 from lxml import etree as ET
 
-from judge.models import Language, Problem, ProblemData, ProblemGroup, ProblemTestCase, ProblemTranslation, ProblemType
+from judge.models import Language, Problem, ProblemData, ProblemGroup, ProblemTestCase, ProblemTranslation, ProblemType, Profile
 from judge.utils.problem_data import ProblemDataCompiler
 from judge.views.widgets import django_uploader
 
@@ -396,6 +396,7 @@ def create_problem(problem_meta):
     )
     problem.save()
     problem.allowed_languages.set(Language.objects.filter(include_in_problem=True))
+    problem.authors.set(problem_meta['authors'])
     problem.types.set([ProblemType.objects.order_by('id').first()])  # Uncategorized
     problem.save()
 
@@ -480,6 +481,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('package', help='path to package in zip format')
         parser.add_argument('code', help='problem code')
+        parser.add_argument('--authors', help='VNOI username of author of the problem', nargs='+')
 
     def handle(self, *args, **options):
         # Force using English
@@ -503,10 +505,21 @@ class Command(BaseCommand):
 
         root = ET.fromstring(package.read('problem.xml'))
 
+        problem_authors_args = options['authors']
+        problem_authors = []
+        for username in problem_authors_args:
+            try:
+                profile = Profile.objects.get(user__username=username)
+            except Profile.DoesNotExist:
+                raise CommandError(f'user {username} does not exist')
+            
+            problem_authors.append(profile)
+
         # A dictionary to hold all problem information.
         problem_meta = {}
         problem_meta['code'] = problem_code
         problem_meta['tmp_dir'] = tempfile.TemporaryDirectory()
+        problem_meta['authors'] = problem_authors
 
         try:
             parse_checker(problem_meta, root, package)


### PR DESCRIPTION
# Description

## What

This allows authors as parameters for import_polygon_package.py.

## Why

For convenience. Instead of adding the authors after the package is uploaded, it can be done beforehand.

# How Has This Been Tested?

Tested on my local version of VNOJ.

# Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [ ] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
