### PR TITLE
Fix new contests section in organization home

### DIFF
--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -537,10 +537,10 @@ class OrganizationHome(TitleMixin, CustomOrganizationMixin, PostListBase):
                 .order_by('-end_time', '-id')
 
             if not see_private_contest:
-                filter = Q(is_private=False)
+                _filter = Q(is_private=False)
                 if user.is_authenticated:
-                    filter |= Q(private_contestants=user.profile)
-                new_contests = new_contests.filter(filter)
+                    _filter |= Q(private_contestants=user.profile)
+                new_contests = new_contests.filter(_filter)
 
             context['new_contests'] = new_contests[:settings.DMOJ_BLOG_NEW_PROBLEM_COUNT]
 
@@ -575,15 +575,15 @@ class ProblemListOrganization(CustomOrganizationMixin, ProblemList):
         if self.request.user.has_perm('judge.see_private_problem'):
             return Q(organizations=self.organization)
 
-        filter = Q(is_public=True)
+        _filter = Q(is_public=True)
 
         # Authors, curators, and testers should always have access, so OR at the very end.
         if self.profile is not None:
-            filter |= Q(authors=self.profile)
-            filter |= Q(curators=self.profile)
-            filter |= Q(testers=self.profile)
+            _filter |= Q(authors=self.profile)
+            _filter |= Q(curators=self.profile)
+            _filter |= Q(testers=self.profile)
 
-        return filter & Q(organizations=self.organization)
+        return _filter & Q(organizations=self.organization)
 
 
 class ContestListOrganization(CustomOrganizationMixin, ContestList):

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -520,21 +520,29 @@ class OrganizationHome(TitleMixin, CustomOrganizationMixin, PostListBase):
                 state='P',
                 organization=self.object).count()
 
+        user = self.request.user
         if context['is_member'] or \
-           self.request.user.has_perm('judge.see_organization_problem') or \
-           self.request.user.has_perm('judge.edit_all_problem'):
+           user.has_perm('judge.see_organization_problem') or \
+           user.has_perm('judge.edit_all_problem'):
             context['new_problems'] = Problem.objects.filter(
                 is_public=True, is_organization_private=True,
                 organizations=self.object) \
                 .order_by('-date', '-id')[:settings.DMOJ_BLOG_NEW_PROBLEM_COUNT]
 
-        if context['is_member'] or \
-           self.request.user.has_perm('judge.see_private_contest') or \
-           self.request.user.has_perm('judge.edit_all_contest'):
-            context['new_contests'] = Contest.objects.filter(
+        see_private_contest = user.has_perm('judge.see_private_contest') or user.has_perm('judge.edit_all_contest')
+        if context['is_member'] or see_private_contest:
+            new_contests = Contest.objects.filter(
                 is_visible=True, is_organization_private=True,
                 organizations=self.object) \
-                .order_by('-end_time', '-id')[:settings.DMOJ_BLOG_NEW_PROBLEM_COUNT]
+                .order_by('-end_time', '-id')
+
+            if not see_private_contest:
+                filter = Q(is_private=False)
+                if user.is_authenticated:
+                    filter |= Q(private_contestants=user.profile)
+                new_contests = new_contests.filter(filter)
+
+            context['new_contests'] = new_contests[:settings.DMOJ_BLOG_NEW_PROBLEM_COUNT]
 
         return context
 

--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -374,14 +374,14 @@ class ProblemList(QueryStringSortMixin, TitleMixin, SolvedProblemMixin, ListView
         return queryset.search(query, queryset.BOOLEAN).extra(order_by=['-relevance'])
 
     def get_filter(self):
-        filter = Q(is_public=True) & Q(is_organization_private=False)
+        _filter = Q(is_public=True) & Q(is_organization_private=False)
         if self.profile is not None:
-            filter = Problem.q_add_author_curator_tester(filter, self.profile)
-        return filter
+            _filter = Problem.q_add_author_curator_tester(_filter, self.profile)
+        return _filter
 
     def get_normal_queryset(self):
-        filter = self.get_filter()
-        queryset = Problem.objects.filter(filter).select_related('group').defer('description', 'summary')
+        _filter = self.get_filter()
+        queryset = Problem.objects.filter(_filter).select_related('group').defer('description', 'summary')
 
         if self.profile is not None and self.hide_solved:
             queryset = queryset.exclude(id__in=Submission.objects.filter(user=self.profile, points=F('problem__points'))


### PR DESCRIPTION
# Description

Type of change: bug fix

## What

Don't show contests with `is_private=True` and current user not in private contestants.

## Why

Bug reported by Lam_lai_cuoc_doi

# How Has This Been Tested?

Tested locally

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
