### PR TITLE
Fix user search

### DIFF
--- a/judge/views/user.py
+++ b/judge/views/user.py
@@ -553,7 +553,7 @@ class UserList(QueryStringSortMixin, InfinitePaginationMixin, DiggPaginatorMixin
     default_sort = '-rating'
 
     def get_queryset(self):
-        return (Profile.objects.filter(is_unlisted=False).order_by(self.order)
+        return (Profile.objects.filter(is_unlisted=False).order_by(self.order, 'id')
                 .prefetch_related(Prefetch('user', queryset=User.objects.only('username', 'first_name')))
                 .prefetch_related(Prefetch('organizations',
                                   queryset=Organization.objects.filter(is_unlisted=False).only('name', 'id', 'slug')))
@@ -588,7 +588,7 @@ class ContribList(QueryStringSortMixin, DiggPaginatorMixin, TitleMixin, ListView
     default_sort = '-contribution_points'
 
     def get_queryset(self):
-        return (Profile.objects.filter(is_unlisted=False).order_by(self.order)
+        return (Profile.objects.filter(is_unlisted=False).order_by(self.order, 'id')
                 .prefetch_related(Prefetch('user', queryset=User.objects.only('username', 'first_name')))
                 .prefetch_related(Prefetch('organizations',
                                   queryset=Organization.objects.filter(is_unlisted=False).only('name', 'id', 'slug')))
@@ -629,9 +629,13 @@ def user_ranking_redirect(request):
     except KeyError:
         raise Http404()
     user = get_object_or_404(Profile, user__username=username)
-    rank = Profile.objects.filter(is_unlisted=False, performance_points__gt=user.performance_points).count()
+    # Assume using MySQL. NULL is considered smaller than any non-NULL value.
+    if user.rating is None:
+        rank = Profile.objects.filter(is_unlisted=False, rating__isnull=False).count()
+    else:
+        rank = Profile.objects.filter(is_unlisted=False, rating__gt=user.rating).count()
     rank += Profile.objects.filter(
-        is_unlisted=False, performance_points__exact=user.performance_points, id__lt=user.id,
+        is_unlisted=False, rating__exact=user.rating, id__lt=user.id,
     ).count()
     page = rank // UserList.paginate_by
     return HttpResponseRedirect('%s%s#!%s' % (reverse('user_list'), '?page=%d' % (page + 1) if page else '', username))


### PR DESCRIPTION
# Description

Type of change: bug fix

## What

Sort users by `id` and fix `user_ranking_redirect` to use `rating`

## Why

User search has always been broken because the rows are not ordered by `id`. It just happens to work for users with positive points because those are almost always sortable by points. For users at the bottom (whose points are all 0), it breaks down.

No one seems to notice this, even DMOJ...

Then, commit https://github.com/VNOI-Admin/OJ/commit/c5b3da4b55564ccc87adefe5cb25225125b99219 changed the default sorting from `performance_points` to `rating` but did not change `user_ranking_redirect` to use `rating `. User search now breaks for everyone (yayyyy!).

# How Has This Been Tested?

Tested locally.

Query time increases from 20ms to 30ms :(

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
