### PR TITLE
Do not allow aborting submissions in official contest mode

### DIFF
--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -331,7 +331,7 @@ class SubmissionSourceDownload(SubmissionDetailBase):
 def abort_submission(request, submission):
     submission = get_object_or_404(Submission, id=int(submission))
     if (not request.user.has_perm('judge.abort_any_submission') and
-       (submission.rejudged_date is not None or request.profile != submission.user)):
+       (submission.rejudged_date is not None or request.profile != submission.user or request.official_contest_mode)):
         raise PermissionDenied()
     submission.abort()
     return HttpResponseRedirect(reverse('submission_status', args=(submission.id,)))

--- a/templates/submission/status.html
+++ b/templates/submission/status.html
@@ -106,7 +106,7 @@
     <div id="test-cases">{% include "submission/status-testcases.html" %}</div>
 
     {% if not submission.is_graded %}
-        {% if request.user == submission.user.user or perms.judge.abort_any_submission %}
+        {% if (request.user == submission.user.user and not request.official_contest_mode) or perms.judge.abort_any_submission %}
             <div id="abort-button">
                 <br>
                 <hr class="half-hr">


### PR DESCRIPTION
# Description

Type of change: improvement

## What

Do not allow aborting submissions in official contest mode

## Why

We're not sure how aborted submissions affect contest results, so let's just disable it.

# How Has This Been Tested?

Tested locally

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [ ] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
