### PR TITLE
Fix issue with user search highlights

### DIFF
--- a/resources/users.scss
+++ b/resources/users.scss
@@ -65,7 +65,7 @@ span.organization {
         }
 
         &.highlight {
-            background: rgba($color_link200, 0.2);
+            background: rgba($color_link200, 0.2) !important;
         }
     }
 


### PR DESCRIPTION
# Description

Type of change: bug fix

## What

In the current code, the highlight styles defined in https://github.com/VNOI-Admin/OJ/blob/df33c2969e17d33c99d37dddc306fbf550d14b63/resources/users.scss#L67-L69 might be overridden by the style defined in https://github.com/VNOI-Admin/OJ/blob/df33c2969e17d33c99d37dddc306fbf550d14b63/resources/table.scss#L16-L19. This means that the highlight does not work on even-indexed rows.

This PR simply adds !important to the style so that it can override other styles.

# Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have explained the purpose of this PR.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [ ] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
