### PR TITLE
Fix the language validation in ProblemSubmitForm

### DIFF
--- a/judge/forms.py
+++ b/judge/forms.py
@@ -379,38 +379,38 @@ class ProblemSubmitForm(ModelForm):
 
     def check_submission(self):
         source = self.cleaned_data.get('source', '')
-        content = self.files.get('submission_file', None)
-        language = self.cleaned_data.get('language', None)
-        lang_obj = Language.objects.get(name=language)
+        content = self.files.get('submission_file')
+        lang_obj = self.cleaned_data.get('language')
 
-        if (source != '' and content is not None) or (source == '' and content is None) or \
-                (source != '' and lang_obj.file_only) or (content == '' and not lang_obj.file_only):
-            raise forms.ValidationError(_('Source code/file is missing or redundant. Please try again'))
+        if lang_obj is not None:
+            if (source != '' and content is not None) or (source == '' and content is None) or \
+                    (source != '' and lang_obj.file_only) or (content == '' and not lang_obj.file_only):
+                raise forms.ValidationError(_('Source code/file is missing or redundant. Please try again'))
 
-        if content:
-            max_file_size = lang_obj.file_size_limit * 1024 * 1024
-            ext = os.path.splitext(content.name)[1][1:]
+            if content:
+                max_file_size = lang_obj.file_size_limit * 1024 * 1024
+                ext = os.path.splitext(content.name)[1][1:]
 
-            if ext.lower() != lang_obj.extension.lower():
-                raise forms.ValidationError(_('Wrong file type for language %(lang)s, expected %(lang_ext)s'
-                                              ', found %(ext)s')
-                                            % {'lang': language, 'lang_ext': lang_obj.extension, 'ext': ext})
+                if ext.lower() != lang_obj.extension.lower():
+                    raise forms.ValidationError(_('Wrong file type for language %(lang)s, expected %(lang_ext)s'
+                                                ', found %(ext)s')
+                                                % {'lang': lang_obj, 'lang_ext': lang_obj.extension, 'ext': ext})
 
-            elif content.size > max_file_size:
-                raise forms.ValidationError(_('File size is too big! Maximum file size is %s')
-                                            % filesizeformat(max_file_size))
+                elif content.size > max_file_size:
+                    raise forms.ValidationError(_('File size is too big! Maximum file size is %s')
+                                                % filesizeformat(max_file_size))
 
-            if lang_obj.key == 'SCRATCH':
-                try:
-                    archive = zipfile.ZipFile(content.file)
-                    info = archive.getinfo('project.json')
-                    if info.file_size > max_file_size:
-                        raise forms.ValidationError(_('project.json is too big! Maximum file size is %s')
-                                                    % filesizeformat(max_file_size))
+                if lang_obj.key == 'SCRATCH':
+                    try:
+                        archive = zipfile.ZipFile(content.file)
+                        info = archive.getinfo('project.json')
+                        if info.file_size > max_file_size:
+                            raise forms.ValidationError(_('project.json is too big! Maximum file size is %s')
+                                                        % filesizeformat(max_file_size))
 
-                    self.files['submission_file'].file = archive.open('project.json')
-                except (zipfile.BadZipFile, KeyError):
-                    pass
+                        self.files['submission_file'].file = archive.open('project.json')
+                    except (zipfile.BadZipFile, KeyError):
+                        pass
 
     def __init__(self, *args, judge_choices=(), **kwargs):
         super(ProblemSubmitForm, self).__init__(*args, **kwargs)


### PR DESCRIPTION
## Description

The current form validation

https://github.com/VNOI-Admin/OJ/blob/ddb0d7c631336caa106da68e8c66ba9981d87195/judge/forms.py#L383-L385

initializes `lang_obj` by querying with `name=language`. However, `language` is already a `Language` instance, so this results in a redundant database query.

This PR fixes the submit form by removing the unnecessary Language fetch.

**Type of change:** Bug fix

## What

* Clean up Language handling in the submit form
* Avoid redundant database queries

## How Has This Been Tested?

* Tested locally


# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [ ] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
