### PR TITLE
[celery] celery task to reset org monthly cost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ tmp.sh
 *.sql
 fc_*
 local_urls.py
+celerybeat-schedule.*

--- a/dmoj/celery.py
+++ b/dmoj/celery.py
@@ -30,6 +30,13 @@ app.conf.beat_schedule = {
             'expires': 60 * 60 * 24,
         },
     },
+    'organization-monthly-reset': {
+        'task': 'judge.tasks.organization.organization_monthly_reset',
+        'schedule': crontab(minute=0, hour=0, day_of_month=1),
+        'options': {
+            'expires': 60 * 60 * 24,
+        },
+    },
 }
 
 

--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -117,7 +117,7 @@ VNOJ_PRICE_PER_HOUR = 50
 
 VNOJ_LONG_QUEUE_ALERT_THRESHOLD = 10
 
-CELERY_TIMEZONE = 'Asia/Ho_Chi_Minh'
+CELERY_TIMEZONE = 'UTC'
 
 # Some problems have a lot of testcases, and each testcase
 # has about 5~6 fields, so we need to raise this

--- a/judge/tasks/__init__.py
+++ b/judge/tasks/__init__.py
@@ -1,5 +1,6 @@
 from judge.tasks.contest import *
 from judge.tasks.demo import *
+from judge.tasks.organization import *
 from judge.tasks.submission import *
 from judge.tasks.user import *
 from judge.tasks.webhook import *

--- a/judge/tasks/organization.py
+++ b/judge/tasks/organization.py
@@ -1,17 +1,18 @@
 from datetime import datetime, timedelta
 
+import pytz
 from celery import shared_task
 from django.conf import settings
-import pytz
 
 from judge.models import Organization, OrganizationMonthlyUsage
+
 
 @shared_task
 def organization_monthly_reset():
     # Get first day of last month
     current_time = datetime.now(pytz.utc)
     month_start = (current_time.replace(day=1, hour=0, minute=0, second=0, microsecond=0) -
-                  timedelta(days=1)).replace(day=1)
+                   timedelta(days=1)).replace(day=1)
 
     organizations = Organization.objects.filter(current_consumed_credit__gt=0)
 
@@ -19,12 +20,12 @@ def organization_monthly_reset():
         usage = OrganizationMonthlyUsage(
             organization=org,
             time=month_start,
-            consumed_credit=org.current_consumed_credit
+            consumed_credit=org.current_consumed_credit,
         )
         usage.save()
 
     organizations.update(
         monthly_credit=settings.VNOJ_MONTHLY_FREE_CREDIT,
-        current_consumed_credit=0
+        current_consumed_credit=0,
     )
-    print("Reset monthly credit for all organizations")
+    print('Reset monthly credit for all organizations')

--- a/judge/tasks/organization.py
+++ b/judge/tasks/organization.py
@@ -1,0 +1,30 @@
+from datetime import datetime, timedelta
+
+from celery import shared_task
+from django.conf import settings
+import pytz
+
+from judge.models import Organization, OrganizationMonthlyUsage
+
+@shared_task
+def organization_monthly_reset():
+    # Get first day of last month
+    current_time = datetime.now(pytz.utc)
+    month_start = (current_time.replace(day=1, hour=0, minute=0, second=0, microsecond=0) -
+                  timedelta(days=1)).replace(day=1)
+
+    organizations = Organization.objects.filter(current_consumed_credit__gt=0)
+
+    for org in organizations:
+        usage = OrganizationMonthlyUsage(
+            organization=org,
+            time=month_start,
+            consumed_credit=org.current_consumed_credit
+        )
+        usage.save()
+
+    organizations.update(
+        monthly_credit=settings.VNOJ_MONTHLY_FREE_CREDIT,
+        current_consumed_credit=0
+    )
+    print("Reset monthly credit for all organizations")


### PR DESCRIPTION
# Description

New feature: each month, the cron job in celery will reset monthly free cost, instead of using system cronjob (as i have been doing it for months)

## Why

Don't need system crontab for this

Fixes # (issue)

# How Has This Been Tested?

Test locally

# Checklist

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
