### PR TITLE
Do not show editorial column if contest is ongoing

### DIFF
--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -299,7 +299,7 @@ class ContestDetail(ContestMixin, TitleMixin, CommentedDetailView):
         context['metadata'] = {
             'has_public_editorials': any(
                 problem.is_public and problem.has_public_editorial for problem in context['contest_problems']
-            ),
+            ) if self.object.ended else False,
         }
         context['metadata'].update(
             **self.object.contest_problems
@@ -342,11 +342,6 @@ class ContestAllProblems(ContestMixin, TitleMixin, DetailView):
         context = super(ContestAllProblems, self).get_context_data(**kwargs)
         context['contest_problems'] = Problem.objects.filter(contests__contest=self.object) \
             .order_by('contests__order') \
-            .annotate(has_public_editorial=Case(
-                When(solution__is_public=True, solution__publish_on__lte=timezone.now(), then=True),
-                default=False,
-                output_field=BooleanField(),
-            )) \
             .add_i18n_name(self.request.LANGUAGE_CODE) \
             .add_i18n_description(self.request.LANGUAGE_CODE)
 


### PR DESCRIPTION
# Description

Type of change: bug fix

## What

Do not show editorial column if contest is ongoing.

Also, remove redundant annotations in `ContestAllProblems`'s query

## Why

An editorial is accessible iff it is public and the user is not joining any contest.

Public problems with editorials can be reused in organization contests. With the current logic, the editorial column is always shown even if the contest is ongoing. This is both confusing (clicking on the link leads to `No such editorial` error page if the user is joining the contest) and discouraging (one should try to solve the problems before consulting the editorials).

# How Has This Been Tested?

Tested locally

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
