### PR TITLE
fix(submission): remove misleading resubmit advice from IE message

### DIFF
--- a/templates/submission/internal-error-message.html
+++ b/templates/submission/internal-error-message.html
@@ -1,8 +1,6 @@
 <h3 style="color:red;font-weight:bold">
     {% if request.user == submission.user.user %}
         {{ _('An internal error occurred while grading, and the %(site_name)s administrators have been notified.', site_name=SITE_NAME) }}
-        <br>
-        {{ _('In the meantime, try resubmitting in a few seconds.') }}
     {% else %}
         {{ _('An internal error occurred while grading.') }}
     {% endif %}


### PR DESCRIPTION
## Description
When a judge Internal Error (IE) occurs, the current error message advised users to "try resubmitting in a few seconds." This is poor guidance, as the issue is very likely to persist on subsequent submissions.

## Changes
- Removed the misleading resubmit advice line from `internal-error-message.html`
- Kept the notification that administrators have been notified

Fixes #501