### PR TITLE
Allow superuser to delete all user's comments

### DIFF
--- a/judge/views/user.py
+++ b/judge/views/user.py
@@ -294,7 +294,8 @@ class UserCommentPage(CustomUserMixin, DiggPaginatorMixin, ListView):
 
         user_id = User.objects.get(username=kwargs['user']).id
         user = Profile.objects.get(user=user_id)
-        for comment in Comment.get_newest_visible_comments(viewer=request.user, author=user, batch=2 * self.paginate_by):
+        for comment in Comment.get_newest_visible_comments(viewer=request.user, author=user, 
+                                                           batch=2 * self.paginate_by):
             comment.get_descendants(include_self=True).update(hidden=True)
         return HttpResponseRedirect(reverse('user_comment', args=(user.user.username,)))
 

--- a/judge/views/user.py
+++ b/judge/views/user.py
@@ -294,7 +294,7 @@ class UserCommentPage(CustomUserMixin, DiggPaginatorMixin, ListView):
 
         user_id = User.objects.get(username=kwargs['user']).id
         user = Profile.objects.get(user=user_id)
-        for comment in Comment.get_newest_visible_comments(viewer=request.user, author=user, 
+        for comment in Comment.get_newest_visible_comments(viewer=request.user, author=user,
                                                            batch=2 * self.paginate_by):
             comment.get_descendants(include_self=True).update(hidden=True)
         return HttpResponseRedirect(reverse('user_comment', args=(user.user.username,)))

--- a/judge/views/user.py
+++ b/judge/views/user.py
@@ -23,11 +23,11 @@ from django.http import Http404, HttpResponse, HttpResponseRedirect, JsonRespons
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.decorators import method_decorator
 from django.utils.formats import date_format
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _, gettext_lazy
-from django.utils.decorators import method_decorator
 from django.views.decorators.http import require_POST
 from django.views.generic import DetailView, FormView, ListView, TemplateView, View
 from reversion import revisions
@@ -286,7 +286,7 @@ class UserCommentPage(CustomUserMixin, DiggPaginatorMixin, ListView):
                 % settings.VNOJ_INTERACT_MIN_PROBLEM_COUNT
 
         return context
-    
+
     @method_decorator(require_POST)
     def delete_comments(self, request, *args, **kwargs):
         if not request.user.is_superuser:

--- a/templates/user/comment.html
+++ b/templates/user/comment.html
@@ -13,6 +13,10 @@
 
 {% block body %}
     {% block before_comments %}{% endblock %}
+        <form action="{{url('user_comment', user.username)}}" method="post">
+            {% csrf_token %}
+            <button type="submit">Delete all comments</button>
+        </form>
         <ul class="comments top-level-comments new-comments">
             {% set logged_in = request.user.is_authenticated %}
             {% for comment in comments %}


### PR DESCRIPTION
# Description
Type of change: new feature

## What
It allows superuser to delete all of user's comments in the view all comments page

## Why
To quickly delete spam or inappropriate comments

# How Has This Been Tested?
Tested on my local VNOJ

# Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [ ] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
