### PR TITLE
Hide Pretest column in test data editor for non-staff users

### DIFF
--- a/templates/problem/data.html
+++ b/templates/problem/data.html
@@ -725,7 +725,9 @@
                 <th>{{ _('Input file') }}</th>
                 <th>{{ _('Output file') }}</th>
                 <th>{{ _('Points') }}</th>
+                {% if request.user.is_staff %}
                 <th>{{ _('Pretest?') }}</th>
+                {% endif %}
                 <!-- <th class="generator-args">{{ _('Generator args') }}</th> -->
                 {% if cases_formset.can_delete %}
                     <th>{{ _('Delete?') }}
@@ -758,8 +760,10 @@
                                   form['output_file'].value() in valid_files) %} class="bad-file"{% endif %}>
                         {{ form.output_file.errors }}{{ form.output_file }}
                     </td>
-                    <td>{{ form.points.errors }}{{ form.points }}</td>
-                    <td>{{ form.is_pretest.errors }}{{ form.is_pretest }}</td>
+                    <td>{{ form.points.errors }}{{ form.points }}{% if not request.user.is_staff %}{{ form.is_pretest.as_hidden() }}{% endif %}</td>
+                    {% if request.user.is_staff %}
+                        <td>{{ form.is_pretest.errors }}{{ form.is_pretest }}</td>
+                    {% endif %}
                     <!-- <td class="generator-args">{{ form.generator_args.errors }}{{ form.generator_args }}
                         <a href="javascript:void(0)" class="edit-generator-args">
                             <i class="fa fa-pencil"></i>


### PR DESCRIPTION
# Description

Hide the Pretest column in the test data editor for non-staff users, as the contest pretest configuration is not exposed to them and is effectively unusable.

**Type of change:** UI improvement

## What

- Hide `Pretest?` column header for non-staff users using `{% if request.user.is_staff %}` condition
- Hide pretest checkbox cell for non-staff users
- Add hidden input `{{ form.is_pretest.as_hidden() }}` to preserve form data when submitting

## Why

For non-staff users, the pretest column is effectively unusable because:
1. Contest pretest configuration is not exposed to them
2. They cannot configure which tests run as pretests
3. Hiding it reduces UI clutter and prevents confusion

Fixes #490 

# How Has This Been Tested?

- [x] flake8 passed with no errors
- [x] Manual verification: view test data editor as staff user (column visible)
- [x] Manual verification: view test data editor as non-staff user (column hidden)
- [x] Verify form submission still works correctly for non-staff users

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Informed of breaking changes, testing and migrations (if applicable).
- [ ] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
