### PR TITLE
Support access organization by subdomain

### DIFF
--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -98,7 +98,8 @@ VNOJ_TESTCASE_VISIBLE_LENGTH = 60
 
 VNOJ_TAG_PROBLEM_MIN_RATING = 1900  # Minimum rating to be able to tag a problem
 
-VNOJ_IGNORED_ORGANIZATION_SUBDOMAINS = ['oj', 'www', 'localhost'] # List of subdomain that will be ignored in organization subdomain middleware
+# List of subdomain that will be ignored in organization subdomain middleware
+VNOJ_IGNORED_ORGANIZATION_SUBDOMAINS = ['oj', 'www', 'localhost']
 
 # Some problems have a lot of testcases, and each testcase
 # has about 5~6 fields, so we need to raise this

--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -98,6 +98,8 @@ VNOJ_TESTCASE_VISIBLE_LENGTH = 60
 
 VNOJ_TAG_PROBLEM_MIN_RATING = 1900  # Minimum rating to be able to tag a problem
 
+VNOJ_IGNORED_ORGANIZATION_SUBDOMAINS = ['oj', 'www', 'localhost'] # List of subdomain that will be ignored in organization subdomain middleware
+
 # Some problems have a lot of testcases, and each testcase
 # has about 5~6 fields, so we need to raise this
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 3000
@@ -418,6 +420,7 @@ MIDDLEWARE = (
     'impersonate.middleware.ImpersonateMiddleware',
     'judge.middleware.DMOJImpersonationMiddleware',
     'judge.middleware.ContestMiddleware',
+    "judge.middleware.OrganizationSubdomainMiddleware",
     'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
     'judge.social_auth.SocialAuthExceptionMiddleware',
     'django.contrib.redirects.middleware.RedirectFallbackMiddleware',

--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -420,7 +420,6 @@ MIDDLEWARE = (
     'impersonate.middleware.ImpersonateMiddleware',
     'judge.middleware.DMOJImpersonationMiddleware',
     'judge.middleware.ContestMiddleware',
-    "judge.middleware.OrganizationSubdomainMiddleware",
     'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
     'judge.social_auth.SocialAuthExceptionMiddleware',
     'django.contrib.redirects.middleware.RedirectFallbackMiddleware',

--- a/judge/middleware.py
+++ b/judge/middleware.py
@@ -190,12 +190,9 @@ class OrganizationSubdomainMiddleware(object):
 
     def __call__(self, request):
         subdomain: str = request.get_host().split('.')[0]
-        # TODO: remove
-        subdomain = 'ctq'
         if subdomain.isnumeric() or subdomain in settings.VNOJ_IGNORED_ORGANIZATION_SUBDOMAINS:
             return self.get_response(request)
 
-        print(subdomain)
         request.organization = get_object_or_404(Organization, slug=subdomain)
         # if the user is trying to access the home page, redirect to the organization's home page
         if request.path == '/':

--- a/judge/middleware.py
+++ b/judge/middleware.py
@@ -201,6 +201,7 @@ class OrganizationSubdomainMiddleware(object):
         return self.get_response(request)
 
     def process_template_response(self, request, response):
-        if 'logo_override_image' not in response.context_data:
+        if hasattr(request, 'organization') and 'logo_override_image' not in response.context_data:
+            # inject the logo override image into the template context
             response.context_data['logo_override_image'] = request.organization.logo_override_image
         return response

--- a/judge/middleware.py
+++ b/judge/middleware.py
@@ -9,11 +9,12 @@ from django.contrib.auth.models import User
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.cache import cache
 from django.http import HttpResponse, HttpResponseRedirect
+from django.shortcuts import get_object_or_404
 from django.urls import Resolver404, resolve, reverse
 from django.utils.encoding import force_bytes
 from requests.exceptions import HTTPError
 
-from judge.models import MiscConfig
+from judge.models import MiscConfig, Organization
 
 try:
     import uwsgi
@@ -180,4 +181,19 @@ class MiscConfigMiddleware:
     def __call__(self, request):
         domain = get_current_site(request).domain
         request.misc_config = MiscConfigDict(language=request.LANGUAGE_CODE, domain=domain)
+        return self.get_response(request)
+
+class OrganizationSubdomainMiddleware(object):
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        subdomain: str = request.get_host().split('.')[0]
+        # TODO: remove
+        subdomain = 'ctq'
+        if subdomain.isnumeric() or subdomain in settings.VNOJ_IGNORED_ORGANIZATION_SUBDOMAINS:
+            return self.get_response(request)
+
+        print(subdomain)
+        request.organization = get_object_or_404(Organization, slug=subdomain)
         return self.get_response(request)

--- a/judge/middleware.py
+++ b/judge/middleware.py
@@ -183,6 +183,7 @@ class MiscConfigMiddleware:
         request.misc_config = MiscConfigDict(language=request.LANGUAGE_CODE, domain=domain)
         return self.get_response(request)
 
+
 class OrganizationSubdomainMiddleware(object):
     def __init__(self, get_response):
         self.get_response = get_response
@@ -197,3 +198,8 @@ class OrganizationSubdomainMiddleware(object):
         print(subdomain)
         request.organization = get_object_or_404(Organization, slug=subdomain)
         return self.get_response(request)
+
+    def process_template_response(self, request, response):
+        if 'logo_override_image' not in response.context_data:
+            response.context_data['logo_override_image'] = request.organization.logo_override_image
+        return response

--- a/judge/middleware.py
+++ b/judge/middleware.py
@@ -197,6 +197,10 @@ class OrganizationSubdomainMiddleware(object):
 
         print(subdomain)
         request.organization = get_object_or_404(Organization, slug=subdomain)
+        # if the user is trying to access the home page, redirect to the organization's home page
+        if request.path == '/':
+            return HttpResponseRedirect(request.organization.get_absolute_url())
+
         return self.get_response(request)
 
     def process_template_response(self, request, response):

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -57,6 +57,12 @@ class OrganizationMixin(object):
 
         try:
             self.object = self.organization
+
+            # block the user from viewing other orgs in the subdomain
+            if self.is_in_organization_subdomain() and self.organization.pk != self.request.organization.pk:
+                return generic_message(request, _('Cannot view other organizations'),
+                                       _('You cannot view other organizations'), status=403)
+
             return super(OrganizationMixin, self).dispatch(request, *args, **kwargs)
         except Http404:
             slug = kwargs.get('slug', None)

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -161,7 +161,10 @@ class OrganizationUsers(QueryStringSortMixin, DiggPaginatorMixin, BaseOrganizati
 
     def get_context_data(self, **kwargs):
         context = super(OrganizationUsers, self).get_context_data(**kwargs)
-        context['title'] = _('Members')
+        if not self.is_in_organization_subdomain():
+            context['title'] = self.organization.name
+        else:
+            context['title'] = _('Members')
         context['users'] = ranker(context['users'])
         context['partial'] = True
         context['is_admin'] = self.can_edit_organization()

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -74,6 +74,9 @@ class OrganizationMixin(object):
             return False
         return org.is_admin(self.request.profile) or self.request.user.has_perm('judge.edit_all_organization')
 
+    def is_in_organization_subdomain(self):
+        return hasattr(self.request, 'organization')
+
 
 # Use this mixin to mark a view is public for all users, including non-members
 class PublicOrganizationMixin(OrganizationMixin):
@@ -151,7 +154,7 @@ class OrganizationUsers(QueryStringSortMixin, DiggPaginatorMixin, BaseOrganizati
 
     def get_context_data(self, **kwargs):
         context = super(OrganizationUsers, self).get_context_data(**kwargs)
-        context['title'] = self.object.name
+        context['title'] = _('Members')
         context['users'] = ranker(context['users'])
         context['partial'] = True
         context['is_admin'] = self.can_edit_organization()
@@ -521,7 +524,8 @@ class ProblemListOrganization(PrivateOrganizationMixin, ProblemList):
 
     def get_context_data(self, **kwargs):
         context = super(ProblemListOrganization, self).get_context_data(**kwargs)
-        context['title'] = self.organization.name
+        if not self.is_in_organization_subdomain():
+            context['title'] = self.organization.name
         return context
 
     def get_filter(self):
@@ -562,7 +566,8 @@ class ContestListOrganization(PrivateOrganizationMixin, ContestList):
 
     def get_context_data(self, **kwargs):
         context = super(ContestListOrganization, self).get_context_data(**kwargs)
-        context['title'] = self.organization.name
+        if not self.is_in_organization_subdomain():
+            context['title'] = self.organization.name
         return context
 
 
@@ -577,8 +582,9 @@ class SubmissionListOrganization(PrivateOrganizationMixin, SubmissionsListBase):
 
     def get_context_data(self, **kwargs):
         context = super(SubmissionListOrganization, self).get_context_data(**kwargs)
-        context['title'] = self.organization.name
-        context['content_title'] = self.organization.name
+        if not self.is_in_organization_subdomain():
+            context['title'] = self.organization.name
+            context['content_title'] = self.organization.name
         return context
 
 

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -24,6 +24,7 @@ from judge.forms import OrganizationForm
 from judge.models import BlogPost, Comment, Contest, Language, Organization, OrganizationRequest, \
     Problem, Profile
 from judge.tasks import on_new_problem
+from judge.utils.infinite_paginator import InfinitePaginationMixin
 from judge.utils.ranker import ranker
 from judge.utils.views import DiggPaginatorMixin, QueryStringSortMixin, TitleMixin, generic_message
 from judge.views.blog import BlogPostCreate, PostListBase
@@ -577,7 +578,7 @@ class ContestListOrganization(PrivateOrganizationMixin, ContestList):
         return context
 
 
-class SubmissionListOrganization(PrivateOrganizationMixin, SubmissionsListBase):
+class SubmissionListOrganization(InfinitePaginationMixin, PrivateOrganizationMixin, SubmissionsListBase):
     template_name = 'organization/submission-list.html'
     permission_bypass = ['judge.view_all_submission']
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -258,7 +258,6 @@
                         </a>
                     </li>
                 {% endmacro %}
-                <!-- set org = request.org -->
                 {% set org = request.organization %}
                 <li class="home-nav-element"><a href="{{ url('organization_home', org.slug) }}">{% include "site-logo-fragment.html" %}</a></li>
                 <li class="home-nav-element"><span class="nav-divider"></span></li>

--- a/templates/base.html
+++ b/templates/base.html
@@ -233,22 +233,40 @@
     <div id="nav-container">
         <a id="navicon" href="javascript:void(0)"><i class="fa fa-bars"></i></a>
         <ul id="nav-list">
-            <li class="home-nav-element"><a href="{{ url('home') }}">{% include "site-logo-fragment.html" %}</a></li>
-            <li class="home-nav-element"><span class="nav-divider"></span></li>
-            <li class="home-menu-item"><a href="{{ url('home') }}" class="nav-home">{{ _('Home') }}</a></li>
-            {% for node in mptt_tree(nav_bar) recursive %}
+            {% if request.organization is none %}
+                <li class="home-nav-element"><a href="{{ url('home') }}">{% include "site-logo-fragment.html" %}</a></li>
+                <li class="home-nav-element"><span class="nav-divider"></span></li>
+                <li class="home-menu-item"><a href="{{ url('home') }}" class="nav-home">{{ _('Home') }}</a></li>
+                {% for node in mptt_tree(nav_bar) recursive %}
+                    <li>
+                        <a href="{{ node.path }}" class="nav-{{ node.key }}{% if node.key in nav_tab %} active{% endif %}">
+                            {{ _(node.label) }}
+                            {% if not node.is_leaf_node() %}
+                                <div class="nav-expand">&gt;</div>
+                            {% endif %}
+                        </a>
+                        {% with children=node.get_children() %}
+                            {% if children %}<ul>{{ loop(children) }}</ul>{% endif %}
+                        {% endwith %}
+                    </li>
+                {% endfor %}
+            {% else %}
+            {% macro make_navbar_item(key, url, text) %}
                 <li>
-                    <a href="{{ node.path }}" class="nav-{{ node.key }}{% if node.key in nav_tab %} active{% endif %}">
-                        {{ _(node.label) }}
-                        {% if not node.is_leaf_node() %}
-                            <div class="nav-expand">&gt;</div>
-                        {% endif %}
+                    <a href="{{ url }}" class="nav-{{ key }}"><span>
+                        {{ text }}
                     </a>
-                    {% with children=node.get_children() %}
-                        {% if children %}<ul>{{ loop(children) }}</ul>{% endif %}
-                    {% endwith %}
                 </li>
-            {% endfor %}
+            {% endmacro %}
+                <!-- set org = request.org -->
+                {% set org = request.organization %}
+                <li class="home-nav-element"><a href="{{ url('organization_home', org.slug) }}">{% include "site-logo-fragment.html" %}</a></li>
+                <li class="home-nav-element"><span class="nav-divider"></span></li>
+                {{ make_navbar_item('problem-list', url('problem_list_organization', org.slug), _('PRoblems')) }}
+                {{ make_navbar_item('submission-list', url('submission_list_organization', org.slug), _('Submissions')) }}
+                {{ make_navbar_item('contest-list',  url('contest_list_organization', org.slug), _('Contests')) }}
+                {{ make_navbar_item('users',org.get_users_url(), _('Users')) }}
+            {% endif %}
         </ul>
 
         <span id="user-links">

--- a/templates/base.html
+++ b/templates/base.html
@@ -233,7 +233,7 @@
     <div id="nav-container">
         <a id="navicon" href="javascript:void(0)"><i class="fa fa-bars"></i></a>
         <ul id="nav-list">
-            {% if request.organization is none %}
+            {% if request.organization is not defined %}
                 <li class="home-nav-element"><a href="{{ url('home') }}">{% include "site-logo-fragment.html" %}</a></li>
                 <li class="home-nav-element"><span class="nav-divider"></span></li>
                 <li class="home-menu-item"><a href="{{ url('home') }}" class="nav-home">{{ _('Home') }}</a></li>
@@ -251,13 +251,13 @@
                     </li>
                 {% endfor %}
             {% else %}
-            {% macro make_navbar_item(key, url, text) %}
-                <li>
-                    <a href="{{ url }}" class="nav-{{ key }}"><span>
-                        {{ text }}
-                    </a>
-                </li>
-            {% endmacro %}
+                {% macro make_navbar_item(key, url, text) %}
+                    <li>
+                        <a href="{{ url }}" class="nav-{{ key }}"><span>
+                            {{ text }}
+                        </a>
+                    </li>
+                {% endmacro %}
                 <!-- set org = request.org -->
                 {% set org = request.organization %}
                 <li class="home-nav-element"><a href="{{ url('organization_home', org.slug) }}">{% include "site-logo-fragment.html" %}</a></li>

--- a/templates/organization/tabs.html
+++ b/templates/organization/tabs.html
@@ -10,7 +10,7 @@
     <h2>{{ content_title or title }}</h2>
     <br>
     <div class="tabs">
-        {% if request.organization is none %}
+        {% if request.organization is not defined %}
             <ul>
                 {{ make_tab('home', 'fa-info-circle', url('organization_home', organization.slug), _('Home')) }}
                 {{ make_tab('users', 'fa-university', organization.get_users_url(), _('Users')) }}

--- a/templates/organization/tabs.html
+++ b/templates/organization/tabs.html
@@ -10,13 +10,15 @@
     <h2>{{ content_title or title }}</h2>
     <br>
     <div class="tabs">
-        <ul>
-            {{ make_tab('home', 'fa-info-circle', url('organization_home', organization.slug), _('Home')) }}
-            {{ make_tab('users', 'fa-university', organization.get_users_url(), _('Users')) }}
-            {{ make_tab('problem-list', 'fa-puzzle-piece', url('problem_list_organization', organization.slug), _('Problems list')) }}
-            {{ make_tab('contest-list', 'fa-trophy', url('contest_list_organization', organization.slug), _('Contests list')) }}
-            {{ make_tab('submission-list', 'fa-list', url('submission_list_organization', organization.slug), _('Submissions')) }}
-        </ul>
+        {% if request.organization is none %}
+            <ul>
+                {{ make_tab('home', 'fa-info-circle', url('organization_home', organization.slug), _('Home')) }}
+                {{ make_tab('users', 'fa-university', organization.get_users_url(), _('Users')) }}
+                {{ make_tab('problem-list', 'fa-puzzle-piece', url('problem_list_organization', organization.slug), _('Problems list')) }}
+                {{ make_tab('contest-list', 'fa-trophy', url('contest_list_organization', organization.slug), _('Contests list')) }}
+                {{ make_tab('submission-list', 'fa-list', url('submission_list_organization', organization.slug), _('Submissions')) }}
+            </ul>
+        {% endif %}
         <span class="spacer"></span>
         <ul>
             {% if organization.is_admin(request.profile) %}

--- a/templates/organization/tabs.html
+++ b/templates/organization/tabs.html
@@ -7,10 +7,10 @@
 {% endmacro %}
 
 <div class="page-title">
-    <h2>{{ content_title or title }}</h2>
-    <br>
-    <div class="tabs">
-        {% if request.organization is not defined %}
+    {% if request.organization is not defined %}
+        <h2>{{ content_title or title }}</h2>
+        <br>
+        <div class="tabs">
             <ul>
                 {{ make_tab('home', 'fa-info-circle', url('organization_home', organization.slug), _('Home')) }}
                 {{ make_tab('users', 'fa-university', organization.get_users_url(), _('Users')) }}
@@ -18,7 +18,10 @@
                 {{ make_tab('contest-list', 'fa-trophy', url('contest_list_organization', organization.slug), _('Contests list')) }}
                 {{ make_tab('submission-list', 'fa-list', url('submission_list_organization', organization.slug), _('Submissions')) }}
             </ul>
-        {% endif %}
+    {% else %}
+        <div class="tabs">
+        <h2>{{ content_title or title }}</h2>
+    {% endif %}
         <span class="spacer"></span>
         <ul>
             {% if organization.is_admin(request.profile) %}


### PR DESCRIPTION
# Description
Now we can access organizations by subdomain. For example: `team-bedao.vnoi.info` will be equal to https://oj.vnoi.info/organization/team-bedao

Type of change: new feature

## What
- Added a Middleware to get the org slug from subdomain, and attach it to `request` instance
- Override the `navbar` to redirect to org page instead of the normal page

## How
- Just add `judge.middleware.OrganizationSubdomainMiddleware` to your middleware list:
```python3
MIDDLEWARE += (
    "judge.middleware.OrganizationSubdomainMiddleware",
)
```
- You might want to whitelist your domain/subdomain so that the middleware doesn't see it as a org slug. For example, vnoj is deployed at `oj.vnoi.info`, so we want to whitelist `oj`.

```python3
VNOJ_IGNORED_ORGANIZATION_SUBDOMAINS += ['oj']
# actually `oj` already whitelisted, this is just for example
```

## UI
The old UI (without subdomain) **is not changed**. The UI with subdomain is here:
- Navbar and problem list: 
<img width="1473" alt="image" src="https://github.com/VNOI-Admin/OJ/assets/23715841/4d0ed2e5-7808-4564-8157-5ce58084ae57">
- Contests list: 
<img width="1367" alt="image" src="https://github.com/VNOI-Admin/OJ/assets/23715841/6979bd24-7f26-4ea8-9d6a-97b687d60094">
- Submissions list: 
<img width="1387" alt="image" src="https://github.com/VNOI-Admin/OJ/assets/23715841/7858f076-6cca-4303-a8f5-bd6e2a2078d1">

Note: because the team-bedao doesn't have any submissions, so i used a random org for the above image


## Why

- With this, each organization page will look more legit


# How Has This Been Tested?

- Tested on my local, with my own domain

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
