### PR TITLE
Send alerts to Discord during long judge queue

### DIFF
--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -114,6 +114,9 @@ VNOJ_ENABLE_ORGANIZATION_CREDIT_LIMITATION = False
 VNOJ_MONTHLY_FREE_CREDIT = 3 * 60 * 60
 VNOJ_PRICE_PER_HOUR = 50
 
+
+VNOJ_LONG_QUEUE_ALERT_THRESHOLD = 10
+
 # Some problems have a lot of testcases, and each testcase
 # has about 5~6 fields, so we need to raise this
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 3000
@@ -176,6 +179,7 @@ DISCORD_WEBHOOK = {
     'on_new_tag': None,
     'on_new_blogpost': None,
     'on_error': None,
+    'on_long_queue': None,
 }
 
 SITE_FULL_URL = None  # ie 'https://oj.vnoi.info', please remove the last / if needed

--- a/judge/bridge/judge_list.py
+++ b/judge/bridge/judge_list.py
@@ -3,7 +3,10 @@ from collections import namedtuple
 from random import random
 from threading import RLock
 
+from django.conf import settings
+
 from judge.judge_priority import REJUDGE_PRIORITY
+from judge.tasks import on_long_queue
 
 try:
     from llist import dllist
@@ -175,3 +178,5 @@ class JudgeList(object):
                     self.priority[priority],
                 )
                 logger.info('Queued submission: %d', id)
+                if self.queue.size == settings.VNOJ_LONG_QUEUE_ALERT_THRESHOLD + self.priorities:
+                    on_long_queue.delay()


### PR DESCRIPTION
# Description

Type of change: new feature

## What

<img width="362" alt="image" src="https://github.com/user-attachments/assets/7799c517-03e9-4380-bbe6-f1cc8162e4d3">

The bridge will send alert messages to the preconfigured Discord webhook when the queue size exceeds `VNOJ_LONG_QUEUE_ALERT_THRESHOLD`.

The message title is a clickable link to `{site}/submissions/?status=QU`.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have explained the purpose of this PR.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [ ] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
