### PR TITLE
Avoid submission's feedback from being leaked when user leaves contest

### DIFF
--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -235,6 +235,8 @@ def group_test_cases(cases):
 
 class SubmissionStatus(SubmissionDetailBase):
     template_name = 'submission/status.html'
+    def get_queryset(self):
+        return super().get_queryset().select_related('contest_object')
 
     def get_context_data(self, **kwargs):
         context = super(SubmissionStatus, self).get_context_data(**kwargs)

--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -236,7 +236,7 @@ def group_test_cases(cases):
 class SubmissionStatus(SubmissionDetailBase):
     template_name = 'submission/status.html'
     def get_queryset(self):
-        return super().get_queryset().select_related('contest_object')
+        return super().get_queryset().select_related('contest', 'contest_object', 'contest__problem')
 
     def get_context_data(self, **kwargs):
         context = super(SubmissionStatus, self).get_context_data(**kwargs)

--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -235,6 +235,7 @@ def group_test_cases(cases):
 
 class SubmissionStatus(SubmissionDetailBase):
     template_name = 'submission/status.html'
+
     def get_queryset(self):
         return super().get_queryset().select_related('contest', 'contest_object', 'contest__problem')
 

--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -244,6 +244,10 @@ class SubmissionStatus(SubmissionDetailBase):
             = group_test_cases(submission.test_cases.all())
 
         context['feedback_limit'] = min(3, test_case_count - 1)
+        # In case the submission is in an on-going contest, we don't want to show any feedback.
+        # However, this can be override by setting `submission.problem.allow_view_feedback`.
+        if submission.contest_object and not submission.contest_object.ended:
+            context['feedback_limit'] = 0
 
         # copy from combine_statuses
         if not submission.is_graded and len(statuses) > 0 and statuses[-1].batch is not None:


### PR DESCRIPTION
# Description

Avoid submission's feedback from being leaked when user leaves contest

Type of change: bug fix

## Why

In an on-going contest, users should not be able to view the submission feedback. We already had a logic to handle that, but there is a case that the user leaves the contest, and after that, the feedback is leaked.


Fixes # (issue)

# How Has This Been Tested?


- Create a contest, use account A (a normal user) to join a contest
- Submit to a problem, -> confirmed that he cannot view the feedback
- Leave the contest, -> confirmed that he cannot view the submission's feedback
