### PR TITLE
Additional changes to the Export contest submissions details script

### DIFF
--- a/judge/management/commands/export_contest_submissions_details.py
+++ b/judge/management/commands/export_contest_submissions_details.py
@@ -1,11 +1,27 @@
 import csv
+import re
 
 from django.core.management.base import BaseCommand, CommandError
 
-from judge.models import Contest, Submission, SubmissionTestCase
+from judge.models import Contest, ContestSubmission, SubmissionTestCase
 from judge.utils.raw_sql import use_straight_join
-from judge.views.submission import submission_related
 
+# https://stackoverflow.com/a/14693789/16224359
+# Error messages may sometimes be formatted with
+# ANSI sequences representing text colors and text weight,
+# which may display dirty text in raw text files.
+# The following regex is to filter such sequences.
+ansi_escape = re.compile(r'''
+    \x1B  # ESC
+    (?:   # 7-bit C1 Fe (except CSI)
+        [@-Z\\-_]
+    |     # or [ for CSI, followed by a control sequence
+        \[
+        [0-?]*  # Parameter bytes
+        [ -/]*  # Intermediate bytes
+        [@-~]   # Final byte
+    )
+''', re.VERBOSE)
 
 class Command(BaseCommand):
     help = 'export contest submissions details'
@@ -21,10 +37,11 @@ class Command(BaseCommand):
         if contest is None:
             raise CommandError('contest not found')
 
-        queryset = Submission.objects.all()
+        queryset = ContestSubmission.objects.all()
         use_straight_join(queryset)
-        queryset = submission_related(queryset.order_by('-id'))
-        queryset = queryset.filter(contest_object=contest)
+        queryset = queryset.filter(submission__contest_object=contest,
+                                   participation__virtual=0) \
+                           .order_by('-id')
 
         self.export_queryset_to_output(queryset, options['output'])
 
@@ -32,10 +49,26 @@ class Command(BaseCommand):
         fout = open(output_file, 'w', newline='')
 
         writer = csv.DictWriter(fout, fieldnames=['username', 'problem', 'submission', 'testcase',
-                                                  'points', 'time', 'memory', 'feedback'])
+                                                  'result', 'points', 'time', 'memory', 'feedback'])
         writer.writeheader()
 
-        for submission in queryset:
+        for contest_submission in queryset:
+            submission = contest_submission.submission
+
+            # Submission row
+            escaped_error = ansi_escape.sub('', submission.error)
+
+            writer.writerow({
+                'username': submission.user.username,
+                'problem': submission.problem.code,
+                'submission': submission.id,
+                'result': submission.result,
+                'points': submission.case_points,
+                'time': submission.time,
+                'memory': submission.memory,
+                'feedback': escaped_error,
+            })
+
             testcases = SubmissionTestCase.objects.filter(submission=submission)
 
             for testcase in testcases:
@@ -43,11 +76,13 @@ class Command(BaseCommand):
                 if submission.batch:
                     case_id += f'/batch{testcase.batch}'
 
+                # Testcase rows
                 writer.writerow({
                     'username': submission.user.username,
                     'problem': submission.problem.code,
                     'submission': submission.id,
                     'testcase': case_id,
+                    'result': testcase.status,
                     'points': testcase.points,
                     'time': testcase.time,
                     'memory': testcase.memory,

--- a/judge/management/commands/export_contest_submissions_details.py
+++ b/judge/management/commands/export_contest_submissions_details.py
@@ -11,7 +11,7 @@ from judge.utils.raw_sql import use_straight_join
 # ANSI sequences representing text colors and text weight,
 # which may display dirty text in raw text files.
 # The following regex is to filter such sequences.
-ansi_escape = re.compile(r'''
+ansi_escape = re.compile(r"""
     \x1B  # ESC
     (?:   # 7-bit C1 Fe (except CSI)
         [@-Z\\-_]
@@ -21,7 +21,8 @@ ansi_escape = re.compile(r'''
         [ -/]*  # Intermediate bytes
         [@-~]   # Final byte
     )
-''', re.VERBOSE)
+""", re.VERBOSE)
+
 
 class Command(BaseCommand):
     help = 'export contest submissions details'


### PR DESCRIPTION
# Description
## What
- Create an additional row above the test case rows for each submission
- Display error messages
- Add a status column to submissions and test cases
- Only export submissions of live participations

![image](https://user-images.githubusercontent.com/68510735/217752759-8dfeb169-62f4-476b-91a5-f2abe8af745f.png)

![image](https://user-images.githubusercontent.com/68510735/217752861-7cc2bffd-6551-4250-99a4-bb48fcd63a07.png)

## Why

- Creating a row for submission information allows the display of submissions with no test case run (CE, IE, etc) and error messages
- Submissions other than those from live participations should not be considered when exported for an official contest

# How Has This Been Tested?

Tested on my local version of VNOI. Ran on contests `hello22` and `contest_testing01`.

# Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [x] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
