### PR TITLE
Allow logging in by IP address

### DIFF
--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -687,6 +687,7 @@ AUTHENTICATION_BACKENDS = (
     'social_core.backends.facebook.FacebookOAuth2',
     'judge.social_auth.GitHubSecureEmailOAuth2',
     'django.contrib.auth.backends.ModelBackend',
+    'judge.ip_based_auth.IPBasedAuthBackend',
 )
 
 SOCIAL_AUTH_PIPELINE = (

--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -55,6 +55,7 @@ VNOJ_ORG_PP_ENTRIES = 100
 VNOJ_ORG_PP_SCALE = 1
 
 VNOJ_OFFICIAL_CONTEST_MODE = False
+VNOJ_ALLOW_LOGIN_BY_IP_ADDRESS = False
 
 # Contribution points function
 # Both should be int

--- a/judge/forms.py
+++ b/judge/forms.py
@@ -443,7 +443,7 @@ class CustomAuthenticationForm(AuthenticationForm):
         try:
             if is_ip_login:
                 ip = get_client_ip(self.request)
-                profile = Profile.objects.filter(ip=ip).select_related('user').first()
+                profile = Profile.objects.filter(ip=ip).order_by('-last_access').select_related('user').first()
 
                 if profile is None:
                     raise Profile.DoesNotExist

--- a/judge/forms.py
+++ b/judge/forms.py
@@ -438,7 +438,7 @@ class CustomAuthenticationForm(AuthenticationForm):
                 getattr(settings, 'SOCIAL_AUTH_%s_SECRET' % key, None))
 
     def clean(self):
-        is_ip_login = self.request.POST.get('ip-login', 'false') == 'true'
+        is_ip_login = settings.VNOJ_ALLOW_LOGIN_BY_IP_ADDRESS and self.request.POST.get('ip-login', 'false') == 'true'
 
         try:
             if is_ip_login:

--- a/judge/ip_based_auth.py
+++ b/judge/ip_based_auth.py
@@ -6,7 +6,7 @@ from judge.models import Profile
 class IPBasedAuthBackend(ModelBackend):
     def authenticate(self, request, ip_address=None):
         try:
-            profile = Profile.objects.filter(ip=ip_address).select_related('user').first()
+            profile = Profile.objects.filter(ip=ip_address).order_by('-last_access').select_related('user').first()
             if profile is None:
                 return None
             return profile.user

--- a/judge/ip_based_auth.py
+++ b/judge/ip_based_auth.py
@@ -6,7 +6,10 @@ from judge.models import Profile
 class IPBasedAuthBackend(ModelBackend):
     def authenticate(self, request, ip_address=None):
         try:
-            user = Profile.objects.filter(ip=ip_address).select_related('user').first().user
+            profile = Profile.objects.filter(ip=ip_address).select_related('user').first()
+            if profile is None:
+                return None
+            return profile.user
         except Profile.DoesNotExist:
             user = None
         return user

--- a/judge/ip_based_auth.py
+++ b/judge/ip_based_auth.py
@@ -1,0 +1,12 @@
+from django.contrib.auth.backends import ModelBackend
+
+from judge.models import Profile
+
+
+class IPBasedAuthBackend(ModelBackend):
+    def authenticate(self, request, ip_address=None):
+        try:
+            user = Profile.objects.filter(ip=ip_address).select_related('user').first().user
+        except Profile.DoesNotExist:
+            user = None
+        return user

--- a/judge/views/user.py
+++ b/judge/views/user.py
@@ -153,7 +153,10 @@ class UserPage(TitleMixin, UserMixin, DetailView):
 
 class CustomLoginView(LoginView):
     template_name = 'registration/login.html'
-    extra_context = {'title': gettext_lazy('Login')}
+    extra_context = {
+        'title': gettext_lazy('Login'),
+        'allow_login_by_ip_address': settings.VNOJ_ALLOW_LOGIN_BY_IP_ADDRESS
+    }
     authentication_form = CustomAuthenticationForm
     redirect_authenticated_user = True
 

--- a/judge/views/user.py
+++ b/judge/views/user.py
@@ -155,7 +155,7 @@ class CustomLoginView(LoginView):
     template_name = 'registration/login.html'
     extra_context = {
         'title': gettext_lazy('Login'),
-        'allow_login_by_ip_address': settings.VNOJ_ALLOW_LOGIN_BY_IP_ADDRESS
+        'allow_login_by_ip_address': settings.VNOJ_ALLOW_LOGIN_BY_IP_ADDRESS,
     }
     authentication_form = CustomAuthenticationForm
     redirect_authenticated_user = True

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -27,13 +27,15 @@
 {% endblock %}
 
 {% block js_media %}
-<script>
-    $(document).ready(function () {
-        $("#ip-login-button").click(function () {
-            $("input[name='ip-login']").val("true");
-        });
-    });
-</script>
+    {% if allow_login_by_ip_address %}
+        <script>
+            $(document).ready(function () {
+                $("#ip-login-button").click(function () {
+                    $("input[name='ip-login']").val("true");
+                });
+            });
+        </script>
+    {% endif %}
 {% endblock %}
 
 {% block body %}
@@ -67,8 +69,9 @@
             </table>
             <hr>
             <button style="float:right;" type="submit">{{ _('Login!') }}</button>
-            <!-- TODO: enabled if allowing login by ip address -->
-            <button style="float:right; margin-right: 0.5em" type="submit" id="ip-login-button" formnovalidate>{{_('Login by IP Address!')}}</button>
+            {% if allow_login_by_ip_address %}
+                <button style="float:right; margin-right: 0.5em" type="submit" id="ip-login-button" formnovalidate>{{_('Login by IP Address!')}}</button>
+            {% endif %}
             <input type="hidden" name="next" value="{{ next }}">
             <input type="hidden" name="ip-login" value="false">
         </form>

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -26,6 +26,16 @@
     </style>
 {% endblock %}
 
+{% block js_media %}
+<script>
+    $(document).ready(function () {
+        $("#ip-login-button").click(function () {
+            $("input[name='ip-login']").val("true");
+        });
+    });
+</script>
+{% endblock %}
+
 {% block body %}
     <div class="auth-flow-form">
         <form action="" method="post" class="form-area">
@@ -57,7 +67,10 @@
             </table>
             <hr>
             <button style="float:right;" type="submit">{{ _('Login!') }}</button>
+            <!-- TODO: enabled if allowing login by ip address -->
+            <button style="float:right; margin-right: 0.5em" type="submit" id="ip-login-button" formnovalidate>{{_('Login by IP Address!')}}</button>
             <input type="hidden" name="next" value="{{ next }}">
+            <input type="hidden" name="ip-login" value="false">
         </form>
         <a href="{{ url('password_reset') }}">{{ _('Forgot your password?') }}</a>
 


### PR DESCRIPTION
# Description
Type of change: new feature

## What

This PR allows logging into the account that is mapped with the IP address in the database.

To be more specific, this PR checks whether any `Profile.ip` matches the requesting IP address.

**THIS PR MAY BRING BREAKING CHANGES. FURTHER TESTING IS REQUIRED.**

## Why

This allows a convenient login experience, especially for onsite competitions where IP addresses are controlled.

# How Has This Been Tested?

Tested locally, in these cases:
- [x] The user has logged in from the current IP address before
- [x] The user has NOT logged in from the current IP address before
- [x] Normal login

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Informed of breaking changes, testing and migrations (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
