### PR TITLE
Preselect the default categories when creating organization problems

### DIFF
--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -29,7 +29,7 @@ from judge.utils.ranker import ranker
 from judge.utils.views import DiggPaginatorMixin, QueryStringSortMixin, TitleMixin, generic_message
 from judge.views.blog import BlogPostCreate, PostListBase
 from judge.views.contests import ContestList, CreateContest
-from judge.views.problem import ProblemCreate, ProblemGroup, ProblemList
+from judge.views.problem import ProblemCreate, ProblemGroup, ProblemList, ProblemType
 from judge.views.submission import SubmissionsListBase
 
 __all__ = ['OrganizationList', 'OrganizationHome', 'OrganizationUsers', 'OrganizationMembershipChange',
@@ -609,6 +609,10 @@ class ProblemCreateOrganization(AdminOrganizationMixin, ProblemCreate):
             initial['group'] = ProblemGroup.objects.get(name='Uncategorized').pk
         except ProblemGroup.DoesNotExist:
             initial['group'] = ProblemGroup.objects.order_by('id').first().pk
+        try:
+            initial['types'] = ProblemType.objects.get(name='uncategorized').pk
+        except ProblemType.DoesNotExist:
+            initial['types'] = ProblemType.objects.order_by('id').first().pk
         return initial
 
     def get_form_kwargs(self):

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -29,7 +29,7 @@ from judge.utils.ranker import ranker
 from judge.utils.views import DiggPaginatorMixin, QueryStringSortMixin, TitleMixin, generic_message
 from judge.views.blog import BlogPostCreate, PostListBase
 from judge.views.contests import ContestList, CreateContest
-from judge.views.problem import ProblemCreate, ProblemGroup, ProblemList, ProblemType
+from judge.views.problem import ProblemCreate, ProblemList
 from judge.views.submission import SubmissionsListBase
 
 __all__ = ['OrganizationList', 'OrganizationHome', 'OrganizationUsers', 'OrganizationMembershipChange',

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -29,7 +29,7 @@ from judge.utils.ranker import ranker
 from judge.utils.views import DiggPaginatorMixin, QueryStringSortMixin, TitleMixin, generic_message
 from judge.views.blog import BlogPostCreate, PostListBase
 from judge.views.contests import ContestList, CreateContest
-from judge.views.problem import ProblemCreate, ProblemList
+from judge.views.problem import ProblemCreate, ProblemGroup, ProblemList
 from judge.views.submission import SubmissionsListBase
 
 __all__ = ['OrganizationList', 'OrganizationHome', 'OrganizationUsers', 'OrganizationMembershipChange',
@@ -605,6 +605,10 @@ class ProblemCreateOrganization(AdminOrganizationMixin, ProblemCreate):
         initial = super(ProblemCreateOrganization, self).get_initial()
         initial = initial.copy()
         initial['code'] = ''.join(x for x in self.organization.slug.lower() if x.isalnum()) + '_'
+        try:
+            initial['group'] = ProblemGroup.objects.get(name='Uncategorized').pk
+        except ProblemGroup.DoesNotExist:
+            initial['group'] = ProblemGroup.objects.order_by('id').first().pk
         return initial
 
     def get_form_kwargs(self):

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -605,14 +605,6 @@ class ProblemCreateOrganization(AdminOrganizationMixin, ProblemCreate):
         initial = super(ProblemCreateOrganization, self).get_initial()
         initial = initial.copy()
         initial['code'] = ''.join(x for x in self.organization.slug.lower() if x.isalnum()) + '_'
-        try:
-            initial['group'] = ProblemGroup.objects.get(name='Uncategorized').pk
-        except ProblemGroup.DoesNotExist:
-            initial['group'] = ProblemGroup.objects.order_by('id').first().pk
-        try:
-            initial['types'] = ProblemType.objects.get(name='uncategorized').pk
-        except ProblemType.DoesNotExist:
-            initial['types'] = ProblemType.objects.order_by('id').first().pk
         return initial
 
     def get_form_kwargs(self):

--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -822,6 +822,14 @@ class ProblemCreate(PermissionRequiredMixin, TitleMixin, CreateView):
         initial['description'] = misc_config(self.request)['misc_config']['description_example']
         initial['memory_limit'] = 262144  # 256 MB
         initial['partial'] = True
+        try:
+            initial['group'] = ProblemGroup.objects.get(name='Uncategorized').pk
+        except ProblemGroup.DoesNotExist:
+            initial['group'] = ProblemGroup.objects.order_by('id').first().pk
+        try:
+            initial['types'] = ProblemType.objects.get(name='uncategorized').pk
+        except ProblemType.DoesNotExist:
+            initial['types'] = ProblemType.objects.order_by('id').first().pk
         return initial
 
 


### PR DESCRIPTION
# Description

Type of change: Refactor

## What

![image](https://github.com/VNOI-Admin/OJ/assets/68510735/37b7d8d6-86e1-4f5f-b555-527c42895f2e)


Preselect the default category for problem group and problem types. It will select `"Uncategorized"` (or the first category by ID if `"Uncategorized"` does not exist).

## Why

Reduce repetitive manual work for users.

# How Has This Been Tested?

Tested on local version of VNOJ.

# Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [x] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
