### PR TITLE
Split the old regex into smaller regex's

### DIFF
--- a/templates/problem/data.html
+++ b/templates/problem/data.html
@@ -426,18 +426,52 @@
             function fill_testcases() {
                 console.log("Filling testcase...");
                 var inFiles = [], outFiles = [];
-                var input_re = new RegExp(/^(?=.*?\.in|in).*?(?:(?:^|\W)(\d+)[^\d\s]+)?(\d+)[^\d\s]*$/);
-                var output_re = new RegExp(/^(?=.*?\.out|.*?\.ok|.*?\.ans|out|ok|ans).*?(?:(?:^|\W)(\d+)[^\d\s]+)?(\d+)[^\d\s]*$/);
+
+                // regex index 0 = Themis, 1 = Polygon, 2 = DMOJ
+
+                var in_re = [
+                    new RegExp(/^(.+\.inp|.+\.in|inp|in)$/),
+                    new RegExp(/^(.+\d+)$/),
+                    new RegExp(/^(?=.*?\.in|in).*?(?:(?:^|\W)(?<batch>\d+)[^\d\s]+)?(?<case>\d+)[^\d\s]*$/),
+                ];
+
+                var out_re = [
+                    new RegExp(/^(.+\.out|.+\.ok|.+\.ans|out|ok|ans)$/),
+                    new RegExp(/^(.+\d+\.a)$/),
+                    new RegExp(/^(?=.*?\.out|out).*?(?:(?:^|\W)(?<batch>\d+)[^\d\s]+)?(?<case>\d+)[^\d\s]*$/),
+                ];
+
+                var test_type = -1;
+
                 for (var i = 0; i < window.valid_files.length; i++) {
-                    if (input_re.test(window.valid_files[i].toLowerCase().replace('/', '.'))) {
-                        inFiles.push(window.valid_files[i]);
-                    }
-                    if (output_re.test(window.valid_files[i].toLowerCase().replace('/', '.'))) {
-                        outFiles.push(window.valid_files[i]);
+                    var tested_filename = window.valid_files[i].toLowerCase().replace('/', '.');
+
+                    for (var type = 0; type < 3; type++) {
+                        if (in_re[type].test(tested_filename)) {
+                            if (test_type != -1 && test_type != type) {
+                                alert("{{_('Files are not in the same format!')}}");
+                                return false;
+                            }
+
+                            test_type = type;
+                            inFiles.push(window.valid_files[i]);
+                            break;
+                        }
+
+                        if (out_re[type].test(tested_filename)) {
+                            if (test_type != -1 && test_type != type) {
+                                alert("{{_('Files are not in the same format!')}}");
+                                return false;
+                            }
+
+                            test_type = type;
+                            outFiles.push(window.valid_files[i]);
+                            break;
+                        }
                     }
                 }
                 if (inFiles.length == 0) {
-                    alert("{{_('No input/output files. Make sure your files are following themis/cms test format')}}");
+                    alert("{{_('No input/output files. Make sure your files are following themis/polygon/cms test format')}}");
                     return false;
                 }
                 if (inFiles.length != outFiles.length) {


### PR DESCRIPTION
# Description

Split the old regex into smaller regex's

Type of change: bug fix, refactor

## What

Instead of using a single regex, the check will go through 3 different regex's. The order of checking is:
- Themis
- Polygon
- [DMOJ](https://docs.dmoj.ca/#/problem_format/problem_format?id=specifying-cases-with-regexes)

## Why

The current regex cannot check correctly in some cases.

For example, if the test structure is `test[number]/in[*].out`, the old check will capture `[number].in` and the file will pass as an input file (while it should not).

![image](https://github.com/VNOI-Admin/OJ/assets/68510735/1d0f30bc-9a61-4332-8105-16a965327c9c)

There is also a check whether all files are in the same format. Some files will be recognized as an input/output file of one format but not another. For example, `TEST01/inftrain.out` will be recognized as an input file instead, from the DMOJ regex. This is why this check is in place, and the DMOJ regex is put at the end as the fallback regex.

# How Has This Been Tested?

On local version of VNOJ.

Tested with:
- A Polygon-style test data (in: `test/[number]`, out: `test/[number].a`
- A Themis-style test data (in: `Test[number]/inftrain.inp`, out: `Test[number]/inftrain.out`)

**NOTE:** Localization has not been updated.

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [x] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
