### PR TITLE
Add cooldown time between blogs/comments creation 

### DIFF
--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -101,6 +101,9 @@ VNOJ_TAG_PROBLEM_MIN_RATING = 1900  # Minimum rating to be able to tag a problem
 # Cooldown time (minutes) between each comment
 VNOJ_COMMENT_COOLDOWN = 10
 
+# Cooldown time (minutes) between each blog post
+VNOJ_BLOG_COOLDOWN = 3 * 60
+
 # Some problems have a lot of testcases, and each testcase
 # has about 5~6 fields, so we need to raise this
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 3000

--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -98,6 +98,9 @@ VNOJ_TESTCASE_VISIBLE_LENGTH = 60
 
 VNOJ_TAG_PROBLEM_MIN_RATING = 1900  # Minimum rating to be able to tag a problem
 
+# Cooldown time (minutes) between each comment
+VNOJ_COMMENT_COOLDOWN = 10
+
 # Some problems have a lot of testcases, and each testcase
 # has about 5~6 fields, so we need to raise this
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 3000

--- a/judge/comments.py
+++ b/judge/comments.py
@@ -79,10 +79,10 @@ class CommentedDetailView(TemplateResponseMixin, SingleObjectMixin, View):
                                                                        author=request.user.profile,
                                                                        n=1)
 
-            if not request.user.is_superuser and len(user_latest_comments) > 0:
+            if len(user_latest_comments) > 0:
                 time_diff = (datetime.now(timezone.utc) - user_latest_comments[0].time).seconds
                 if time_diff < settings.VNOJ_COMMENT_COOLDOWN * 60:
-                    return HttpResponseBadRequest(_('You can only comment after {0} minutes'
+                    return HttpResponseBadRequest(_('You can only comment after {0} minutes '
                                                     'since your latest comment')
                                                   .format(settings.VNOJ_COMMENT_COOLDOWN), content_type='text/plain')
 


### PR DESCRIPTION
# Description
Type of change: new feature

## What

Adds cooldown time between the creation of two blogs or two comments.

## Why

To avoid spam.

# How Has This Been Tested?

Tested manually on local version of VNOJ.

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [ ] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
