### PR TITLE
Fix JudgeHandler to void leaking submission result via event server

### DIFF
--- a/judge/bridge/judge_handler.py
+++ b/judge/bridge/judge_handler.py
@@ -15,6 +15,7 @@ from judge.bridge.base_handler import ZlibPacketHandler, proxy_list
 from judge.caching import finished_submission
 from judge.models import Judge, Language, LanguageLimit, Problem, Profile, \
     RuntimeVersion, Submission, SubmissionTestCase
+from judge.models.problem import ProblemTestcaseResultAccess
 from judge.utils.url import get_absolute_submission_file_url
 
 logger = logging.getLogger('judge.bridge')
@@ -426,14 +427,7 @@ class JudgeHandler(ZlibPacketHandler):
 
         finished_submission(submission)
 
-        event.post('sub_%s' % submission.id_secret, {
-            'type': 'grading-end',
-            'time': time,
-            'memory': memory,
-            'points': float(points),
-            'total': float(problem.points),
-            'result': submission.result,
-        })
+        event.post('sub_%s' % submission.id_secret, {'type': 'grading-end'})
         if hasattr(submission, 'contest'):
             participation = submission.contest.participation
             event.post('contest_%d' % participation.contest_id, {'type': 'update'})
@@ -444,10 +438,7 @@ class JudgeHandler(ZlibPacketHandler):
         self._free_self(packet)
 
         if Submission.objects.filter(id=packet['submission-id']).update(status='CE', result='CE', error=packet['log']):
-            event.post('sub_%s' % Submission.get_id_secret(packet['submission-id']), {
-                'type': 'compile-error',
-                'log': packet['log'],
-            })
+            event.post('sub_%s' % Submission.get_id_secret(packet['submission-id']), {'type': 'compile-error'})
             self._post_update_submission(packet['submission-id'], 'compile-error', done=True)
             json_log.info(self._make_json_log(packet, action='compile-error', log=packet['log'],
                                               finish=True, result='CE'))
@@ -565,6 +556,12 @@ class JudgeHandler(ZlibPacketHandler):
                 runtime_version=result.get('runtime-version', ''),
             ))
 
+        SubmissionTestCase.objects.bulk_create(bulk_test_case_updates)
+
+        data = self._get_submission_cache(id)
+        if data['problem__testcase_result_visibility_mode'] != ProblemTestcaseResultAccess.ALL_TEST_CASE:
+            return
+
         do_post = True
 
         if id in self.update_counter:
@@ -580,13 +577,8 @@ class JudgeHandler(ZlibPacketHandler):
             self.update_counter[id] = (1, time.monotonic())
 
         if do_post:
-            event.post('sub_%s' % Submission.get_id_secret(id), {
-                'type': 'test-case',
-                'id': max_position,
-            })
+            event.post('sub_%s' % Submission.get_id_secret(id), {'type': 'test-case'})
             self._post_update_submission(id, state='test-case')
-
-        SubmissionTestCase.objects.bulk_create(bulk_test_case_updates)
 
     def on_malformed(self, packet):
         logger.error('%s: Malformed packet: %s', self.name, packet)
@@ -627,16 +619,18 @@ class JudgeHandler(ZlibPacketHandler):
         data.update(kwargs)
         return json.dumps(data)
 
-    def _post_update_submission(self, id, state, done=False):
-        if self._submission_cache_id == id:
-            data = self._submission_cache
-        else:
-            self._submission_cache = data = Submission.objects.filter(id=id).values(
-                'problem__is_public', 'contest_object_id',
+    def _get_submission_cache(self, id):
+        if self._submission_cache_id != id:
+            self._submission_cache = Submission.objects.filter(id=id).values(
+                'problem__is_public', 'problem__testcase_result_visibility_mode', 'contest_object_id',
                 'user_id', 'problem_id', 'status', 'language__key',
             ).get()
             self._submission_cache_id = id
 
+        return self._submission_cache
+
+    def _post_update_submission(self, id, state, done=False):
+        data = self._get_submission_cache(id)
         if data['problem__is_public']:
             event.post('submissions', {
                 'type': 'done-submission' if done else 'update-submission',


### PR DESCRIPTION
# Description

Type of change: bug fix

## What

The following messages are broadcasted when a submission is being graded:
- `grading-begin`
- `test-case`, one message for every test case
- `grading-end`, includes information like time and memory usage.

![image](https://github.com/VNOI-Admin/OJ/assets/17219541/71107e1e-a2dc-4931-8eaf-c4c800fd9537)

Hence, these messages can be used to leak the number of test cases and time/memory usage even when testcase result visibility is set to "Show submission result only".

This PR fixes it by removing all additional information (they are not used at all) and not broadcasting `test-case` messages if testcase result visibility is not "Show all testcase result".

Note that this change applies to everyone because the event server does not have a notion of permissions. While superusers can view the full test case result, they no longer get live updates for each test case.

# How Has This Been Tested?

Tested locally

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [ ] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
