### PR TITLE
Escape special characters in user's output in testcase's result

### DIFF
--- a/templates/submission/status-testcases.html
+++ b/templates/submission/status-testcases.html
@@ -138,11 +138,12 @@
                                 <pre class="case-output">{{ curr_data['answer']|linebreaksbr }}</pre>
                             {% endif %}
                             {% if print_case_output %}
+                                {% set escaped_output = case.output.encode("unicode-escape").decode("utf-8") %}
                                 <strong>{{ _('Your output (clipped)') }}</strong>
                                 {% if prefix_length is none or prefix_length == 0 %}
-                                    <pre class="case-output">{{ case.output|linebreaksbr }}</pre>
+                                    <pre class="case-output">{{ escaped_output|linebreaksbr }}</pre>
                                 {% else %}
-                                    <pre class="case-output">{{ case.output[:prefix_length]|linebreaksbr }}</pre>
+                                    <pre class="case-output">{{ escaped_output[:prefix_length]|linebreaksbr }}</pre>
                                 {% endif %}
                             {% endif %}
                             {% if print_case_ext_feedback %}


### PR DESCRIPTION
# Description

## What

This PR escapes special characters in user's output in testcase's result.

## Why

The following image shows that a token differs, although they appear to be the same. However, the user in fact printed a null character at the end of their string, and the null character is not visible.

![image](https://user-images.githubusercontent.com/68510735/197426499-0de97608-e174-43e1-a388-47e0a4f6d859.png)

Escaping the user's output will result in the following image:

![image](https://user-images.githubusercontent.com/68510735/197426623-ce74bc13-d33f-4c47-9baa-b19cc8ad34d0.png)

# How Has This Been Tested?

Tested on my local version of VNOJ.

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [x] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
