### PR TITLE
Alert when user upload a test file that's not a zip file

### DIFF
--- a/templates/problem/data.html
+++ b/templates/problem/data.html
@@ -522,6 +522,8 @@
                     }).catch(function(err) {
                         console.log(err);
                         console.error("Failed to open as ZIP file");
+                        alert('Test file must be a zip file');
+                        event.target.value = "";
                     })
                 };
                 reader.readAsArrayBuffer(fileInput);

--- a/templates/problem/data.html
+++ b/templates/problem/data.html
@@ -522,7 +522,7 @@
                     }).catch(function(err) {
                         console.log(err);
                         console.error("Failed to open as ZIP file");
-                        alert(`{{_("Test file must be a zip file")}}`);
+                        alert("{{ _('Test file must be a ZIP file') }}");
                         event.target.value = "";
                     })
                 };

--- a/templates/problem/data.html
+++ b/templates/problem/data.html
@@ -522,7 +522,7 @@
                     }).catch(function(err) {
                         console.log(err);
                         console.error("Failed to open as ZIP file");
-                        alert('Test file must be a zip file');
+                        alert(`{{_("Test file must be a zip file")}}`);
                         event.target.value = "";
                     })
                 };


### PR DESCRIPTION
# Description
The error happens when user uploads a .rar test file
Type of change: bug fix

## What

What does the PR do?
It alert the user that the test file must be a .zip file, and clear the input

# How Has This Been Tested?
Locally on my VNOJ version

# Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [ ] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
