### PR TITLE
Always show join/spectate buttons in contest list

### DIFF
--- a/locale/vi/LC_MESSAGES/django.po
+++ b/locale/vi/LC_MESSAGES/django.po
@@ -4631,7 +4631,7 @@ msgstr "Báo cáo mới"
 
 #: templates/blog/list.html:111 templates/contest/list.html:192
 msgid "Ongoing contests"
-msgstr "Kỳ thi đang diễn ra"
+msgstr "Các kỳ thi đang diễn ra"
 
 #: templates/blog/list.html:119
 #, python-format
@@ -4640,7 +4640,7 @@ msgstr "Kết thúc trong %(countdown)s."
 
 #: templates/blog/list.html:129 templates/contest/list.html:229
 msgid "Upcoming contests"
-msgstr "Kỳ thi sắp tới"
+msgstr "Các kỳ thi sắp tới"
 
 #: templates/blog/list.html:137 templates/contest/contest.html:55
 #, python-format

--- a/templates/contest/list.html
+++ b/templates/contest/list.html
@@ -16,7 +16,18 @@
             {% if not request.official_contest_mode %}
                 $('.join-warning').click(function () {
                     return confirm('{{ _('Are you sure you want to join?') }}\n' +
-                        '{{ _('Joining a contest for the first time starts your timer, after which it becomes unstoppable.') }}');
+                        '{{ _('Joining a contest for the first time starts your timer, after which it becomes unstoppable.') }}'
+                        {% if request.in_contest %}
+                            + '\n{{ _('Joining this contest will leave %(contest)s.', contest=request.participation.contest.name) }}'
+                        {% endif %}
+                    );
+                });
+            {% endif %}
+
+            {% if request.in_contest %}
+                $('.spectate-warning').click(function () {
+                    return confirm('{{ _('Are you sure you want to spectate?') }}\n' +
+                        '{{ _('Spectating this contest will leave %(contest)s.', contest=request.participation.contest.name) }}');
                 });
             {% endif %}
 
@@ -133,12 +144,14 @@
 {% endmacro %}
 
 {% macro contest_join(contest, request, finished_contests) %}
-    {% if not request.in_contest %}
+    {% if request.in_contest and contest.key == request.participation.contest.key %}
+        <td><span>Already joined</span></td>
+    {% else %}
         <td>
             {% if contest.key in finished_contests or request.profile in contest.authors.all() or request.profile in contest.curators.all() or request.profile in contest.testers.all() %}
                 <form action="{{ url('contest_join', contest.key) }}" method="post">
                     {% csrf_token %}
-                    <input type="submit" class="unselectable button full participate-button"
+                    <input type="submit" class="unselectable button full participate-button spectate-warning"
                            value="{{ _('Spectate') }}">
                 </form>
             {% else %}
@@ -189,9 +202,7 @@
                 <tr>
                     <th style="width:80%">{{ _('Contest') }}</th>
                     <th>{{ _('Users') }}</th>
-                    {% if not request.in_contest %}
-                        <th style="width:20%"></th>
-                    {% endif %}
+                    <th style="width:20%"></th>
                 </tr>
                 </thead>
                 <tbody>
@@ -231,9 +242,7 @@
                 <tr>
                     <th style="width:80%">{{ _('Contest') }}</th>
                     <th>{{ _('Users') }}</th>
-                    {% if not request.in_contest %}
-                        <th style="width:15%"></th>
-                    {% endif %}
+                    <th style="width:15%"></th>
                 </tr>
                 </thead>
                 <tbody>


### PR DESCRIPTION
# Description

Type of change: improvement

## What

Always show join/spectate buttons in contest list

<img width="840" alt="image" src="https://github.com/VNOI-Admin/OJ/assets/17219541/74e7dfb7-2472-42de-ab6c-894b9b902519">

## Why

Previously, if the user is joining a contest, the join buttons in the contest list are hidden. If the user wants to join another contest, they must go to the contest detail page.

This PR changes that to always show the join buttons. The user will be warned if joining a new contest leaves the current contest.

Also fixes this:

![image](https://github.com/VNOI-Admin/OJ/assets/17219541/cfad9cfa-7ab5-43d0-8784-9176dca48c67)

# How Has This Been Tested?

Tested locally

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
