### PR TITLE
Add Developer Quickstart guide and improve local dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Check out its features [here](https://github.com/DMOJ/online-judge#features).
 ## Installation
 
 Refer to the install documentation [here](https://vnoi-admin.github.io/vnoj-docs/#/site/installation). Almost all installation steps remain the same as the docs, but there are several minor differences, including cloning this repo instead of DMOJ's repo.
-
+> *You find Quickstart for developer? Check [here](contributing.md)*
 ### Additional installation steps
 
 - You **have to** define `DMOJ_PROBLEM_DATA_ROOT` in `local_settings.py`, which should be the path to the directory that contains your problems' tests.

--- a/contributing.md
+++ b/contributing.md
@@ -10,6 +10,92 @@ If you're unable to find an open issue addressing the problem, [open](https://gi
 
 Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
 
+## Developer Quickstart
+
+This quickstart is intended for contributors who want to run VNOJ locally in **development mode**.  
+It is a simplified flow compared to the full production installation guide in [vnoj-docs](https://vnoi-admin.github.io/vnoj-docs/).
+
+### Requirements
+- **Python** ≥ 3.9 (with `venv` and `pip`), you can use `uv` or `pyenv`.
+- **Node.js** ≥ 18.x + npm/pnpm
+- **MariaDB/MySQL** ≥ 10.6 
+- **Redis** ≥ 6 (running on port 6379)
+- **Git**
+- A small cup of coffee.
+
+Any Linux distribution or macOS should work. On Windows, WSL2 with Ubuntu/Debian is recommended.
+
+### 1. Clone & create virtual environment
+```bash
+pip install uv && npm install -g pnpm
+uv venv vnojsite
+source vnojsite/bin/activate
+
+git clone https://github.com/VNOI-Admin/OJ.git site
+cd site
+
+uv pip install -r requirements.txt
+pnpm install
+````
+
+### 2. Database setup
+
+Create a database and user (replace `<mariadb user password>` with your own):
+
+```sql
+CREATE DATABASE dmoj DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_general_ci;
+GRANT ALL PRIVILEGES ON dmoj.* TO 'dmoj'@'localhost' IDENTIFIED BY '<mariadb user password>';
+```
+
+### 3. Local configuration
+
+```bash
+cp dmoj/local_settings.py.example dmoj/local_settings.py
+```
+
+- Update DB credentials in `local_settings.py`.
+- Keep `DEBUG = True` for development.
+
+### 4. Migrate & load demo data
+
+```bash
+python manage.py migrate
+python manage.py loaddata navbar language_small demo
+```
+
+### 5. Create superuser & run server
+
+```bash
+python manage.py createsuperuser
+python manage.py runserver 0.0.0.0:8000
+```
+
+Access `http://127.0.0.1:8000` and log in with your admin account.
+
+### 6. Optional: run background services
+
+```bash
+python manage.py runbridged    # event bridge
+celery -A dmoj_celery worker   # Celery tasks
+```
+
+### 7. Optional: Compiling assets
+
+```bash
+./make_style.sh
+python manage.py collectstatic
+python manage.py compilemessages
+python manage.py compilejsi18n
+```
+
+---
+
+⚡ This setup is enough to:
+
+* Explore the site locally
+* Test templates, UI, and most features
+* Make contributions without a full production deployment
+
 ## Coding convention
 
 We use flake8.

--- a/dmoj/local_settings.py.example
+++ b/dmoj/local_settings.py.example
@@ -1,0 +1,353 @@
+#####################################
+########## Django settings ##########
+#####################################
+# See <https://docs.djangoproject.com/en/3.2/ref/settings/>
+# for more info and help. If you are stuck, you can try Googling about
+# Django - many of these settings below have external documentation about them.
+#
+# The settings listed here are of special interest in configuring the site.
+
+# SECURITY WARNING: keep the secret key used in production secret!
+# You may use this command to generate a key:
+# python3 -c 'from django.core.management.utils import get_random_secret_key;print(get_random_secret_key())'
+SECRET_KEY = 'i7a-ll-+sq-y+*wq1d4&(z@3!)sg$2+ud6(+94o^n@#lbvrr5o'
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True  # Change to False once you are done with runserver testing.
+
+# Uncomment and set to the domain names this site is intended to serve.
+# You must do this once you set DEBUG to False.
+#ALLOWED_HOSTS = ['oj.vnoi.info']
+
+# Optional apps that DMOJ can make use of.
+INSTALLED_APPS += (
+)
+
+# Caching. You can use memcached or redis instead.
+# Documentation: <https://docs.djangoproject.com/en/3.2/topics/cache/>
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    },
+}
+
+# Your database credentials. Only MySQL is supported by DMOJ.
+# Documentation: <https://docs.djangoproject.com/en/3.2/ref/databases/>
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'dmoj',
+        'USER': 'dmoj',
+        'PASSWORD': '<mariadb user password>',
+        'HOST': '127.0.0.1',
+        'OPTIONS': {
+            'charset': 'utf8mb4',
+            'sql_mode': 'STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION',
+        },
+    },
+}
+
+# Sessions.
+# Documentation: <https://docs.djangoproject.com/en/3.2/topics/http/sessions/>
+#SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
+
+# Internationalization.
+# Documentation: <https://docs.djangoproject.com/en/3.2/topics/i18n/>
+LANGUAGE_CODE = 'vi'
+DEFAULT_USER_TIME_ZONE = 'Asia/Ho_Chi_Minh'
+USE_I18N = True
+USE_L10N = True
+USE_TZ = True
+
+## django-compressor settings, for speeding up page load times by minifying CSS and JavaScript files.
+# Documentation: <https://django-compressor.readthedocs.io/en/latest/>
+COMPRESS_OUTPUT_DIR = 'cache'
+COMPRESS_CSS_FILTERS = [
+    'compressor.filters.css_default.CssAbsoluteFilter',
+    'compressor.filters.cssmin.CSSMinFilter',
+]
+COMPRESS_JS_FILTERS = ['compressor.filters.jsmin.JSMinFilter']
+COMPRESS_STORAGE = 'compressor.storage.GzipCompressorFileStorage'
+STATICFILES_FINDERS += ('compressor.finders.CompressorFinder',)
+
+
+#########################################
+########## Email configuration ##########
+#########################################
+# See <https://docs.djangoproject.com/en/3.2/topics/email/#email-backends>
+# for more documentation. You should follow the information there to define
+# your email settings.
+
+# Use this if you are just testing.
+#EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+# The following block is included for your convenience, if you want
+# to use Gmail.
+#EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+#EMAIL_USE_TLS = True
+#EMAIL_HOST = 'smtp.gmail.com'
+#EMAIL_HOST_USER = '<your account>@gmail.com'
+#EMAIL_HOST_PASSWORD = '<your password>'
+#EMAIL_PORT = 587
+
+# To use Mailgun, uncomment this block.
+# You will need to run `pip install django-mailgun-mime` to get `MailgunBackend`.
+#EMAIL_BACKEND = 'django_mailgun_mime.backends.MailgunMIMEBackend'
+#MAILGUN_API_KEY = '<your Mailgun access key>'
+#MAILGUN_DOMAIN_NAME = '<your Mailgun domain>'
+
+# You can also use SendGrid, with `pip install sendgrid-django`.
+#EMAIL_BACKEND = 'sgbackend.SendGridBackend'
+#SENDGRID_API_KEY = '<Your SendGrid API Key>'
+
+# The DMOJ site is able to notify administrators of errors via email,
+# if configured as shown below.
+
+# A tuple of (name, email) pairs that specifies those who will be mailed
+# when the server experiences an error when DEBUG = False.
+ADMINS = (
+    ('Your Name', 'your.email@example.com'),
+)
+
+# The sender for the aforementioned emails.
+SERVER_EMAIL = 'VNOJ: VNOI Online Judge <vnoj@vnoi.info>'
+
+
+################################################
+########## Static files configuration ##########
+################################################
+# See <https://docs.djangoproject.com/en/3.2/howto/static-files/>.
+
+# Change this to somewhere more permanent, especially if you are using a
+# webserver to serve the static files. This is the directory where all the
+# static files DMOJ uses will be collected to.
+# You must configure your webserver to serve this directory as /static/ in production.
+STATIC_ROOT = '/tmp/static'
+
+# URL to access static files.
+#STATIC_URL = '/static/'
+
+# Uncomment to use hashed filenames with the cache framework.
+#STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
+
+
+############################################
+########## DMOJ-specific settings ##########
+############################################
+
+## DMOJ site display settings.
+SITE_NAME = 'VNOJ'
+SITE_FULL_URL = 'https://oj.vnoi.info'
+SITE_LONG_NAME = 'VNOJ: VNOI Online Judge'
+SITE_ADMIN_EMAIL = 'admin@example.com'
+TERMS_OF_SERVICE_URL = '//oj.vnoi.info/tos/'  # Use a flatpage.
+
+## Media files settings.
+# This is the directory where all the media files are stored.
+# Change this to somewhere more permanent.
+# You must configure your webserver to serve this directory in production.
+MEDIA_ROOT = '/tmp/media'
+
+## Problem data settings.
+# This is the directory where all the problem data are stored.
+# Change this to somewhere more permanent.
+DMOJ_PROBLEM_DATA_ROOT = '/tmp/problem_data/'
+
+## Bridge controls.
+# The judge connection address and port; where the judges will connect to the site.
+# You should change this to something your judges can actually connect to
+# (e.g., a port that is unused and unblocked by a firewall).
+BRIDGED_JUDGE_ADDRESS = [('localhost', 9999)]
+
+# The bridged daemon bind address and port to communicate with the site.
+#BRIDGED_DJANGO_ADDRESS = [('localhost', 9998)]
+
+## DMOJ features.
+# Set to True to enable full-text searching for problems.
+ENABLE_FTS = False
+
+# Set of email providers to ban when a user registers, e.g., {'throwawaymail.com'}.
+BAD_MAIL_PROVIDERS = set()
+
+# The number of submissions that a staff user can rejudge at once without
+# requiring the permission 'Rejudge a lot of submissions'.
+# Uncomment to change the submission limit.
+#DMOJ_SUBMISSIONS_REJUDGE_LIMIT = 10
+
+## Event server.
+# Uncomment to enable live updating.
+#EVENT_DAEMON_USE = True
+
+# Uncomment this section to use websocket/daemon.js included in the site.
+#EVENT_DAEMON_POST = '<ws:// URL to post to>'
+
+# If you are using the defaults from the guide, it is this:
+#EVENT_DAEMON_POST = 'ws://127.0.0.1:15101/'
+
+# These are the publicly accessed interface configurations.
+# They should match those used by the script.
+#EVENT_DAEMON_GET = '<public ws:// URL for clients>'
+#EVENT_DAEMON_GET_SSL = '<public wss:// URL for clients>'
+#EVENT_DAEMON_POLL = '<public URL to access the HTTP long polling of event server>'
+# i.e. the path to /channels/ exposed by the daemon, through whatever proxy setup you have.
+
+# Using our standard nginx configuration, these should be:
+#EVENT_DAEMON_GET = 'ws://<your domain>/event/'
+#EVENT_DAEMON_GET_SSL = 'wss://<your domain>/event/'  # Optional
+#EVENT_DAEMON_POLL = '/channels/'
+
+# If you would like to use the AMQP-based event server from <https://github.com/DMOJ/event-server>,
+# uncomment this section instead. This is more involved, and recommended to be done
+# only after you have a working event server.
+#EVENT_DAEMON_AMQP = '<amqp:// URL to connect to, including username and password>'
+#EVENT_DAEMON_AMQP_EXCHANGE = '<AMQP exchange to use>'
+
+## Celery
+CELERY_BROKER_URL = 'redis://localhost:6379'
+CELERY_RESULT_BACKEND = 'redis://localhost:6379'
+
+## CDN control.
+# Base URL for a copy of Ace editor.
+# Should contain ace.js, along with mode-*.js.
+ACE_URL = '//cdnjs.cloudflare.com/ajax/libs/ace/1.2.3/'
+JQUERY_JS = '//cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js'
+SELECT2_JS_URL = '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.min.js'
+SELECT2_CSS_URL = '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/css/select2.min.css'
+
+# A map of Earth in equirectangular projection, for timezone selection.
+# Please try not to hotlink this poor site.
+TIMEZONE_MAP = 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/23/Blue_Marble_2002.png/1024px-Blue_Marble_2002.png'
+
+## Camo (https://github.com/atmos/camo) usage.
+#DMOJ_CAMO_URL = '<URL to your camo install>'
+#DMOJ_CAMO_KEY = '<The CAMO_KEY environmental variable you used>'
+
+# Domains to exclude from being camo'd.
+#DMOJ_CAMO_EXCLUDE = ('https://dmoj.ml', 'https://dmoj.ca')
+
+# Set to True to use https when dealing with protocol-relative URLs.
+# See <https://www.paulirish.com/2010/the-protocol-relative-url/> for what they are.
+#DMOJ_CAMO_HTTPS = False
+
+# HTTPS level. Affects <link rel='canonical'> elements generated.
+# Set to 0 to make http URLs canonical.
+# Set to 1 to make the currently used protocol canonical.
+# Set to 2 to make https URLs canonical.
+#DMOJ_HTTPS = 0
+
+## PDF rendering settings.
+
+# Enable PDF generation.
+#DMOJ_PDF_PDFOID_URL = '<URL to your pdfoid install>.'
+
+# Directory to cache the PDF.
+#DMOJ_PDF_PROBLEM_CACHE = '/home/dmoj-uwsgi/pdfcache'
+
+# Path to use for nginx's X-Accel-Redirect feature.
+# Should be an internal location mapped to the above directory.
+#DMOJ_PDF_PROBLEM_INTERNAL = '/pdfcache'
+
+## Data download settings.
+# Uncomment to allow users to download their data.
+#DMOJ_USER_DATA_DOWNLOAD = True
+
+# Directory to cache user data downloads.
+# It is the administrator's responsibility to clean up old files.
+#DMOJ_USER_DATA_CACHE = '/home/dmoj-uwsgi/userdatacache'
+
+# Path to use for nginx's X-Accel-Redirect feature.
+# Should be an internal location mapped to the above directory.
+#DMOJ_USER_DATA_INTERNAL = '/userdatacache'
+
+# How often a user can download their data.
+#DMOJ_USER_DATA_DOWNLOAD_RATELIMIT = datetime.timedelta(days=1)
+
+# Uncomment to allow contest authors to download contest data
+#DMOJ_CONTEST_DATA_DOWNLOAD = True
+
+# Directory to cache contest data downloads.
+# It is the administrator's responsibility to clean up old files.
+#DMOJ_CONTEST_DATA_CACHE = '/home/dmoj-uwsgi/contestdatacache'
+
+# Path to use for nginx's X-Accel-Redirect feature.
+# Should be an internal location mapped to the above directory.
+#DMOJ_CONTEST_DATA_INTERNAL = '/contestdatacache'
+
+# How often contest data can be exported.
+# This applies per contest, not per user.
+#DMOJ_CONTEST_DATA_DOWNLOAD_RATELIMIT = datetime.timedelta(days=1)
+
+## ======== Logging Settings ========
+# Documentation: https://docs.djangoproject.com/en/3.2/ref/settings/#logging
+#                https://docs.python.org/3/library/logging.config.html#configuration-dictionary-schema
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'file': {
+            'format': '%(levelname)s %(asctime)s %(module)s %(message)s',
+        },
+        'simple': {
+            'format': '%(levelname)s %(message)s',
+        },
+    },
+    'handlers': {
+        # You may use this handler as an example for logging to other files.
+        'bridge': {
+            'level': 'INFO',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': '<desired bridge log path>',
+            'maxBytes': 10 * 1024 * 1024,
+            'backupCount': 10,
+            'formatter': 'file',
+        },
+        'mail_admins': {
+            'level': 'ERROR',
+            'class': 'dmoj.throttle_mail.ThrottledEmailHandler',
+        },
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'file',
+        },
+    },
+    'loggers': {
+        # Site 500 error mails.
+        'django.request': {
+            'handlers': ['mail_admins'],
+            'level': 'ERROR',
+            'propagate': False,
+        },
+        # Judging logs as received by bridged.
+        'judge.bridge': {
+            'handlers': ['bridge', 'mail_admins'],
+            'level': 'INFO',
+            'propagate': True,
+        },
+        # Catch all logs to stderr.
+        '': {
+            'handlers': ['console'],
+        },
+        # Other loggers of interest. Configure at will.
+        #  - judge.user: logs naughty user behaviours.
+        #  - judge.problem.pdf: PDF generation log.
+        #  - judge.html: HTML parsing errors when processing problem statements etc.
+        #  - judge.mail.activate: logs for the reply to activate feature.
+        #  - event_socket_server
+    },
+}
+
+## ======== Integration Settings ========
+## Python Social Auth
+# Documentation: https://python-social-auth.readthedocs.io/en/latest/
+# You can define these to enable authentication through the following services.
+#SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = ''
+#SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = ''
+#SOCIAL_AUTH_FACEBOOK_KEY = ''
+#SOCIAL_AUTH_FACEBOOK_SECRET = ''
+#SOCIAL_AUTH_GITHUB_SECURE_KEY = ''
+#SOCIAL_AUTH_GITHUB_SECURE_SECRET = ''
+
+## ======== Custom Configuration ========
+# You may add whatever Django configuration you would like here.
+# Do try to keep it separate so you can quickly patch in new settings.

--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -27,7 +27,7 @@ SECRET_KEY = '5*9f5q57mqmlz2#f$x1h76&jxy#yortjl1v+l*6hd18$d*yx#0'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["0.0.0.0", "localhost", "127.0.0.1"]
 
 CSRF_FAILURE_VIEW = 'judge.views.widgets.csrf_failure'
 


### PR DESCRIPTION
**Summary:**

* Added **Developer Quickstart** section in `CONTRIBUTING.md` for contributors who want to run VNOJ locally.
* Updated `README.md` with a link to the Contributing guide.
* Added a `dmoj/local_settings.py.example` file to simplify local configuration.
* Updated `settings.py` with `ALLOWED_HOSTS = ["0.0.0.0", "localhost", "127.0.0.1"]` so the dev server works out-of-the-box.

**Why:**

* Current documentation focuses on **production deployment**. New contributors often struggle to bootstrap a dev environment.
* This change lowers “time-to-first-PR” to \~5–10 minutes with a simplified setup.
* Adding `local_settings.py.example` and permissive local `ALLOWED_HOSTS` reduces confusion for new devs.

**Changes:**

* `CONTRIBUTING.md`: added **Developer Quickstart** guide, coding conventions, translation note.
* `README.md`: linked to the Contributing guide.
* `settings.py`: updated `ALLOWED_HOSTS` default to allow local development.
* `dmoj/local_settings.py.example`: new file with sample local configuration.

**Test plan:**

1. Fresh clone.
2. Follow steps in **Developer Quickstart** (`CONTRIBUTING.md`).
3. Run `python manage.py runserver 0.0.0.0:8000`.
4. Confirm site accessible at `http://127.0.0.1:8000`.
5. Load demo fixtures and log in with admin.
6. (Optional) Run `celery worker` and `runbridged`, compile assets.