### PR TITLE
Limit full name in `/user/edit-profile.html`

### DIFF
--- a/judge/forms.py
+++ b/judge/forms.py
@@ -123,10 +123,11 @@ class UserForm(ModelForm):
         # In contest mode, we don't want user to change their name.
         if settings.VNOJ_OFFICIAL_CONTEST_MODE:
             fields.remove('first_name')
+
     def clean_first_name(self):
-        first_name = self.cleaned_data["first_name"]
+        first_name = self.cleaned_data['first_name']
         if len(first_name) > 30:
-            raise ValidationError(_("Your full name is too long!"), code="NAME_LIMIT_EXCEEDED")
+            raise ValidationError(_('Your full name is too long!'), code='NAME_LIMIT_EXCEEDED')
         return first_name
 
 

--- a/judge/forms.py
+++ b/judge/forms.py
@@ -123,6 +123,11 @@ class UserForm(ModelForm):
         # In contest mode, we don't want user to change their name.
         if settings.VNOJ_OFFICIAL_CONTEST_MODE:
             fields.remove('first_name')
+    def clean_first_name(self):
+        first_name = self.cleaned_data["first_name"]
+        if len(first_name) > 30:
+            raise ValidationError(_("Your full name is too long!"), code="NAME_LIMIT_EXCEEDED")
+        return first_name
 
 
 class ProposeProblemSolutionForm(ModelForm):

--- a/templates/user/edit-profile.html
+++ b/templates/user/edit-profile.html
@@ -260,14 +260,18 @@
 {% block body %}
     <div class="centered-form">
         <form id="edit-form" action="" method="post" class="form-area">
-            {% if form.errors %}
+            {% if form.errors or form_user.errors %}
                 <div class="alert alert-danger alert-dismissable">
                     <a href="#" class="close">x</a>
-                    {{ form.non_field_errors() }}
-                    {{ form.about.errors }}
+                    {% if form.errors %}
+                        {{ form.non_field_errors() }}
+                        {{ form.about.errors }}
+                    {% endif %}
+                    {% if form_user.errors %}
+                        {{ form_user.first_name.errors }}
+                    {% endif %}
                 </div>
             {% endif %}
-
             {% csrf_token %}
             {% if form_user.first_name %}
                 <table>


### PR DESCRIPTION
## Description
This PR limits how long the full name is allowed to be.

## Why?
This is simply a task assigned to me.

## How to test this?
You simply need to try to change your full name to something longer than 30 characters in `/edit/profile`. You should be presented with "Your full name is too long!" in red, with your name remaining unchanged. If you try a name shorter than the limit then it should work as expected.

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [ ] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
