### PR TITLE
Toggling instead of filtering the balloon page

### DIFF
--- a/templates/contest/balloons.html
+++ b/templates/contest/balloons.html
@@ -32,7 +32,7 @@
         // mark rows with submission id in localStorage
         function mark_stored_ids() {
             let marked_ids = localStorage.getItem('marked_ids');
-            marked_ids = marked_ids !== '' ? marked_ids.split(',') : [];
+            marked_ids = marked_ids ? marked_ids.split(',') : [];
 
             let rows = document.querySelectorAll('tbody > tr');
 
@@ -50,7 +50,7 @@
             let sub_id = $(this).children()[1].textContent.trim();
 
             let marked_ids = localStorage.getItem('marked_ids') || '';
-            marked_ids = marked_ids !== '' ? marked_ids.split(',') : [];
+            marked_ids = marked_ids ? marked_ids.split(',') : [];
 
             let pos = marked_ids.indexOf(sub_id);
 

--- a/templates/contest/balloons.html
+++ b/templates/contest/balloons.html
@@ -21,15 +21,78 @@
 
 {% block content_js_media %}
     {% include "contest/media-js.html" %}
+
+    <style>
+        .marked {
+            background-color: #31c742;
+        }
+    </style>
+
+    <script>
+        // mark rows with submission id in localStorage
+        function mark_stored_ids() {
+            let marked_ids = localStorage.getItem('marked_ids');
+            marked_ids = marked_ids !== '' ? marked_ids.split(',') : [];
+
+            let rows = document.querySelectorAll('tbody > tr');
+
+            for (let row_i = 0; row_i < rows.length; row_i++) {
+                let row = rows[row_i];
+                let sub_id = row.children[1].textContent.trim();
+
+                if (marked_ids.includes(sub_id)) {
+                    row.classList.add('marked');
+                }
+            }
+        }
+
+        function mark_row() {
+            let sub_id = $(this).children()[1].textContent.trim();
+
+            let marked_ids = localStorage.getItem('marked_ids') || '';
+            marked_ids = marked_ids !== '' ? marked_ids.split(',') : [];
+
+            let pos = marked_ids.indexOf(sub_id);
+
+            if (pos == -1) {
+                marked_ids.push(sub_id);
+                $(this).addClass('marked');
+            } else {
+                marked_ids.splice(pos, 1);
+                $(this).removeClass('marked');
+            }
+
+            localStorage.setItem('marked_ids', marked_ids.join(','));
+        }
+
+        function scroll_to_unmarked() {
+            const first_unmarked = document.querySelector('tbody > tr:not(.marked)');
+            const navbar_height = document.getElementById('navigation').offsetHeight;
+            if (first_unmarked) {
+                window.scroll(0, first_unmarked.offsetTop - navbar_height);
+            }
+        }
+
+        document.addEventListener("DOMContentLoaded", function() {
+            // disable scroll restoration
+            if ('scrollRestoration' in history) {
+                history.scrollRestoration = 'manual';
+            }
+
+            mark_stored_ids();
+            scroll_to_unmarked();
+            $('tr').click(mark_row);
+            $('#scroll-to-unmarked').click(scroll_to_unmarked);
+        });
+    </script>
 {% endblock %}
 
 
 {% block body %}
     <div class="contest-clartifications">
-        <form action="balloons" method="get">
-            <input type="hidden" name="balloons_done" value="0">
-            <input type="submit" value="Reset filter">
-        </form>
+        <button class="button" id="scroll-to-unmarked">
+            Scroll to unmarked
+        </button>
         <table id="contest-clartifications" class="table">
             <thead>
                 <tr>
@@ -37,7 +100,6 @@
                     <th>{{ _('SubID.') }}</th>
                     <th>{{ _('TEAM') }}</th>
                     <th>{{ _('PROBLEM') }}</th>
-                    <th></th>
                 </tr>
             </thead>
             <tbody>
@@ -53,12 +115,6 @@
                     </td>
                     <td style="text-align: left; padding-left: 2em;">
                         {{ submission.problem.code }}
-                    </td>
-                    <td>
-                        <form action="balloons" method="get">
-                            <input type="hidden" name="balloons_done" value="{{ loop.index0 + balloons_done + 1 }}">
-                            <input type="submit" value="Filter from here">
-                        </form>
                     </td>
                 </tr>
             {% endfor %}


### PR DESCRIPTION
# Description
Type of change: new feature, refactor

## What

![image](https://github.com/VNOI-Admin/OJ/assets/68510735/4576830c-6c65-4aa3-be3c-be487291fee9)

Instead of using filtering like last year, a toggling feature is applied.

- Click on a row to highlight it (thus marking it done)
- Reloading the page now scrolls to the first unmarked submission

## Why

Some late-arriving submissions may be wrongly filtered.

# How Has This Been Tested?

Tested on local version of VNOJ.

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [x] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
