### PR TITLE
Speed up JudgeHandler's processing of problem list

### DIFF
--- a/judge/bridge/judge_handler.py
+++ b/judge/bridge/judge_handler.py
@@ -118,8 +118,8 @@ class JudgeHandler(ZlibPacketHandler):
         judge = self.judge = Judge.objects.get(name=self.name)
         judge.start_time = timezone.now()
         judge.online = True
-        judge.problems.set(Problem.objects.filter(code__in=list(self.problems.keys())))
-        judge.runtimes.set(Language.objects.filter(key__in=list(self.executors.keys())))
+        judge.problems.set(Problem.objects.filter(code__in=list(self.problems.keys())).values_list('id', flat=True))
+        judge.runtimes.set(Language.objects.filter(key__in=list(self.executors.keys())).values_list('id', flat=True))
 
         # Cache is_disabled for faster access
         self.is_disabled = judge.is_disabled
@@ -331,7 +331,9 @@ class JudgeHandler(ZlibPacketHandler):
         if not self.working:
             self.judges.update_problems(self)
 
-        self.judge.problems.set(Problem.objects.filter(code__in=list(self.problems.keys())))
+        self.judge.problems.set(
+            Problem.objects.filter(code__in=list(self.problems.keys())).values_list('id', flat=True),
+        )
         json_log.info(self._make_json_log(action='update-problems', count=len(self.problems)))
 
     def on_grading_begin(self, packet):


### PR DESCRIPTION
# Description

Type of change: improvement

## What

Speed up JudgeHandler's processing of problem list

## Why

OJ has more than 40k+ problems now. Judges sometimes stall waiting for `bridged` to process the problem list.

When test data for any problem changes, judges send the codes of **ALL** judge-able problems to `bridged`, which then maps these codes to primary keys:

```py
judge.problems.set(Problem.objects.filter(code__in=list(self.problems.keys())))
```

This is extremely slow because:

1. This retrieves all fields, not just primary keys.
2. This creates a model instance for every returned row just to be discarded right after `set` runs.

Mitigated by only querying the primary keys as values list.

A proper fix for this could be caching the mapping, but it's not straightforward as problems can be renamed.

# How Has This Been Tested?

On my PC, I simulate processing all problems:

```py
_problems = Problem.objects.values_list('code', flat=True).all()
_problems = list(zip(_problems, [0] * len(_problems)))
self._problems = _problems
```

Previously, this takes 0.351s. After this patch, it only takes 0.129s :)

Be aware that my PC is faster than our server, and I only run 1 judge instead of 4. The processing time would be further multiplied by the number of judges.

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
