### PR TITLE
Allow joining ongoing contest directly without registering first

### DIFF
--- a/judge/models/contest.py
+++ b/judge/models/contest.py
@@ -215,9 +215,11 @@ class Contest(models.Model):
         if self.start_time and self.end_time and self.start_time >= self.end_time:
             raise ValidationError('What is this? A contest that ended before it starts?')
 
-        if self.registration_start and self.registration_end and \
-                self.registration_start >= self.registration_end:
+        if self.registration_start and self.registration_end and self.registration_start >= self.registration_end:
             raise ValidationError('Registration window must start before it ends.')
+
+        if self.registration_start and self.start_time and self.registration_start >= self.start_time:
+            raise ValidationError('Registration window must start before the contest starts.')
 
         if self.registration_end and self.end_time and self.registration_end >= self.end_time:
             raise ValidationError('Registration window must end before the contest ends.')

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -551,7 +551,7 @@ class ContestJoin(LoginRequiredMixin, ContestMixin, SingleObjectMixin, View):
                                      'You are permanently barred from joining this contest.'))
 
         # Conditions for joining a contest:
-        #   - If contest has ended, allow virtual joining iif:
+        #   - If contest has ended, allow virtual joining iff:
         #       - contest.disallow_virtual is False
         #       - requires_access_code is False
         #   - If contest is ongoing, allow joining iff:

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -501,7 +501,6 @@ class ContestRegister(LoginRequiredMixin, ContestMixin, SingleObjectMixin, View)
                 return generic_message(request, _('Already registered'),
                                        _('You have already registered for this contest.'))
 
-        profile.save()
         contest._updating_stats_only = True
         contest.update_user_count()
         return HttpResponseRedirect(reverse('contest_view', args=(contest.key,)))
@@ -557,7 +556,7 @@ class ContestJoin(LoginRequiredMixin, ContestMixin, SingleObjectMixin, View):
         #       - requires_access_code is False
         #   - If contest is ongoing, allow joining iff:
         #       - Not editor or tester
-        #       - Registered if registration is required
+        #       - Registered if registration windows has ended
         #       - requires_access_code is False
         #   - Editors/Testers can only spectate live contests and only when requires_access_code is False.
 
@@ -592,7 +591,7 @@ class ContestJoin(LoginRequiredMixin, ContestMixin, SingleObjectMixin, View):
                     contest=contest, user=profile, virtual=(SPECTATE if can_only_spectate else LIVE),
                 )
             except ContestParticipation.DoesNotExist:
-                if contest.require_registration and not can_only_spectate:
+                if contest.require_registration and not contest.can_register and not can_only_spectate:
                     return generic_message(request, _('Not registered'),
                                            _('You are not registered for this contest.'))
 

--- a/templates/contest/contest-tabs.html
+++ b/templates/contest/contest-tabs.html
@@ -89,7 +89,7 @@
                 {% endif %}
             {% endif %}
         {% endif %}
-    {% elif contest.can_join %}
+    {% elif (contest.can_join and not contest.require_registration) or contest.can_register %}
         <form action="{{ url('auth_login') }}" method="get"
               class="contest-join-pseudotab unselectable button">
             <input type="hidden" name="next" value="{{ LOGIN_RETURN_PATH|urlencode }}">

--- a/templates/contest/contest-tabs.html
+++ b/templates/contest/contest-tabs.html
@@ -69,26 +69,22 @@
                         <input type="submit" value="{{ _('Spectate contest') }}" class="contest-join">
                     </form>
                 {% else %}
-                    {% if contest.require_registration and not has_joined %}
-                        {% if contest.can_register %}
-                            <form action="{{ url('contest_register', contest.key) }}" method="post"
-                                class="contest-join-pseudotab unselectable button" style="background: linear-gradient(to bottom, #87ab69 0, #4b6043 100%) repeat-x">
-                                {% csrf_token %}
-                                <input type="submit"
-                                    class="register-warning"
-                                    value="{{ _('Register') }}">
-                            </form>
-                        {% endif %}
-                    {% else %}
-                        {% if contest.can_join %}
-                            <form action="{{ url('contest_join', contest.key) }}" method="post"
-                                class="contest-join-pseudotab unselectable button">
-                                {% csrf_token %}
-                                <input type="submit"
-                                    class="contest-join{% if not has_joined %} first-join{% endif %}"
-                                    value="{{ _('Join contest') }}">
-                            </form>
-                        {% endif %}
+                    {% if contest.can_join and (has_joined or not contest.require_registration or contest.can_register) %}
+                        <form action="{{ url('contest_join', contest.key) }}" method="post"
+                            class="contest-join-pseudotab unselectable button">
+                            {% csrf_token %}
+                            <input type="submit"
+                                class="contest-join{% if not has_joined %} first-join{% endif %}"
+                                value="{{ _('Join contest') }}">
+                        </form>
+                    {% elif contest.can_register and not has_joined %}
+                        <form action="{{ url('contest_register', contest.key) }}" method="post"
+                            class="contest-join-pseudotab unselectable button" style="background: linear-gradient(to bottom, #87ab69 0, #4b6043 100%) repeat-x">
+                            {% csrf_token %}
+                            <input type="submit"
+                                class="register-warning"
+                                value="{{ _('Register') }}">
+                        </form>
                     {% endif %}
                 {% endif %}
             {% endif %}

--- a/templates/contest/list.html
+++ b/templates/contest/list.html
@@ -292,6 +292,8 @@
                         </td>
                         {% if contest.require_registration %}
                             {{ contest_register(contest, request) }}
+                        {% else %}
+                            <td></td>
                         {% endif %}
                     </tr>
                 {% endfor %}

--- a/templates/contest/list.html
+++ b/templates/contest/list.html
@@ -254,10 +254,10 @@
                         <td>
                             {{ user_count(contest, request.user) }}
                         </td>
-                        {% if contest.require_registration %}
-                            {{ contest_register(contest, request) }}
-                        {% else %}
+                        {% if not contest.require_registration or contest.can_register %}
                             {{ contest_join(contest, request, finished_contests) }}
+                        {% else %}
+                            {{ contest_register(contest, request) }}
                         {% endif %}
                     </tr>
                 {% endfor %}


### PR DESCRIPTION
# Description

Type of change: improvement

## What

For an ongoing contest that requires registration, users can click on `Join` to do both registration and joining in one step.

## Why

Currently, if an ongoing contest requires registration, users must do two things (assuming we're on the contest list):

- Click on `Register` and get redirected to the contest page
- Click on `Join` in the top left corner. Only after this can the contestant access the problems.

The second step can be confusing for many users since they are used to having to click only once from the contest list.

# How Has This Been Tested?

Tested in production =))

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
