### PR TITLE
Fix sitemap generation after Django 4.1

### DIFF
--- a/judge/management/commands/generate_sitemap.py
+++ b/judge/management/commands/generate_sitemap.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 from urllib.parse import urljoin
 
+from django.contrib.sitemaps.views import SitemapIndexItem
 from django.contrib.sites.models import Site
 from django.core.management import BaseCommand
 from django.template.loader import get_template
@@ -66,4 +67,4 @@ class Command(BaseCommand):
             self.stdout.write('Rendering sitemap index file...')
 
         with open(directory / 'sitemap.xml', 'w', encoding='utf-8') as f:
-            f.write(index_template.render({'sitemaps': [urljoin(prefix, file) for file in maps]}))
+            f.write(index_template.render({'sitemaps': [SitemapIndexItem(urljoin(prefix, file)) for file in maps]}))


### PR DESCRIPTION
# Description

Django 4.1 changed the context passed to `sitemap_index.xml` from a list of URLs to a list of objects with attributes ([docs](https://docs.djangoproject.com/en/4.1/ref/contrib/sitemaps/#index)).

PR #425 upgraded Django from 3.2 to 4.2 but missed this breaking change, which caused the sitemap generation script to fail. This PR fixes the issue by updating the sitemap handling to match the new context structure.

**Type of change:** Bug fix
**Fixes:** #518

# How Has This Been Tested?

The sitemap generation command was run manually, and the generated sitemap was verified to be correct.

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [ ] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
