### PR TITLE
feat(prefix-contest-slug): rename org contests when the org's slug ch…

### DIFF
--- a/judge/utils/organization.py
+++ b/judge/utils/organization.py
@@ -8,3 +8,34 @@ def add_admin_to_group(form):
     g = Group.objects.get(name=settings.GROUP_PERMISSION_FOR_ORG_ADMIN)
     for admin in all_admins:
         admin.user.groups.add(g)
+
+
+def rename_organization_contests(organization, old_slug, new_slug):
+    from judge.models import Contest
+
+    # Generate old and new prefixes (alphanumeric characters only)
+    old_prefix = ''.join(x for x in old_slug.lower() if x.isalnum()) + '_'
+    new_prefix = ''.join(x for x in new_slug.lower() if x.isalnum()) + '_'
+
+    if old_prefix == new_prefix:
+        return 0
+
+    # Find all contests belonging to this organization that start with the old prefix
+    org_contests = Contest.objects.filter(
+        organizations=organization,
+        is_organization_private=True,
+        key__startswith=old_prefix,
+    )
+
+    renamed_count = 0
+    for contest in org_contests:
+        # Replace the old prefix with the new prefix
+        new_key = new_prefix + contest.key[len(old_prefix):]
+
+        # Check if the new key already exists
+        if not Contest.objects.filter(key=new_key).exists():
+            contest.key = new_key
+            contest.save()
+            renamed_count += 1
+
+    return renamed_count


### PR DESCRIPTION
…anges

# Description

rename org contests when an organization's slug changes.

Type of change: new feature,

## What

What does the PR do?

## Why

Create a function to rename org contests when an organization's slug changes.

Fixes # (486)

# How Has This Been Tested?

Manually testing

# Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the README/documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Informed of breaking changes, testing and migrations (if applicable).
- [x] Attached screenshots (if applicable).
By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.

Before changed
<img width="1708" height="565" alt="Screenshot 2026-01-26 172858" src="https://github.com/user-attachments/assets/3f3c1d24-0cb8-4e46-bcbe-1c0a172f5bcb" />

Changed
<img width="862" height="398" alt="Screenshot 2026-01-26 172942" src="https://github.com/user-attachments/assets/0036dfb5-0c06-4fc8-b2ec-c933da3582e7" />

After
<img width="1717" height="602" alt="Screenshot 2026-01-26 173005" src="https://github.com/user-attachments/assets/95351f43-b876-4e40-8843-d84a515eefe5" />


