### PR TITLE
Fix the contest cloning bug

### DIFF
--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -369,11 +369,12 @@ class ContestClone(ContestMixin, PermissionRequiredMixin, TitleMixin, SingleObje
     def form_valid(self, form):
         contest = self.object
 
-        tags = contest.tags.all()
-        organizations = contest.organizations.all()
-        private_contestants = contest.private_contestants.all()
-        view_contest_scoreboard = contest.view_contest_scoreboard.all()
-        contest_problems = contest.contest_problems.all()
+        # Using list() to force QuerySets evaluation, as `contest.pk = None` affects these queries
+        tags = list(contest.tags.all())
+        organizations = list(contest.organizations.all())
+        private_contestants = list(contest.private_contestants.all())
+        view_contest_scoreboard = list(contest.view_contest_scoreboard.all())
+        contest_problems = list(contest.contest_problems.all())
         old_key = contest.key
 
         contest.pk = None


### PR DESCRIPTION
# Description

Type of change: bug fix

## What

Fix the issue that problems are not properly copied to the destination contest when executing a contest cloning.

## Why

The assignment of `pk` to `None` affects QuerySets that haven't been evaluated yet (not sure if these behaviors are intended). Using `list()` effectively forces the queries to perform actual db hits [(link)](https://docs.djangoproject.com/en/4.2/ref/models/querysets/#when-querysets-are-evaluated).

https://docs.djangoproject.com/en/4.2/topics/db/queries/#querysets-are-lazy

The performance impact of these changes is negligible for all practical use cases.

# How Has This Been Tested?

Tested on local.

# Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [ ] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
