### PR TITLE
[misc] run user comment through bleach

### DIFF
--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -595,6 +595,12 @@ MARKDOWN_DEFAULT_STYLE = {
     'nofollow': True,
     'use_camo': True,
     'math': True,
+    'bleach': {
+        'tags': BLEACH_USER_SAFE_TAGS,
+        'attributes': BLEACH_USER_SAFE_ATTRS,
+        'styles': True,
+        'mathml': True,
+    },
 }
 
 MARKDOWN_USER_LARGE_STYLE = {
@@ -602,6 +608,12 @@ MARKDOWN_USER_LARGE_STYLE = {
     'nofollow': True,
     'use_camo': True,
     'math': True,
+    'bleach': {
+        'tags': BLEACH_USER_SAFE_TAGS,
+        'attributes': BLEACH_USER_SAFE_ATTRS,
+        'styles': True,
+        'mathml': True,
+    },
 }
 
 MARKDOWN_STYLES = {


### PR DESCRIPTION
# Description

Previously, the script `<img src=1 href=1 onerror="alert(123)"></p>` will got XSS. To fix that, we have two options, one is to update our markdown2 fork (at: https://github.com/VNOI-Admin/python-markdown2), the other is using bleach. 

It has been too long since i last touch the markdown2, i couldn't recall why i made those fix in the fork, so better leave it as it for now. Updating the settings is more easy, and no need to reinstall requirements!



## What

Update the markdown style settings!
