### PR TITLE
Use absolute URL for PDF files when rendering

### DIFF
--- a/judge/bridge/judge_handler.py
+++ b/judge/bridge/judge_handler.py
@@ -3,14 +3,11 @@ import json
 import logging
 import threading
 import time
-import urllib.parse
 from collections import deque, namedtuple
 from operator import itemgetter
 
 from django import db
 from django.conf import settings
-from django.core.exceptions import ValidationError
-from django.core.validators import URLValidator
 from django.utils import timezone
 
 from judge import event_poster as event
@@ -18,11 +15,11 @@ from judge.bridge.base_handler import ZlibPacketHandler, proxy_list
 from judge.caching import finished_submission
 from judge.models import Judge, Language, LanguageLimit, Problem, Profile, \
     RuntimeVersion, Submission, SubmissionTestCase
+from judge.utils.url import get_absolute_submission_file_url
 
 logger = logging.getLogger('judge.bridge')
 json_log = logging.getLogger('judge.json.bridge')
 
-URL_VALIDATOR = URLValidator()
 UPDATE_RATE_LIMIT = 5
 UPDATE_RATE_TIME = 0.5
 SubmissionData = namedtuple(
@@ -33,20 +30,6 @@ SubmissionData = namedtuple(
 
 def _ensure_connection():
     db.connection.close_if_unusable_or_obsolete()
-
-
-def get_submission_file_url(source):
-    """ Get absolute URL to submission file
-    We cannot simply return domain + source, because
-    in the future, we might want to serve this by MEDIA_URL
-    """
-    try:
-        # If source is a valid url,
-        # it might be serve by a MEDIA_URL
-        URL_VALIDATOR(source)
-        return source
-    except ValidationError:
-        return urllib.parse.urljoin(settings.SITE_FULL_URL, source)
 
 
 class JudgeHandler(ZlibPacketHandler):
@@ -257,7 +240,7 @@ class JudgeHandler(ZlibPacketHandler):
             'submission-id': id,
             'problem-id': problem,
             'language': language,
-            'source': source if not data.file_only else get_submission_file_url(source),
+            'source': source if not data.file_only else get_absolute_submission_file_url(source),
             'time-limit': data.time,
             'memory-limit': data.memory,
             'short-circuit': data.short_circuit,

--- a/judge/models/problem.py
+++ b/judge/models/problem.py
@@ -20,6 +20,7 @@ from judge.models.problem_data import problem_data_storage
 from judge.models.profile import Organization, Profile
 from judge.models.runtime import Language
 from judge.user_translations import gettext as user_gettext
+from judge.utils.url import get_absolute_pdf_url
 
 __all__ = ['ProblemGroup', 'ProblemType', 'Problem', 'ProblemTranslation', 'ProblemClarification', 'License',
            'Solution', 'SubmissionSourceAccess', 'TranslatedProblemQuerySet']
@@ -235,6 +236,10 @@ class Problem(models.Model):
         # We only set original points it is not deferred
         if 'points' in self.__dict__:
             self.__original_points = self.points
+
+    @property
+    def absolute_pdf_url(self):
+        return get_absolute_pdf_url(self.pdf_url) if self.pdf_url else None
 
     @cached_property
     def types_list(self):

--- a/judge/utils/url.py
+++ b/judge/utils/url.py
@@ -1,0 +1,23 @@
+import urllib.parse
+
+from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.core.validators import URLValidator
+
+URL_VALIDATOR = URLValidator(schemes=['http', 'https'])
+
+
+def get_absolute_url(url, host):
+    try:
+        URL_VALIDATOR(url)
+        return url
+    except ValidationError:
+        return urllib.parse.urljoin(host, url)
+
+
+def get_absolute_submission_file_url(source):
+    return get_absolute_url(source, settings.SITE_FULL_URL)
+
+
+def get_absolute_pdf_url(pdf_url):
+    return get_absolute_url(pdf_url, settings.SITE_FULL_URL)

--- a/templates/problem/problem-detail.html
+++ b/templates/problem/problem-detail.html
@@ -1,4 +1,4 @@
-{% with pdf_url=problem.pdf_url %}
+{% with pdf_url=problem.absolute_pdf_url %}
 {% if pdf_url %}
     <p>{{ _("In case the statement didn't load correctly, you can download the statement here: ") }}<a href="{{ pdf_url }}">{{ _("Statement") }}</a></p>
     <object id="pdfContainer" data="{{ pdf_url }}" type="application/pdf" height="1000" style="width: 100%;" ></object>


### PR DESCRIPTION
# Description

Type of change: bug fix, refactor

## What

Make relative PDF files correctly displayed on sites that cached our HTML output (e.g. vjudge.net).
Also refactor `get_submission_file_url` into utility functions.

## Why

Some problems on our site use PDF statements with relative URLs (e.g. `olp_sc22_bstr` has `PDF_URL` = `/pdf/bea47451-ed48-4b8c-9c8f-a9189b1e4aac.pdf`). On Virtual Judge, the PDF doesn't show up because the host is `vjudge.net`, not `oj.vnoi.info`

Fixes # (issue)

# How Has This Been Tested?

Tested locally

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
