### PR TITLE
Fix organization filtering in ranking page

### DIFF
--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -321,24 +321,43 @@
                     multiple: true,
                     closeOnSelect: false,
                     placeholder: '{{ _('Search organizations') }}',
-                }).on('select2:selecting', function(e) {
-                    let selected = e.params.args.data.id;
-                    let val = $(e.target).val().concat([selected]);
+                });
+
+                var selection = $('#org-check-list').data().select2.selection;
+                var results = $('#org-check-list').data().select2.results;
+
+                $('#org-check-list').on('select2:selecting', function(e) {
+                    let id = e.params.args.data.id;
+                    let val = $(e.target).val().concat([id]);
                     $(e.target).val(val).trigger('change');
-                    $(e.params.args.originalEvent.currentTarget).attr('aria-selected', 'true');
-                    $('#org-check-list').data().select2.selection.$search.val('');
+
+                    if (selection.$search.val() != '') {
+                        selection.$search.val('');
+                        selection.trigger('query', {});
+                    } else {
+                        results.setClasses();
+                    }
+
                     return false;
-                }).on('select2:unselecting', function(e) {
-                    let selected = e.params.args.data.id;
-                    let val = $(e.target).val().filter(function(v) { return v != selected; });
+                });
+
+                $('#org-check-list').on('select2:unselecting', function(e) {
+                    let id = e.params.args.data.id;
+                    let val = $(e.target).val().filter(function(v) { return v != id; });
                     $(e.target).val(val).trigger('change');
-                    $(e.params.args.originalEvent.currentTarget).attr('aria-selected', 'false');
-                    $('#org-check-list').data().select2.selection.$search.val('');
+
+                    if (selection.$search.val() != '') {
+                        selection.$search.val('');
+                        selection.trigger('query', {});
+                    } else {
+                        results.setClasses();
+                    }
+
                     return false;
                 });
 
                 $('#org-check-list').data().select2.toggleDropdown = function () {
-                    $('#org-check-list').data().select2.selection.$search.trigger('focus');
+                    selection.$search.trigger('focus');
 
                     if (!this.isOpen()) {
                         this.open();
@@ -389,9 +408,13 @@
                     return;
                 }
 
+                if ($(e.target).attr('id') && $(e.target).attr('id').startsWith('select2-org-check-list-result')) {
+                    return;
+                }
+
                 // check if the clicked area is the checklist or not
                 if ($('#org-dropdown-check-list').has(e.target).length === 0) {
-                    $('#org-check-list-wrapper').hide();
+                    $('#apply-organization-filter').click();
                 }
             });
 

--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -281,6 +281,16 @@
                 $('#show-personal-info-checkbox').prop('checked', true);
             }
 
+            {% if show_virtual %}
+                $('#show-virtual-participations-checkbox').prop('checked', true);
+            {% endif %}
+
+            $('#show-virtual-participations-checkbox').click(function () {
+                const parser = new URL(window.location.href);
+                parser.searchParams.set('show_virtual', '{{ 'false' if show_virtual else 'true' }}');
+                window.location.href = parser.href;
+            });
+
             var contest_key = '{{contest.key}}';
 
             $("a#cache_alert").click(function () {
@@ -308,23 +318,32 @@
             // scrollAfterSelect is only available after v4.0.6
             $(document).ready(function() {
                 $('#org-check-list').select2({
+                    multiple: true,
                     closeOnSelect: false,
-                }).on('select2:selecting select2:unselecting', function(e) {
-                    let cur = e.params.args.data.id;
-                    let old = (e.target.value == '') ? [cur] : $(e.target).val().concat([cur]);
-                    $(e.target).val(old).trigger('change');
-
-                    if (e.params.args.originalEvent) {
-                        let target = $(e.params.args.originalEvent.currentTarget);
-                        if (target.attr('aria-selected') == 'true') {
-                            target.attr('aria-selected', 'false');
-                        } else {
-                            target.attr('aria-selected', 'true');
-                        }
-                    }
-
+                    placeholder: '{{ _('Search organizations') }}',
+                }).on('select2:selecting', function(e) {
+                    let selected = e.params.args.data.id;
+                    let val = $(e.target).val().concat([selected]);
+                    $(e.target).val(val).trigger('change');
+                    $(e.params.args.originalEvent.currentTarget).attr('aria-selected', 'true');
+                    $('#org-check-list').data().select2.selection.$search.val('');
+                    return false;
+                }).on('select2:unselecting', function(e) {
+                    let selected = e.params.args.data.id;
+                    let val = $(e.target).val().filter(function(v) { return v != selected; });
+                    $(e.target).val(val).trigger('change');
+                    $(e.params.args.originalEvent.currentTarget).attr('aria-selected', 'false');
+                    $('#org-check-list').data().select2.selection.$search.val('');
                     return false;
                 });
+
+                $('#org-check-list').data().select2.toggleDropdown = function () {
+                    $('#org-check-list').data().select2.selection.$search.trigger('focus');
+
+                    if (!this.isOpen()) {
+                        this.open();
+                    }
+                }
             });
 
             if (localStorage.getItem(`filter-cleared-${contest_key}`) === null) {
@@ -337,26 +356,23 @@
 
             $(document).ready(function() {
                 $('#filter-by-organization-button').click(function () {
-                    $('#org-check-list-wrapper').toggle();
+                    $('#org-check-list-wrapper').show();
                     $('#org-check-list').select2('open');
                 });
             });
 
             $('#apply-organization-filter').click(function () {
-                let selected_orgs = [];
-                $('#org-check-list').find(':selected').each(function () {
-                    selected_orgs.push($(this).text());
-                });
+                $('#org-check-list-wrapper').hide();
 
+                let selected_orgs = $('#org-check-list').val();
                 localStorage.setItem(`filter-selected-orgs-${contest_key}`, selected_orgs);
                 window.applyRankingFilter();
                 window.totalAC();
-
-                $('#org-check-list-wrapper').toggle();
             });
 
             $('#clear-organization-filter').click(function () {
                 $('#org-check-list').val(null).trigger('change');
+                $('#apply-organization-filter').click();
             });
 
             // hide checklist by clicking outside
@@ -475,17 +491,17 @@
 
             window.restoreChecklistOptions();
 
-            function convertToSeconds(timeString) {
-                const time = timeString.split(':').map(Number); // time = [hour, minute, second]
-                return time[0] * 60 * 60 + time[1] * 60 + time[2];
-            }
-
-            function timeComparison(sub1, sub2) {
-                if (!sub2) return;
-                return sub1['time'] < sub2['time'];
-            }
-
             window.firstSolve = function() {
+                function convertToSeconds(timeString) {
+                    const time = timeString.split(':').map(Number); // time = [hour, minute, second]
+                    return time[0] * 60 * 60 + time[1] * 60 + time[2];
+                }
+
+                function timeComparison(sub1, sub2) {
+                    if (!sub2) return;
+                    return sub1['time'] < sub2['time'];
+                }
+
                 let firstSolves = {};
 
                 $('td.full-score a').each(function () {
@@ -549,18 +565,6 @@
             };
 
             window.totalAC();
-
-            {% if tab == 'ranking' %}
-                {% if show_virtual %}
-                    $('#show-virtual-participations-checkbox').prop('checked', true);
-                {% endif %}
-
-                $('#show-virtual-participations-checkbox').click(function () {
-                    const parser = new URL(window.location.href);
-                    parser.searchParams.set('show_virtual', '{{ 'false' if show_virtual else 'true' }}');
-                    window.location.href = parser.href;
-                });
-            {% endif %}
         });
 
         {% if tab == 'ranking' %}

--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -100,6 +100,10 @@
             white-space: nowrap;
         }
 
+        .select2-container {
+            z-index: 1;
+        }
+
         #search-contest, #search-contest + .select2 {
             margin-top: 0.5em;
         }
@@ -108,9 +112,7 @@
             width: 200px;
             height: 2.3em;
         }
-    </style>
 
-    <style>
         #org-dropdown-check-list {
             display: inline-block;
         }
@@ -176,22 +178,6 @@
 {% endblock %}
 
 {% block users_js_media %}
-    {% if can_edit %}
-        <script type="text/javascript">
-            $(function () {
-                $('a.disqualify-participation').click(function (e) {
-                    e.preventDefault();
-                    if (e.ctrlKey || e.metaKey || confirm("{{ _('Are you sure you want to disqualify this participation?') }}"))
-                        $(this).closest('form').submit();
-                })
-                $('a.un-disqualify-participation').click(function (e) {
-                    e.preventDefault();
-                    if (e.ctrlKey || e.metaKey || confirm("{{ _('Are you sure you want to un-disqualify this participation?') }}"))
-                        $(this).closest('form').submit();
-                })
-            });
-        </script>
-    {% endif %}
     {% if not contest.ended %}
         <script type="text/javascript">
             $(function () {
@@ -228,6 +214,7 @@
                         {% endif %}
                         window.firstSolve();
                         window.totalAC();
+                        window.enableAdminOperations();
                     }).always(function () {
                         ranking_outdated = false;
                         setTimeout(update_ranking, 10000);
@@ -316,7 +303,7 @@
             // hack to keep scroll position after selecting option
             // https://stackoverflow.com/questions/55045146/select2-do-not-scroll-on-selection
             // scrollAfterSelect is only available after v4.0.6
-            $(document).ready(function() {
+            $(function() {
                 $('#org-check-list').select2({
                     multiple: true,
                     closeOnSelect: false,
@@ -363,6 +350,11 @@
                         this.open();
                     }
                 }
+
+                $('#filter-by-organization-button').click(function () {
+                    $('#org-check-list-wrapper').toggle();
+                    $('#org-check-list').select2('open');
+                });
             });
 
             if (localStorage.getItem(`filter-cleared-${contest_key}`) === null) {
@@ -372,13 +364,6 @@
             if (localStorage.getItem(`filter-selected-orgs-${contest_key}`) === null) {
                 localStorage.setItem(`filter-selected-orgs-${contest_key}`, []);
             }
-
-            $(document).ready(function() {
-                $('#filter-by-organization-button').click(function () {
-                    $('#org-check-list-wrapper').show();
-                    $('#org-check-list').select2('open');
-                });
-            });
 
             $('#apply-organization-filter').click(function () {
                 $('#org-check-list-wrapper').hide();
@@ -588,6 +573,21 @@
             };
 
             window.totalAC();
+
+            window.enableAdminOperations = function () {
+                $('a.disqualify-participation').click(function (e) {
+                    e.preventDefault();
+                    if (e.ctrlKey || e.metaKey || confirm("{{ _('Are you sure you want to disqualify this participation?') }}"))
+                        $(this).closest('form').submit();
+                })
+                $('a.un-disqualify-participation').click(function (e) {
+                    e.preventDefault();
+                    if (e.ctrlKey || e.metaKey || confirm("{{ _('Are you sure you want to un-disqualify this participation?') }}"))
+                        $(this).closest('form').submit();
+                })
+            };
+
+            window.enableAdminOperations();
         });
 
         {% if tab == 'ranking' %}

--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -118,11 +118,10 @@
         #org-check-list-wrapper {
             display: none;
             background: #ffffff;
-            width: 300px;
             border: 1px solid gray;
+            padding: 10px;
 
             right: auto;
-            transform: translateX(-50%);
             position: absolute;
             z-index: 1;
         }
@@ -136,13 +135,12 @@
         }
 
         #org-check-list-wrapper button {
-            margin: 5px;
+            margin-bottom: 5px;
+            margin-left: 5px;
         }
 
         #org-check-list {
             border-bottom: 1px solid gray;
-            padding-inline-start: 0px;
-            margin-block: 0px;
 
             /* reset properties of the parent elements */
             color: black;
@@ -152,12 +150,6 @@
 
         .filter-checklist-button {
             float: right;
-        }
-
-        .header.username > * {
-            margin-left: 10px;
-            margin-right: 10px;
-            vertical-align: middle;
         }
 
         .select2-selection__rendered {
@@ -170,12 +162,15 @@
             color: black;
         }
 
-        .select2-selection {
-            margin-top: 10px !important;
-        }
-
         #select2-org-check-list-results > li {
             color: black;
+        }
+        #select2-org-check-list-results > li:hover {
+            background: #aaaaaa !important;
+        }
+
+        .select2-results__option[aria-selected=true] {
+            background: #cdcdcd !important;
         }
     </style>
 {% endblock %}
@@ -229,7 +224,6 @@
                             $('#show-personal-info-checkbox').prop('checked', true);
                         }
                         {% if tab == 'ranking' %}
-                            window.getOrganizationCodes();
                             window.applyRankingFilter();
                         {% endif %}
                         window.firstSolve();
@@ -311,34 +305,27 @@
 
             // hack to keep scroll position after selecting option
             // https://stackoverflow.com/questions/55045146/select2-do-not-scroll-on-selection
+            // scrollAfterSelect is only available after v4.0.6
             $(document).ready(function() {
                 $('#org-check-list').select2({
                     closeOnSelect: false,
-                }).on('select2:selecting', function(e) {
+                }).on('select2:selecting select2:unselecting', function(e) {
                     let cur = e.params.args.data.id;
                     let old = (e.target.value == '') ? [cur] : $(e.target).val().concat([cur]);
                     $(e.target).val(old).trigger('change');
-                    $(e.params.args.originalEvent?.currentTarget).attr('aria-selected', 'true');
+
+                    if (e.params.args.originalEvent) {
+                        let target = $(e.params.args.originalEvent.currentTarget);
+                        if (target.attr('aria-selected') == 'true') {
+                            target.attr('aria-selected', 'false');
+                        } else {
+                            target.attr('aria-selected', 'true');
+                        }
+                    }
+
                     return false;
                 });
             });
-
-            {% if tab == 'ranking' %}
-                $('.header.username').append(
-                    `<div id="org-dropdown-check-list">
-                        <button id="filter-by-organization-button" class="inline-button">
-                            <i class="tab-icon fa fa-filter"></i>
-                            <b>{{ _('Filter') }}</b>
-                        </button>
-
-                        <div id="org-check-list-wrapper">
-                            <select id="org-check-list" name="orgs[]" multiple="multiple"></select>
-                            <button id="apply-organization-filter" class="inline-button filter-checklist-button">{{ _('Apply') }}</button>
-                            <button id="clear-organization-filter" class="inline-button filter-checklist-button">{{ _('Clear') }}</button>
-                        </div>
-                    </div>`
-                );
-            {% endif %}
 
             if (localStorage.getItem(`filter-cleared-${contest_key}`) === null) {
                 localStorage.setItem(`filter-cleared-${contest_key}`, 'true');
@@ -348,8 +335,11 @@
                 localStorage.setItem(`filter-selected-orgs-${contest_key}`, []);
             }
 
-            $('#filter-by-organization-button').click(function () {
-                $('#org-check-list-wrapper').toggle();
+            $(document).ready(function() {
+                $('#filter-by-organization-button').click(function () {
+                    $('#org-check-list-wrapper').toggle();
+                    $('#org-check-list').select2('open');
+                });
             });
 
             $('#apply-organization-filter').click(function () {
@@ -664,6 +654,22 @@
             {% if contest.can_see_full_scoreboard(request.user) %}
                 <input id="search-contest" type="text" placeholder="{{ _('View user participation') }}">
             {% endif %}
+        {% endif %}
+        {% if tab == 'ranking' %}
+            <div id="org-dropdown-check-list">
+                <button id="filter-by-organization-button" class="inline-button">
+                    <i class="tab-icon fa fa-filter"></i>
+                    <b>{{ _('Filter') }}</b>
+                </button>
+
+                <div id="org-check-list-wrapper">
+                    <div>
+                        <button id="apply-organization-filter" class="inline-button filter-checklist-button">{{ _('Apply') }}</button>
+                        <button id="clear-organization-filter" class="inline-button filter-checklist-button">{{ _('Clear') }}</button>
+                    </div>
+                    <select id="org-check-list" name="orgs[]" multiple="multiple"></select>
+                </div>
+            </div>
         {% endif %}
         {% if tab != 'official_ranking' %}
             <input id="show-personal-info-checkbox" type="checkbox" style="vertical-align: bottom">


### PR DESCRIPTION
# Description

Type of change: bug fix, refactor

## What

This PR aims to change unwanted behaviors and reposition elements.
- The filter button is now moved outside the ranking table
- The filter button can only be clicked after the document is ready
- The dropdown list is expanded when the filter button is clicked
- Stop the dropdown list from scrolling back to the top when unselecting

## Why

- Users have reported the filter button missing after the ranking table is updated
- Opening the filter list before select2 is fully loaded breaks the styling
- Others are for better experiences

# How Has This Been Tested?

Tested locally (including the contest mode).

# Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [ ] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
