### PR TITLE
feat(problem): add IP-auth submission API endpoint

### DIFF
--- a/dmoj/urls.py
+++ b/dmoj/urls.py
@@ -128,6 +128,7 @@ urlpatterns = [
         path('/pdf/<slug:language>', problem.ProblemPdfView.as_view(), name='problem_pdf'),
         path('/clone', problem.ProblemClone.as_view(), name='problem_clone'),
         path('/submit', problem.ProblemSubmit.as_view(), name='problem_submit'),
+        path('/api_submit', problem.ProblemAPISubmit.as_view(), name='problem_api_submit'),
         path('/resubmit/<int:submission>', problem.ProblemSubmit.as_view(), name='problem_submit'),
         path('/update-polygon', problem.ProblemUpdatePolygon.as_view(), name='problem_update_polygon'),
 


### PR DESCRIPTION
# Description

Type of change: new feature

## What

- Add a CSRF-exempt `/problem/<code>/api_submit` view for trusted IP-authenticated clients, reusing the existing submission pipeline while returning JSON.
- Introduce language-extension preference mapping and a helper to pick the best match when inferring the language from uploaded files.
- Inline non–file-only submissions as source text, leaving file uploads only for file-only languages, so API judging mirrors the UI flow.
- Register the new endpoint in `site/dmoj/urls.py` without affecting the classic `/submit`.

## Why

To provide an official form-data submission API for IP-based authentication users while keeping the current UI behaviour untouched.

Fixes #

# How Has This Been Tested?

- [x] Test A – Manual UI submission (browser) succeeds and still requires CSRF.
- [x] Test B – `curl -F submission_file=@aplusb.cpp http://0.0.0.0:8000/problem/aplusb/api_submit` from an IP-auth session returns `{"id": ...}` and judges correctly; the same request from a non IP-auth session returns the expected JSON 403.

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [ ] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
