### PR TITLE
fix: prevent long ticket title from stretching the homepage layout

### DIFF
--- a/resources/blog.scss
+++ b/resources/blog.scss
@@ -139,6 +139,13 @@
     }
 }
 
+.open-tickets, .own-open-tickets {
+    .title {
+        word-break: break-word;
+        overflow-wrap: anywhere;
+    }
+}
+
 .open-tickets {
     .object {
         margin-left: 1em;

--- a/templates/blog/list.html
+++ b/templates/blog/list.html
@@ -107,7 +107,7 @@
                             {% for ticket in open_tickets %}
                                 <li>
                                     <div class="title">
-                                        <a href="{{ url('ticket', ticket.id) }}">{{ ticket.title|truncatechars_html(40) }}</a>
+                                        <a href="{{ url('ticket', ticket.id) }}">{{ ticket.title }}</a>
                                     </div>
                                     <div class="object">
                                         <a href="{{ ticket.linked_item.get_absolute_url() }}">


### PR DESCRIPTION
# Description

Type of change: bug fix

Before:
<img width="1400" height="215" alt="image" src="https://github.com/user-attachments/assets/d654b40b-4543-4352-8e8b-fef613f53ff6" />

After:
<img width="1357" height="250" alt="image" src="https://github.com/user-attachments/assets/5cf9d586-91aa-4556-b3ae-d87b3fb228c6" />


Fixes #554

# Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [ ] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
