### PR TITLE
Calculate first solves/total AC in backend

### DIFF
--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -486,6 +486,9 @@ TEMPLATES = [
                 'judge.jinja2.DMOJExtension',
                 'judge.jinja2.spaceless.SpacelessExtension',
             ],
+            'bytecode_cache': {
+                'enabled': True,
+            },
         },
     },
     {

--- a/judge/contest_format/atcoder.py
+++ b/judge/contest_format/atcoder.py
@@ -95,7 +95,7 @@ class AtCoderContestFormat(DefaultContestFormat):
         participation.format_data = format_data
         participation.save()
 
-    def display_user_problem(self, participation, contest_problem, frozen=False):
+    def display_user_problem(self, participation, contest_problem, first_solves, frozen=False):
         format_data = (participation.format_data or {}).get(str(contest_problem.id))
         if format_data:
             penalty = format_html('<small style="color:red"> ({penalty})</small>',
@@ -103,6 +103,7 @@ class AtCoderContestFormat(DefaultContestFormat):
             return format_html(
                 '<td class="{state}"><a href="{url}">{points}{penalty}<div class="solving-time">{time}</div></a></td>',
                 state=(('pretest-' if self.contest.run_pretests_only and contest_problem.is_pretested else '') +
+                       ('first-solve ' if first_solves.get(str(contest_problem.id), None) == participation.id else '') +
                        self.best_solution_state(format_data['points'], contest_problem.points)),
                 url=reverse('contest_user_submissions',
                             args=[self.contest.key, participation.user.user.username, contest_problem.problem.code]),

--- a/judge/contest_format/base.py
+++ b/judge/contest_format/base.py
@@ -48,6 +48,18 @@ class BaseContestFormat(metaclass=ABCMeta):
         raise NotImplementedError()
 
     @abstractmethod
+    def get_total_ac(self, problems, participations, frozen=False):
+        """
+        Returns a dictionary mapping ContestProblem to the total number of accepted submissions.
+
+        :param problems: A list of ContestProblem objects.
+        :param participations: A list of ContestParticipation objects.
+        :param frozen: Whether the ranking is frozen or not. Only useful for ICPC/VNOJ format.
+        :return: A dictionary mapping ContestProblem's ID to total number of accepted submissions.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     def get_first_solves(self, problems, participations, frozen=False):
         """
         Returns a dictionary mapping ContestProblem to the first ContestParticipation that solves it.

--- a/judge/contest_format/base.py
+++ b/judge/contest_format/base.py
@@ -69,7 +69,7 @@ class BaseContestFormat(metaclass=ABCMeta):
 
         :param participation: The ContestParticipation object linking the user to the contest.
         :param contest_problem: The ContestProblem object representing the problem in question.
-        :param first_solves: The dictionary returned by get_first_solves.
+        :param first_solves: The first dictionary returned by get_first_solves_and_total_ac.
         :param frozen: Whether the ranking is frozen or not. Only useful for ICPC/VNOJ format.
         :return: An HTML fragment, marked as safe for Jinja2.
         """

--- a/judge/contest_format/base.py
+++ b/judge/contest_format/base.py
@@ -48,14 +48,27 @@ class BaseContestFormat(metaclass=ABCMeta):
         raise NotImplementedError()
 
     @abstractmethod
-    def display_user_problem(self, participation, contest_problem, frozen=False):
+    def get_first_solves(self, problems, participations, frozen=False):
+        """
+        Returns a dictionary mapping ContestProblem to the first ContestParticipation that solves it.
+
+        :param problems: A list of ContestProblem objects.
+        :param participations: A list of ContestParticipation objects.
+        :param frozen: Whether the ranking is frozen or not. Only useful for ICPC/VNOJ format.
+        :return: A dictionary mapping ContestProblem's ID to ContestParticipation's ID, or None if no solves yet.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def display_user_problem(self, participation, contest_problem, first_solves, frozen=False):
         """
         Returns the HTML fragment to show a user's performance on an individual problem. This is expected to use
         information from the format_data field instead of computing it from scratch.
 
         :param participation: The ContestParticipation object linking the user to the contest.
         :param contest_problem: The ContestProblem object representing the problem in question.
-        :param frozen: Whether the ranking is frozen or not. Only useful for ICPC format.
+        :param first_solves: The dictionary returned by get_first_solves.
+        :param frozen: Whether the ranking is frozen or not. Only useful for ICPC/VNOJ format.
         :return: An HTML fragment, marked as safe for Jinja2.
         """
         raise NotImplementedError()
@@ -67,7 +80,7 @@ class BaseContestFormat(metaclass=ABCMeta):
         information from the format_data field instead of computing it from scratch.
 
         :param participation: The ContestParticipation object.
-        :param frozen: Whether the ranking is frozen or not. Only useful for ICPC format.
+        :param frozen: Whether the ranking is frozen or not. Only useful for ICPC/VNOJ format.
         :return: An HTML fragment, marked as safe for Jinja2.
         """
         raise NotImplementedError()

--- a/judge/contest_format/base.py
+++ b/judge/contest_format/base.py
@@ -48,26 +48,16 @@ class BaseContestFormat(metaclass=ABCMeta):
         raise NotImplementedError()
 
     @abstractmethod
-    def get_total_ac(self, problems, participations, frozen=False):
+    def get_first_solves_and_total_ac(self, problems, participations, frozen=False):
         """
-        Returns a dictionary mapping ContestProblem to the total number of accepted submissions.
+        Returns two dictionaries mapping ContestProblem to the first ContestParticipation that solves it
+        and the total number of accepted submissions.
 
         :param problems: A list of ContestProblem objects.
         :param participations: A list of ContestParticipation objects.
         :param frozen: Whether the ranking is frozen or not. Only useful for ICPC/VNOJ format.
-        :return: A dictionary mapping ContestProblem's ID to total number of accepted submissions.
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
-    def get_first_solves(self, problems, participations, frozen=False):
-        """
-        Returns a dictionary mapping ContestProblem to the first ContestParticipation that solves it.
-
-        :param problems: A list of ContestProblem objects.
-        :param participations: A list of ContestParticipation objects.
-        :param frozen: Whether the ranking is frozen or not. Only useful for ICPC/VNOJ format.
-        :return: A dictionary mapping ContestProblem's ID to ContestParticipation's ID, or None if no solves yet.
+        :return: A tuple of two dictionaries. First one maps ContestProblem's ID to ContestParticipation's ID,
+        or None if no solves yet. Second one maps ContestProblem's ID to total number of accepted submissions.
         """
         raise NotImplementedError()
 

--- a/judge/contest_format/default.py
+++ b/judge/contest_format/default.py
@@ -45,20 +45,37 @@ class DefaultContestFormat(BaseContestFormat):
         participation.format_data = format_data
         participation.save()
 
+    def get_total_ac(self, problems, participations, frozen=False):
+        total_ac = {}
+
+        for problem in problems:
+            problem_id = str(problem.id)
+            total_ac[problem_id] = 0
+            for participation in participations:
+                format_data = (participation.format_data or {}).get(problem_id)
+                if format_data:
+                    points = format_data['points']
+
+                    if points == problem.points:
+                        total_ac[problem_id] += 1
+
+        return total_ac
+
     def get_first_solves(self, problems, participations, frozen=False):
         first_solves = {}
 
         for problem in problems:
+            problem_id = str(problem.id)
             min_time = None
             for participation in participations:
-                format_data = (participation.format_data or {}).get(str(problem.id))
+                format_data = (participation.format_data or {}).get(problem_id)
                 if format_data:
                     points = format_data['points']
                     time = format_data['time']
 
                     if points == problem.points and (min_time is None or min_time > time):
                         min_time = time
-                        first_solves[str(problem.id)] = participation.id
+                        first_solves[problem_id] = participation.id
 
         return first_solves
 

--- a/judge/contest_format/default.py
+++ b/judge/contest_format/default.py
@@ -63,7 +63,9 @@ class DefaultContestFormat(BaseContestFormat):
 
                     if points == problem.points:
                         total_ac[problem_id] += 1
-                        if min_time is None or min_time > time:
+
+                        # Only acknowledge first solves for live participations
+                        if participation.virtual == 0 and (min_time is None or min_time > time):
                             min_time = time
                             first_solves[problem_id] = participation.id
 

--- a/judge/contest_format/default.py
+++ b/judge/contest_format/default.py
@@ -49,19 +49,26 @@ class DefaultContestFormat(BaseContestFormat):
         from judge.models import ContestSubmission, Submission
         format_data = (participation.format_data or {}).get(str(contest_problem.id))
         first_solve = False
-        submissions = ContestSubmission.objects.filter(problem=contest_problem, points=contest_problem.points, participation=participation)
-        first_submission = Submission.objects.filter(problem=contest_problem.problem, date__gt=self.contest.start_time, date__lt=self.contest.end_time).order_by('-points', 'date').first()
-        for tmp in Submission.objects.filter(problem=contest_problem.problem, date__gt=self.contest.start_time, date__lt=self.contest.end_time).order_by('-points', 'date'):
+        submissions = ContestSubmission.objects.filter(problem=contest_problem,
+                                                       points=contest_problem.points,
+                                                       participation=participation)
+        first_submission = Submission.objects.filter(problem=contest_problem.problem,
+                                                     date__gt=self.contest.start_time,
+                                                     date__lt=self.contest.end_time).order_by('-points', 'date').first()
+        for tmp in Submission.objects.filter(problem=contest_problem.problem,
+                                             date__gt=self.contest.start_time,
+                                             date__lt=self.contest.end_time).order_by('-points', 'date'):
             print(tmp.user, tmp.points)
         if submissions and first_submission:
             print(submissions[0].participation.user, first_submission.user)
             if (submissions[0].participation.user == first_submission.user):
                 first_solve = True
-                
+
         if format_data:
             return format_html(
                 '<td class="{state}"><a href="{url}">{points}<div class="solving-time">{time}</div></a></td>',
-                state=(('pretest-' if self.contest.run_pretests_only and contest_problem.is_pretested else 'first-solve ' if first_solve else '') +
+                state=(('pretest-' if self.contest.run_pretests_only and contest_problem.is_pretested
+                        else 'first-solve ' if first_solve else '') +
                        self.best_solution_state(format_data['points'], contest_problem.points)),
                 url=reverse('contest_user_submissions',
                             args=[self.contest.key, participation.user.user.username, contest_problem.problem.code]),

--- a/judge/contest_format/default.py
+++ b/judge/contest_format/default.py
@@ -45,30 +45,31 @@ class DefaultContestFormat(BaseContestFormat):
         participation.format_data = format_data
         participation.save()
 
-    def display_user_problem(self, participation, contest_problem, frozen=False):
-        from judge.models import ContestSubmission, Submission
+    def get_first_solves(self, problems, participations, frozen=False):
+        first_solves = {}
+
+        for problem in problems:
+            min_time = None
+            for participation in participations:
+                format_data = (participation.format_data or {}).get(str(problem.id))
+                if format_data:
+                    points = format_data['points']
+                    time = format_data['time']
+
+                    if points == problem.points and (min_time is None or min_time > time):
+                        min_time = time
+                        first_solves[str(problem.id)] = participation.id
+
+        return first_solves
+
+    def display_user_problem(self, participation, contest_problem, first_solves, frozen=False):
         format_data = (participation.format_data or {}).get(str(contest_problem.id))
-        first_solve = False
-        submissions = ContestSubmission.objects.filter(problem=contest_problem,
-                                                       points=contest_problem.points,
-                                                       participation=participation)
-        first_submission = Submission.objects.filter(problem=contest_problem.problem,
-                                                     date__gt=self.contest.start_time,
-                                                     date__lt=self.contest.end_time).order_by('-points', 'date').first()
-        for tmp in Submission.objects.filter(problem=contest_problem.problem,
-                                             date__gt=self.contest.start_time,
-                                             date__lt=self.contest.end_time).order_by('-points', 'date'):
-            print(tmp.user, tmp.points)
-        if submissions and first_submission:
-            print(submissions[0].participation.user, first_submission.user)
-            if (submissions[0].participation.user == first_submission.user):
-                first_solve = True
 
         if format_data:
             return format_html(
                 '<td class="{state}"><a href="{url}">{points}<div class="solving-time">{time}</div></a></td>',
-                state=(('pretest-' if self.contest.run_pretests_only and contest_problem.is_pretested
-                        else 'first-solve ' if first_solve else '') +
+                state=(('pretest-' if self.contest.run_pretests_only and contest_problem.is_pretested else '') +
+                       ('first-solve ' if first_solves.get(str(contest_problem.id), None) == participation.id else '') +
                        self.best_solution_state(format_data['points'], contest_problem.points)),
                 url=reverse('contest_user_submissions',
                             args=[self.contest.key, participation.user.user.username, contest_problem.problem.code]),

--- a/judge/contest_format/default.py
+++ b/judge/contest_format/default.py
@@ -45,39 +45,29 @@ class DefaultContestFormat(BaseContestFormat):
         participation.format_data = format_data
         participation.save()
 
-    def get_total_ac(self, problems, participations, frozen=False):
+    def get_first_solves_and_total_ac(self, problems, participations, frozen=False):
+        first_solves = {}
         total_ac = {}
 
         for problem in problems:
             problem_id = str(problem.id)
-            total_ac[problem_id] = 0
-            for participation in participations:
-                format_data = (participation.format_data or {}).get(problem_id)
-                if format_data:
-                    points = format_data['points']
-
-                    if points == problem.points:
-                        total_ac[problem_id] += 1
-
-        return total_ac
-
-    def get_first_solves(self, problems, participations, frozen=False):
-        first_solves = {}
-
-        for problem in problems:
-            problem_id = str(problem.id)
             min_time = None
+            first_solves[problem_id] = None
+            total_ac[problem_id] = 0
+
             for participation in participations:
                 format_data = (participation.format_data or {}).get(problem_id)
                 if format_data:
                     points = format_data['points']
                     time = format_data['time']
 
-                    if points == problem.points and (min_time is None or min_time > time):
-                        min_time = time
-                        first_solves[problem_id] = participation.id
+                    if points == problem.points:
+                        total_ac[problem_id] += 1
+                        if min_time is None or min_time > time:
+                            min_time = time
+                            first_solves[problem_id] = participation.id
 
-        return first_solves
+        return first_solves, total_ac
 
     def display_user_problem(self, participation, contest_problem, first_solves, frozen=False):
         format_data = (participation.format_data or {}).get(str(contest_problem.id))

--- a/judge/contest_format/default.py
+++ b/judge/contest_format/default.py
@@ -46,11 +46,22 @@ class DefaultContestFormat(BaseContestFormat):
         participation.save()
 
     def display_user_problem(self, participation, contest_problem, frozen=False):
+        from judge.models import ContestSubmission, Submission
         format_data = (participation.format_data or {}).get(str(contest_problem.id))
+        first_solve = False
+        submissions = ContestSubmission.objects.filter(problem=contest_problem, points=contest_problem.points, participation=participation)
+        first_submission = Submission.objects.filter(problem=contest_problem.problem, date__gt=self.contest.start_time, date__lt=self.contest.end_time).order_by('-points', 'date').first()
+        for tmp in Submission.objects.filter(problem=contest_problem.problem, date__gt=self.contest.start_time, date__lt=self.contest.end_time).order_by('-points', 'date'):
+            print(tmp.user, tmp.points)
+        if submissions and first_submission:
+            print(submissions[0].participation.user, first_submission.user)
+            if (submissions[0].participation.user == first_submission.user):
+                first_solve = True
+                
         if format_data:
             return format_html(
                 '<td class="{state}"><a href="{url}">{points}<div class="solving-time">{time}</div></a></td>',
-                state=(('pretest-' if self.contest.run_pretests_only and contest_problem.is_pretested else '') +
+                state=(('pretest-' if self.contest.run_pretests_only and contest_problem.is_pretested else 'first-solve ' if first_solve else '') +
                        self.best_solution_state(format_data['points'], contest_problem.points)),
                 url=reverse('contest_user_submissions',
                             args=[self.contest.key, participation.user.user.username, contest_problem.problem.code]),

--- a/judge/contest_format/ecoo.py
+++ b/judge/contest_format/ecoo.py
@@ -98,7 +98,7 @@ class ECOOContestFormat(DefaultContestFormat):
         participation.format_data = format_data
         participation.save()
 
-    def display_user_problem(self, participation, contest_problem, frozen=False):
+    def display_user_problem(self, participation, contest_problem, first_solves, frozen=False):
         format_data = (participation.format_data or {}).get(str(contest_problem.id))
         if format_data:
             bonus = format_html('<small> +{bonus}</small>',
@@ -107,6 +107,7 @@ class ECOOContestFormat(DefaultContestFormat):
             return format_html(
                 '<td class="{state}"><a href="{url}">{points}{bonus}<div class="solving-time">{time}</div></a></td>',
                 state=(('pretest-' if self.contest.run_pretests_only and contest_problem.is_pretested else '') +
+                       ('first-solve ' if first_solves.get(str(contest_problem.id), None) == participation.id else '') +
                        self.best_solution_state(format_data['points'], contest_problem.points)),
                 url=reverse('contest_user_submissions',
                             args=[self.contest.key, participation.user.user.username, contest_problem.problem.code]),

--- a/judge/contest_format/icpc.py
+++ b/judge/contest_format/icpc.py
@@ -163,7 +163,9 @@ class ICPCContestFormat(DefaultContestFormat):
 
                     if points == problem.points:
                         total_ac[problem_id] += 1
-                        if min_time is None or min_time > time:
+
+                        # Only acknowledge first solves for live participations
+                        if participation.virtual == 0 and (min_time is None or min_time > time):
                             min_time = time
                             first_solves[problem_id] = participation.id
 

--- a/judge/contest_format/icpc.py
+++ b/judge/contest_format/icpc.py
@@ -144,21 +144,39 @@ class ICPCContestFormat(DefaultContestFormat):
         participation.format_data = format_data
         participation.save()
 
+    def get_total_ac(self, problems, participations, frozen=False):
+        total_ac = {}
+
+        prefix = 'frozen_' if frozen else ''
+        for problem in problems:
+            problem_id = str(problem.id)
+            total_ac[problem_id] = 0
+            for participation in participations:
+                format_data = (participation.format_data or {}).get(problem_id)
+                if format_data:
+                    points = format_data[prefix + 'points']
+
+                    if points == problem.points:
+                        total_ac[problem_id] += 1
+
+        return total_ac
+
     def get_first_solves(self, problems, participations, frozen=False):
         first_solves = {}
 
         prefix = 'frozen_' if frozen else ''
         for problem in problems:
+            problem_id = str(problem.id)
             min_time = None
             for participation in participations:
-                format_data = (participation.format_data or {}).get(str(problem.id))
+                format_data = (participation.format_data or {}).get(problem_id)
                 if format_data:
                     points = format_data[prefix + 'points']
                     time = format_data['time']
 
                     if points == problem.points and (min_time is None or min_time > time):
                         min_time = time
-                        first_solves[str(problem.id)] = participation.id
+                        first_solves[problem_id] = participation.id
 
         return first_solves
 

--- a/judge/contest_format/icpc.py
+++ b/judge/contest_format/icpc.py
@@ -144,41 +144,30 @@ class ICPCContestFormat(DefaultContestFormat):
         participation.format_data = format_data
         participation.save()
 
-    def get_total_ac(self, problems, participations, frozen=False):
+    def get_first_solves_and_total_ac(self, problems, participations, frozen=False):
+        first_solves = {}
         total_ac = {}
 
         prefix = 'frozen_' if frozen else ''
         for problem in problems:
             problem_id = str(problem.id)
-            total_ac[problem_id] = 0
-            for participation in participations:
-                format_data = (participation.format_data or {}).get(problem_id)
-                if format_data:
-                    points = format_data[prefix + 'points']
-
-                    if points == problem.points:
-                        total_ac[problem_id] += 1
-
-        return total_ac
-
-    def get_first_solves(self, problems, participations, frozen=False):
-        first_solves = {}
-
-        prefix = 'frozen_' if frozen else ''
-        for problem in problems:
-            problem_id = str(problem.id)
             min_time = None
+            first_solves[problem_id] = None
+            total_ac[problem_id] = 0
+
             for participation in participations:
                 format_data = (participation.format_data or {}).get(problem_id)
                 if format_data:
                     points = format_data[prefix + 'points']
                     time = format_data['time']
 
-                    if points == problem.points and (min_time is None or min_time > time):
-                        min_time = time
-                        first_solves[problem_id] = participation.id
+                    if points == problem.points:
+                        total_ac[problem_id] += 1
+                        if min_time is None or min_time > time:
+                            min_time = time
+                            first_solves[problem_id] = participation.id
 
-        return first_solves
+        return first_solves, total_ac
 
     def display_user_problem(self, participation, contest_problem, first_solves, frozen=False):
         format_data = (participation.format_data or {}).get(str(contest_problem.id))

--- a/judge/contest_format/legacy_ioi.py
+++ b/judge/contest_format/legacy_ioi.py
@@ -74,6 +74,33 @@ class LegacyIOIContestFormat(DefaultContestFormat):
         participation.format_data = format_data
         participation.save()
 
+    def get_first_solves_and_total_ac(self, problems, participations, frozen=False):
+        first_solves = {}
+        total_ac = {}
+
+        show_time = self.config['cumtime'] or self.config.get('last_score_altering', False)
+        for problem in problems:
+            problem_id = str(problem.id)
+            min_time = None
+            first_solves[problem_id] = None
+            total_ac[problem_id] = 0
+
+            for participation in participations:
+                format_data = (participation.format_data or {}).get(problem_id)
+                if format_data:
+                    points = format_data['points']
+                    time = format_data['time']
+
+                    if points == problem.points:
+                        total_ac[problem_id] += 1
+
+                        # Only acknowledge first solves for live participations
+                        if show_time and participation.virtual == 0 and (min_time is None or min_time > time):
+                            min_time = time
+                            first_solves[problem_id] = participation.id
+
+        return first_solves, total_ac
+
     def display_user_problem(self, participation, contest_problem, first_solves, frozen=False):
         format_data = (participation.format_data or {}).get(str(contest_problem.id))
         if format_data:

--- a/judge/contest_format/legacy_ioi.py
+++ b/judge/contest_format/legacy_ioi.py
@@ -74,13 +74,14 @@ class LegacyIOIContestFormat(DefaultContestFormat):
         participation.format_data = format_data
         participation.save()
 
-    def display_user_problem(self, participation, contest_problem, frozen=False):
+    def display_user_problem(self, participation, contest_problem, first_solves, frozen=False):
         format_data = (participation.format_data or {}).get(str(contest_problem.id))
         if format_data:
             show_time = self.config['cumtime'] or self.config.get('last_score_altering', False)
             return format_html(
                 '<td class="{state}"><a href="{url}">{points}<div class="solving-time">{time}</div></a></td>',
                 state=(('pretest-' if self.contest.run_pretests_only and contest_problem.is_pretested else '') +
+                       ('first-solve ' if first_solves.get(str(contest_problem.id), None) == participation.id else '') +
                        self.best_solution_state(format_data['points'], contest_problem.points)),
                 url=reverse('contest_user_submissions',
                             args=[self.contest.key, participation.user.user.username, contest_problem.problem.code]),

--- a/judge/contest_format/vnoj.py
+++ b/judge/contest_format/vnoj.py
@@ -194,21 +194,20 @@ class VNOJContestFormat(DefaultContestFormat):
 
         if format_data:
             # This prefix is used to help get the correct data from the format_data dictionary
-            has_pending = bool(format_data.get('pending', 0))
-
-            prefix = 'frozen_' if frozen and has_pending else ''
+            has_pending = frozen and bool(format_data.get('pending', 0))
+            prefix = 'frozen_' if has_pending else ''
 
             # AC before frozen_time
-            if format_data[prefix + 'points'] == contest_problem.points:
+            if has_pending and format_data[prefix + 'points'] == contest_problem.points:
+                has_pending = False
                 prefix = ''
-                frozen = False
 
             penalty = format_html(
                 '<small style="color:red"> ({penalty})</small>',
                 penalty=floatformat(format_data[prefix + 'penalty']),
             ) if format_data[prefix + 'penalty'] else ''
 
-            state = (('pending ' if frozen and has_pending else '') +
+            state = (('pending ' if has_pending else '') +
                      ('pretest-' if self.contest.run_pretests_only and contest_problem.is_pretested else '') +
                      ('first-solve ' if first_solves.get(str(contest_problem.id), None) == participation.id else '') +
                      self.best_solution_state(format_data[prefix + 'points'], contest_problem.points))
@@ -219,9 +218,9 @@ class VNOJContestFormat(DefaultContestFormat):
             points = floatformat(format_data[prefix + 'points'], -self.contest.points_precision)
             time = nice_repr(timedelta(seconds=format_data[prefix + 'time']), 'noday')
             pending = format_html(' <small style="color:black;">[{pending}]</small>',
-                                  pending=floatformat(format_data['pending'])) if frozen and has_pending else ''
+                                  pending=floatformat(format_data['pending'])) if has_pending else ''
 
-            if frozen and has_pending:
+            if has_pending:
                 time = '?'
                 # hide penalty if there are pending submissions
                 penalty = ''

--- a/judge/contest_format/vnoj.py
+++ b/judge/contest_format/vnoj.py
@@ -183,7 +183,9 @@ class VNOJContestFormat(DefaultContestFormat):
 
                     if points == problem.points:
                         total_ac[problem_id] += 1
-                        if min_time is None or min_time > time:
+
+                        # Only acknowledge first solves for live participations
+                        if participation.virtual == 0 and (min_time is None or min_time > time):
                             min_time = time
                             first_solves[problem_id] = participation.id
 

--- a/judge/contest_format/vnoj.py
+++ b/judge/contest_format/vnoj.py
@@ -163,13 +163,32 @@ class VNOJContestFormat(DefaultContestFormat):
         participation.format_data = format_data
         participation.save()
 
+    def get_total_ac(self, problems, participations, frozen=False):
+        total_ac = {}
+
+        for problem in problems:
+            problem_id = str(problem.id)
+            total_ac[problem_id] = 0
+            for participation in participations:
+                format_data = (participation.format_data or {}).get(problem_id)
+                if format_data:
+                    has_pending = bool(format_data.get('pending', 0))
+                    prefix = 'frozen_' if frozen and has_pending else ''
+                    points = format_data[prefix + 'points']
+
+                    if points == problem.points:
+                        total_ac[problem_id] += 1
+
+        return total_ac
+
     def get_first_solves(self, problems, participations, frozen=False):
         first_solves = {}
 
         for problem in problems:
+            problem_id = str(problem.id)
             min_time = None
             for participation in participations:
-                format_data = (participation.format_data or {}).get(str(problem.id))
+                format_data = (participation.format_data or {}).get(problem_id)
                 if format_data:
                     has_pending = bool(format_data.get('pending', 0))
                     prefix = 'frozen_' if frozen and has_pending else ''
@@ -178,7 +197,7 @@ class VNOJContestFormat(DefaultContestFormat):
 
                     if points == problem.points and (min_time is None or min_time > time):
                         min_time = time
-                        first_solves[str(problem.id)] = participation.id
+                        first_solves[problem_id] = participation.id
 
         return first_solves
 

--- a/judge/contest_format/vnoj.py
+++ b/judge/contest_format/vnoj.py
@@ -163,30 +163,16 @@ class VNOJContestFormat(DefaultContestFormat):
         participation.format_data = format_data
         participation.save()
 
-    def get_total_ac(self, problems, participations, frozen=False):
+    def get_first_solves_and_total_ac(self, problems, participations, frozen=False):
+        first_solves = {}
         total_ac = {}
 
         for problem in problems:
             problem_id = str(problem.id)
-            total_ac[problem_id] = 0
-            for participation in participations:
-                format_data = (participation.format_data or {}).get(problem_id)
-                if format_data:
-                    has_pending = bool(format_data.get('pending', 0))
-                    prefix = 'frozen_' if frozen and has_pending else ''
-                    points = format_data[prefix + 'points']
-
-                    if points == problem.points:
-                        total_ac[problem_id] += 1
-
-        return total_ac
-
-    def get_first_solves(self, problems, participations, frozen=False):
-        first_solves = {}
-
-        for problem in problems:
-            problem_id = str(problem.id)
             min_time = None
+            first_solves[problem_id] = None
+            total_ac[problem_id] = 0
+
             for participation in participations:
                 format_data = (participation.format_data or {}).get(problem_id)
                 if format_data:
@@ -195,11 +181,13 @@ class VNOJContestFormat(DefaultContestFormat):
                     points = format_data[prefix + 'points']
                     time = format_data[prefix + 'time']
 
-                    if points == problem.points and (min_time is None or min_time > time):
-                        min_time = time
-                        first_solves[problem_id] = participation.id
+                    if points == problem.points:
+                        total_ac[problem_id] += 1
+                        if min_time is None or min_time > time:
+                            min_time = time
+                            first_solves[problem_id] = participation.id
 
-        return first_solves
+        return first_solves, total_ac
 
     def display_user_problem(self, participation, contest_problem, first_solves, frozen=False):
         format_data = (participation.format_data or {}).get(str(contest_problem.id))

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -859,13 +859,10 @@ def make_contest_ranking_profile(contest, participation, contest_problems, first
 
 def base_contest_ranking_list(contest, problems, queryset, frozen=False):
     queryset = queryset.select_related('user__user', 'rating').defer('user__about', 'user__organizations__about')
-    first_solves = contest.format.get_first_solves(problems, queryset, frozen)
-    total_ac = contest.format.get_total_ac(problems, queryset, frozen)
-    return (
-        [make_contest_ranking_profile(contest, participation, problems, first_solves, frozen) for participation
-            in queryset],
-        total_ac,
-    )
+    first_solves, total_ac = contest.format.get_first_solves_and_total_ac(problems, queryset, frozen)
+    users = [make_contest_ranking_profile(contest, participation, problems, first_solves, frozen) for participation
+             in queryset]
+    return users, total_ac
 
 
 def base_contest_ranking_queryset(contest):

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -18,8 +18,8 @@ from django.db.models.expressions import CombinedExpression
 from django.db.models.query import Prefetch
 from django.http import Http404, HttpResponse, HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
-from django.template.loader import get_template
 from django.template.defaultfilters import date as date_filter, floatformat
+from django.template.loader import get_template
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -860,8 +860,12 @@ def make_contest_ranking_profile(contest, participation, contest_problems, first
 def base_contest_ranking_list(contest, problems, queryset, frozen=False):
     queryset = queryset.select_related('user__user', 'rating').defer('user__about', 'user__organizations__about')
     first_solves = contest.format.get_first_solves(problems, queryset, frozen)
-    return [make_contest_ranking_profile(contest, participation, problems, first_solves, frozen) for participation
-            in queryset]
+    total_ac = contest.format.get_total_ac(problems, queryset, frozen)
+    return (
+        [make_contest_ranking_profile(contest, participation, problems, first_solves, frozen) for participation
+            in queryset],
+        total_ac,
+    )
 
 
 def base_contest_ranking_queryset(contest):
@@ -886,9 +890,10 @@ def contest_ranking_list(contest, problems, frozen=False):
 
 def get_contest_ranking_list(request, contest, participation=None, ranking_list=contest_ranking_list, ranker=ranker):
     problems = list(contest.contest_problems.select_related('problem').defer('problem__description').order_by('order'))
-    users = ranker(ranking_list(contest, problems), key=attrgetter('points', 'cumtime', 'tiebreaker'))
+    users, total_ac = ranking_list(contest, problems)
+    users = ranker(users, key=attrgetter('points', 'cumtime', 'tiebreaker'))
 
-    return users, problems
+    return users, problems, total_ac
 
 
 class ContestRankingBase(ContestMixin, TitleMixin, DetailView):
@@ -914,12 +919,13 @@ class ContestRankingBase(ContestMixin, TitleMixin, DetailView):
             raise Http404()
 
     def get_rendered_ranking_table(self):
-        users, problems = self.get_ranking_list()
+        users, problems, total_ac = self.get_ranking_list()
 
         return self.ranking_table_template.render(request=self.request, context={
             'table_id': 'ranking-table',
             'users': users,
             'problems': problems,
+            'total_ac': total_ac,
             'contest': self.object,
             'has_rating': self.object.ratings.exists(),
             'is_frozen': self.is_frozen,
@@ -1064,7 +1070,7 @@ class ContestOfficialRanking(ContestRankingBase):
 
         users = list(zip(range(1, len(users) + 1), users))
 
-        return users, problems
+        return users, problems, {}
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -18,7 +18,7 @@ from django.db.models.expressions import CombinedExpression
 from django.db.models.query import Prefetch
 from django.http import Http404, HttpResponse, HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
-from django.template import loader
+from django.template.loader import get_template
 from django.template.defaultfilters import date as date_filter, floatformat
 from django.urls import reverse
 from django.utils import timezone
@@ -893,7 +893,7 @@ def get_contest_ranking_list(request, contest, participation=None, ranking_list=
 
 class ContestRankingBase(ContestMixin, TitleMixin, DetailView):
     template_name = 'contest/ranking.html'
-    ranking_table_template_name = 'contest/ranking-table.html'
+    ranking_table_template = get_template('contest/ranking-table.html')
     tab = None
 
     def get_title(self):
@@ -916,7 +916,7 @@ class ContestRankingBase(ContestMixin, TitleMixin, DetailView):
     def get_rendered_ranking_table(self):
         users, problems = self.get_ranking_list()
 
-        return loader.render_to_string(self.ranking_table_template_name, request=self.request, context={
+        return self.ranking_table_template.render(request=self.request, context={
             'table_id': 'ranking-table',
             'users': users,
             'problems': problems,
@@ -1043,7 +1043,7 @@ class ContestPublicRanking(ContestRanking):
 
 class ContestOfficialRanking(ContestRankingBase):
     template_name = 'contest/official-ranking.html'
-    ranking_table_template_name = 'contest/official-ranking-table.html'
+    ranking_table_template = get_template('contest/official-ranking-table.html')
     tab = 'official_ranking'
 
     def get_title(self):

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -829,12 +829,12 @@ ContestRankingProfile = namedtuple(
 BestSolutionData = namedtuple('BestSolutionData', 'code points time state is_pretested')
 
 
-def make_contest_ranking_profile(contest, participation, contest_problems, frozen=False):
+def make_contest_ranking_profile(contest, participation, contest_problems, first_solves, frozen=False):
     def display_user_problem(contest_problem):
         # When the contest format is changed, `format_data` might be invalid.
         # This will cause `display_user_problem` to error, so we display '???' instead.
         try:
-            return contest.format.display_user_problem(participation, contest_problem, frozen)
+            return contest.format.display_user_problem(participation, contest_problem, first_solves, frozen)
         except (KeyError, TypeError, ValueError):
             return mark_safe('<td>???</td>')
 
@@ -858,8 +858,10 @@ def make_contest_ranking_profile(contest, participation, contest_problems, froze
 
 
 def base_contest_ranking_list(contest, problems, queryset, frozen=False):
-    return [make_contest_ranking_profile(contest, participation, problems, frozen) for participation in
-            queryset.select_related('user__user', 'rating').defer('user__about', 'user__organizations__about')]
+    queryset = queryset.select_related('user__user', 'rating').defer('user__about', 'user__organizations__about')
+    first_solves = contest.format.get_first_solves(problems, queryset, frozen)
+    return [make_contest_ranking_profile(contest, participation, problems, first_solves, frozen) for participation
+            in queryset]
 
 
 def base_contest_ranking_queryset(contest):

--- a/templates/contest/ranking-table.html
+++ b/templates/contest/ranking-table.html
@@ -81,7 +81,13 @@
         {{ cell }}
     {% endfor %}
     {% if has_rating %}
-        <td class="rating-column">{% if user.participation_rating %}{{ rating_number(user.participation_rating) }}{% endif %}</td>
+        <td class="rating-column">
+            {% if user.participation_rating %}
+                {% cache 86400 'rating_number' user.participation_rating %}
+                    {{ rating_number(user.participation_rating) }}
+                {% endcache %}
+            {% endif %}
+        </td>
     {% endif %}
 {% endblock %}
 

--- a/templates/contest/ranking-table.html
+++ b/templates/contest/ranking-table.html
@@ -99,7 +99,7 @@
     <tr>
         <td colspan={% if is_ICPC_format %}4{% else %}3{% endif %}>Total AC</td>
         {% for problem in problems %}
-            <td class="total-ac" id='{{- contest.get_label_for_problem(loop.index0) }}-total'>0</td>
+            <td class="total-ac" id='{{- contest.get_label_for_problem(loop.index0) }}-total'>{{ total_ac.get(str(problem.id), 0) }}</td>
         {% endfor %}
         {% if has_rating %}
             <td></td>

--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -78,7 +78,7 @@
                         {% if tab == 'ranking' %}
                             window.applyRankingFilter();
                         {% endif %}
-                        window.firstSolve();
+                        // window.firstSolve();
                         window.totalAC();
                         window.enableAdminOperations();
                     }).always(function () {
@@ -418,7 +418,7 @@
                 }
             }
 
-            window.firstSolve();
+            // window.firstSolve();
 
             window.totalAC = function() {
                 // Problems are indexed from 0

--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -78,7 +78,6 @@
                         {% if tab == 'ranking' %}
                             window.applyRankingFilter();
                         {% endif %}
-                        // window.firstSolve();
                         window.totalAC();
                         window.enableAdminOperations();
                     }).always(function () {
@@ -366,59 +365,6 @@
             };
 
             window.restoreChecklistOptions();
-
-            window.firstSolve = function() {
-                function convertToSeconds(timeString) {
-                    const time = timeString.split(':').map(Number); // time = [hour, minute, second]
-                    return time[0] * 60 * 60 + time[1] * 60 + time[2];
-                }
-
-                function timeComparison(sub1, sub2) {
-                    if (!sub2) return;
-                    return sub1['time'] < sub2['time'];
-                }
-
-                let firstSolves = {};
-
-                $('td.full-score a').each(function () {
-                    if (this.parentNode.parentNode.getElementsByClassName('virtual-participation').length) {
-                        // Skip virtual participation
-                        return;
-                    }
-
-                    if (this.parentNode.parentNode.classList.contains('disqualified')) {
-                        return;
-                    }
-
-                    let href = this['attributes']['href']['value'];
-                    if (href.includes('submissions')) {
-                        let time = this.getElementsByClassName('solving-time')[0].textContent;
-                        if (time.length == 0) {
-                            return;
-                        }
-                        let hrefElement = href.split('/');
-
-                        let problem = hrefElement[hrefElement.length - 2];
-
-                        let curSub = {
-                            'td': $(this).parent(),
-                            'time': convertToSeconds(time),
-                        }
-
-                        let fs = firstSolves[problem];
-
-                        if (fs == null || timeComparison(curSub, fs)) {
-                            firstSolves[problem] = curSub;
-                        }
-                    }
-                });
-
-                for (let problem in firstSolves) {
-                    firstSolves[problem]['td'].addClass('first-solve');
-                }
-            }
-
-            // window.firstSolve();
 
             window.totalAC = function() {
                 // Problems are indexed from 0

--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -78,7 +78,6 @@
                         {% if tab == 'ranking' %}
                             window.applyRankingFilter();
                         {% endif %}
-                        window.totalAC();
                         window.enableAdminOperations();
                     }).always(function () {
                         ranking_outdated = false;
@@ -238,7 +237,6 @@
                 let selected_orgs = $('#org-check-list').val().map(x => x.trim());
                 localStorage.setItem(`filter-selected-orgs-${contest_key}`, selected_orgs);
                 window.applyRankingFilter();
-                window.totalAC();
             });
 
             $('#clear-organization-filter').click(function () {
@@ -365,28 +363,6 @@
             };
 
             window.restoreChecklistOptions();
-
-            window.totalAC = function() {
-                // Problems are indexed from 0
-                let total_ac = {};
-
-                // Number of columns before first problem
-                let offset = {% if is_ICPC_format %}4{% else %}3{% endif %};
-
-                $('td.full-score').each(function () {
-                    if ($(this).parent().is(':hidden')) {
-                        return;
-                    }
-
-                    total_ac[$(this).index() - offset] = (total_ac[$(this).index() - offset] || 0) + 1;
-                });
-                $('td.total-ac').each(function () {
-                    // There is exactly one column (Total AC) before first problem
-                    $(this).text(total_ac[$(this).index() - 1]);
-                });
-            };
-
-            window.totalAC();
 
             window.enableAdminOperations = function () {
                 $('a.disqualify-participation').click(function (e) {

--- a/templates/user/base-users-table.html
+++ b/templates/user/base-users-table.html
@@ -1,3 +1,4 @@
+{% spaceless %}
 <table {% if table_id %}id="{{ table_id }}"{% endif %} class="users-table table striped">
     <thead>
         <tr>
@@ -60,3 +61,4 @@
     {% block after_user_list scoped %}{% endblock %}
     </tbody>
 </table>
+{% endspaceless %}


### PR DESCRIPTION
# Description
Type of change: improvement

## What

Move the calculation of first solves/total AC from client to server

## Why

In `ranking.html`, `firstSolve` and `totalAC` loop through all elements in the ranking table and block the browser every time the ranking is refreshed, resulting in bad UX for contests with 1000+ users.

Now the calculation is moved to the server. The client no longer needs to process anything and renders much faster. In addition, the ranking table can be cached for all users, so the processing cost is paid only once.

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
