### PR TITLE
Improve ContestAllProblems

### DIFF
--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -364,6 +364,10 @@ class ContestAllProblems(ContestMixin, TitleMixin, DetailView):
         for idx, p in enumerate(context['contest_problems']):
             p.points = points_list[idx][0]
 
+        authenticated = self.request.user.is_authenticated
+        context['completed_problem_ids'] = user_completed_ids(self.request.profile) if authenticated else []
+        context['attempted_problem_ids'] = user_attempted_ids(self.request.profile) if authenticated else []
+
         return context
 
 

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -173,6 +173,10 @@ class ContestMixin(object):
     slug_url_kwarg = 'contest'
 
     @cached_property
+    def is_in_contest(self):
+        return self.object.is_in_contest(self.request.user)
+
+    @cached_property
     def is_editor(self):
         if not self.request.user.is_authenticated:
             return False
@@ -208,6 +212,7 @@ class ContestMixin(object):
             context['has_joined'] = False
 
         context['now'] = self.object._now
+        context['is_in_contest'] = self.is_in_contest
         context['is_editor'] = self.is_editor
         context['is_tester'] = self.is_tester
         context['can_edit'] = self.can_edit
@@ -268,8 +273,7 @@ class ContestDetail(ContestMixin, TitleMixin, CommentedDetailView):
     def is_comment_locked(self):
         if self.object.use_clarifications:
             now = timezone.now()
-            if self.object.is_in_contest(self.request.user) or \
-                    (self.object.start_time <= now and now <= self.object.end_time):
+            if self.is_in_contest or (self.object.start_time <= now and now <= self.object.end_time):
                 return True
 
         return super(ContestDetail, self).is_comment_locked()

--- a/templates/contest/contest-all-problems.html
+++ b/templates/contest/contest-all-problems.html
@@ -19,35 +19,39 @@
 {% endblock %}
 
 {% block body %}
-    {% set in_contest = contest.is_in_contest(request.user) %}
-    {% if in_contest or contest.ended or request.user.is_superuser or is_editor or is_tester %}
-        {% block description %}
-                {% for problem in contest_problems %}
-                    <div style="display: flex; flex-direction: column; align-items: center;">
-                        <div class="content-description" style="width: 70%;">
-                            <div class="problem_container">
-                                <div style="display: flex">
-                                    <h2 style="margin-top: 0.5em; margin-right: 0.5em;">{{ problem.i18n_name }}</h2>
-                                    <a href="{{ url('problem_submit', problem.code) }}" class="button" style="display: inline; margin: auto 0;">
-                                        {{ _('Submit') }}
-                                    </a>
-                                </div>
-
-                                <div>
-                                    <span><strong>Time limit:</strong> {{ problem.time_limit }} /</span>
-                                    <span><strong>Memory limit:</strong> {{ problem.memory_limit|kbsimpleformat }}</span>
-                                    <p><strong>Point:</strong> {{ problem.points }}</p>
-                                </div>
-                            </div>
-                            {% include "problem/problem-detail.html" %}
-                            <hr>
-                        </div>
+    {% for problem in contest_problems %}
+        <div style="display: flex; flex-direction: column; align-items: center;">
+            <div class="content-description" style="width: 70%;">
+                <div class="problem_container">
+                    <div style="display: flex">
+                        <h2 style="margin-top: 0.5em; margin-right: 0.5em;">
+                            {% if problem.id in completed_problem_ids %}
+                                <a href="{{ url('user_submissions', problem.code, request.user.username) }}">
+                                    <i class="solved-problem-color fa fa-check-circle"></i>
+                                </a>
+                            {% elif problem.id in attempted_problem_ids %}
+                                <a href="{{ url('user_submissions', problem.code, request.user.username) }}">
+                                    <i class="attempted-problem-color fa fa-frown-o"></i>
+                                </a>
+                            {% endif %}
+                            <a href="{{ url('problem_detail', problem.code) }}">{{ problem.i18n_name or problem.name }}</a>
+                        </h2>
+                        <a href="{{ url('problem_submit', problem.code) }}" class="button" style="display: inline; margin: auto 0;">
+                            {{ _('Submit') }}
+                        </a>
                     </div>
-                {% endfor %}
-        {% endblock %}
-    {% endif %}
 
-    <!-- <hr> -->
+                    <div>
+                        <span><strong>{{ _('Time limit:') }}</strong> {{ problem.time_limit }}s /</span>
+                        <span><strong>{{ _('Memory limit:') }}</strong> {{ problem.memory_limit|kbsimpleformat }}</span>
+                        <p><strong>{{ _('Points:') }}</strong> {{ problem.points }}</p>
+                    </div>
+                </div>
+                {% include "problem/problem-detail.html" %}
+                <hr>
+            </div>
+        </div>
+    {% endfor %}
 {% endblock %}
 
 {% block description_end %}{% endblock %}

--- a/templates/contest/contest-tabs.html
+++ b/templates/contest/contest-tabs.html
@@ -32,10 +32,9 @@
 
     {% if request.user.is_authenticated %}
         {% if contest.can_join or contest.require_registration or is_editor or is_tester %}
-            {% set in_contest = contest.is_in_contest(request.user) %}
             {% if contest.ended %}
                 {# Allow users to leave the virtual contest #}
-                {% if in_contest %}
+                {% if is_in_contest %}
                     <form action="{{ url('contest_leave', contest.key) }}" method="post"
                           class="contest-join-pseudotab unselectable button">
                         {% csrf_token %}
@@ -51,7 +50,7 @@
                 {% endif %}
             {% else %}
                 {# Allow users to leave the contest #}
-                {% if in_contest %}
+                {% if is_in_contest %}
                     <form action="{{ url('contest_leave', contest.key) }}" method="post"
                           class="contest-join-pseudotab unselectable button">
                         {% csrf_token %}

--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -42,7 +42,7 @@
     <div id="banner">
         <a href="https://www.timeanddate.com/worldclock/fixedtime.html?msg={{ contest.name|urlquote('') }}&amp;iso=
                 {{- (contest.start_time if contest.start_time >= now else contest.end_time)|utc|date('Y-m-d\TH:i:s') }}" class="date">
-            {%- if contest.is_in_contest(request.user) and not request.participation.live -%}
+            {%- if is_in_contest and not request.participation.live -%}
                 {% if request.participation.spectate %}
                     {{- _('Spectating, contest ends in %(countdown)s.', countdown=as_countdown(contest.time_before_end)) -}}
                 {% elif request.participation.end_time %}
@@ -184,8 +184,7 @@
         {% endif %}
     </div>
 
-    {% set in_contest = contest.is_in_contest(request.user) %}
-    {% if in_contest or contest.ended or request.user.is_superuser or is_editor or is_tester %}
+    {% if is_in_contest or contest.ended or request.user.is_superuser or is_editor or is_tester %}
         <div class="contest-problems">
             <h2 style="margin-bottom: 0.2em; float:left;"><i class="fa fa-fw fa-question-circle"></i>{{ _('Problems') }} </h2>
             {% if can_edit and can_download_data %}
@@ -243,7 +242,7 @@
                             {% endif %}
                         {% endif %}
                         <td style="text-align: left; padding-left: 2em;">
-                            {% if in_contest or problem.is_public or request.user.is_superuser or is_editor or is_tester %}
+                            {% if is_in_contest or problem.is_public or request.user.is_superuser or is_editor or is_tester %}
                                 <a href="{{ url('problem_detail', problem.code) }}">{{ problem.i18n_name or problem.name }}</a>
                             {% else %}
                                 {{ problem.i18n_name or problem.name }}

--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -242,7 +242,7 @@
                             {% endif %}
                         {% endif %}
                         <td style="text-align: left; padding-left: 2em;">
-                            {% if is_in_contest or problem.is_public or request.user.is_superuser or is_editor or is_tester %}
+                            {% if can_view_all_problems or problem.is_public %}
                                 <a href="{{ url('problem_detail', problem.code) }}">{{ problem.i18n_name or problem.name }}</a>
                             {% else %}
                                 {{ problem.i18n_name or problem.name }}
@@ -262,8 +262,9 @@
                 {% endfor %}
                 </tbody>
             </table>
-
+            {% if can_view_all_problems %}
             <a class="button" style="width: fit-content" href="{{ url('contest_all_problems', contest.key) }}">{{ _('All problems') }}</a>
+            {% endif %}
         </div>
         {% if has_announcements or can_edit %}
         <div class="contest-clartifications">


### PR DESCRIPTION
# Description

Type of change: bug fix, refactor, improvement

## What

- Add cached property `is_in_contest` and refactor contest views to use it
- Disable ContestAllProblems access if the contest has ended and problems are not public
- Improve problem headers in ContestAllProblems

Before:

<img width="1042" alt="image" src="https://github.com/VNOI-Admin/OJ/assets/17219541/63e98056-6a2e-451e-b926-c3dba9ae8c96">

After:

<img width="1040" alt="image" src="https://github.com/VNOI-Admin/OJ/assets/17219541/dd9d1253-b207-4b06-ad7b-39d66fc6e0e4">

## Why

:)

# How Has This Been Tested?

Locally

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [x] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
