### PR TITLE
feat(contest): limit number of problems in a contest

### DIFF
--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -136,6 +136,9 @@ VNOJ_LOW_POWER_MODE_CONFIG = {
     'heat_map_limit': 20_000,
 }
 
+# maximum number of problems in a contest
+MAX_CONTEST_PROBLEMS_COUNT = None
+
 VNOJ_MAGAZINE_TAG_SLUG = None
 
 CELERY_TIMEZONE = 'UTC'

--- a/judge/forms.py
+++ b/judge/forms.py
@@ -705,7 +705,19 @@ class ProposeContestProblemFormSet(
             ContestProblem,
             form=ProposeContestProblemForm,
             can_delete=True,
+            max_num=settings.MAX_CONTEST_PROBLEMS_COUNT,
+            validate_max=True,
         )):
+
+    def full_clean(self):
+        # Django < 5.0 doesn't support override the too_many_forms message in the constructor.
+        # So we have to do it ourselves
+        super().full_clean()
+
+        for error in self._non_form_errors.as_data():
+            if error.code == 'too_many_forms':
+                error.message = _('Contest cannot have more than %(limit)d problems.') % \
+                    {'limit': self.max_num}
 
     def clean(self) -> None:
         """Checks that no Contest problems have the same order."""

--- a/templates/contest/edit.html
+++ b/templates/contest/edit.html
@@ -225,12 +225,12 @@
     <form action="" method="post" class="form-area" style="display: flex; justify-content: center; flex-direction: column;">
         {% csrf_token %}
         {{ contest_problem_formset.management_form }}
-        <table class="django-as-table">{{ form.as_table() }}</table>
-        <hr>
-        <center><h3> {{ _('Problems') }} </h3></center>
         {% if contest_problem_formset.non_form_errors() %}
             {{ contest_problem_formset.non_form_errors() }}
         {% endif %}
+        <table class="django-as-table">{{ form.as_table() }}</table>
+        <hr>
+        <center><h3> {{ _('Problems') }} </h3></center>
         <table class="table">
             <thead>
                 <tr>


### PR DESCRIPTION
Limit contest problems to MAX_CONTEST_PROBLEMS_COUNT. All users are affected, **including superusers**. To add more than the limit, use the admin panel.

This also means that existing large contests will not be able to edit! They shouldn't have our mercy!!!!
<img width="722" height="178" alt="image" src="https://github.com/user-attachments/assets/a23f7fb9-05ad-438a-b9d9-81219da1f674" />

## Reason

Who on earth in their right mind would add 100+ problems to a contest?
<img width="454" height="188" alt="image" src="https://github.com/user-attachments/assets/41aa4a19-3c75-4745-bf13-9d97a026fad8" />