### PR TITLE
Fix username not being inline

### DIFF
--- a/resources/ranks.scss
+++ b/resources/ranks.scss
@@ -94,10 +94,6 @@ svg.rate-box {
 
 .rating {
     font-weight: bold;
-
-    a {
-        display: inline-block;
-    }
 }
 
 .rate-none, .rate-none a {

--- a/templates/user/link.html
+++ b/templates/user/link.html
@@ -1,5 +1,5 @@
 <span class="{{ profile.css_class }}">
-    <a href="{{ url('user_page', user.username) }}" style="display: flex; align-items: center;">{{ profile.display_name }}
+    <a href="{{ url('user_page', user.username) }}" style="display: inline-flex; align-items: center;">{{ profile.display_name }}
     {% if profile.display_badge %}
         <img src="{{ profile.display_badge.mini }}" title="{{ profile.display_badge.name }}" style="height: 1em; width: auto; margin-left: 0.25em;" />
     {% endif %}


### PR DESCRIPTION
# Description
Type of change: bug fix

## What

Make the username inline again

## Why

[This commit](https://github.com/VNOI-Admin/OJ/commit/579113a43c5e86ec4312be5ee1d67e260b2b4643) broke the inline

![image](https://user-images.githubusercontent.com/68510735/206887710-48820271-82e8-46d2-807b-19da6ef35656.png)

### Fixes

Replace `flex` with `inline-flex`.

This can actually be fixed in `resources/ranks.scss` ([here](https://github.com/VNOI-Admin/OJ/blob/master/resources/ranks.scss#L99)), but that would require the scss file to be recompiled and I guess I'm just lazy.

# How Has This Been Tested?

On local version of VNOJ

# Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [x] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
