### PR TITLE
feat(webhook): support sending to thread, remove default webhook fallback

### DIFF
--- a/dmoj/throttle_discord_webhook.py
+++ b/dmoj/throttle_discord_webhook.py
@@ -68,10 +68,15 @@ class ThrottledDiscordWebhookHandler(logging.Handler):
         self.send_webhook(subject, message)
 
     def send_webhook(self, subject, message):
-        webhook = settings.DISCORD_WEBHOOK.get('on_error', None)
-        if webhook is None:
+        webhook_config = settings.DISCORD_WEBHOOK.get('on_error', None)
+        if webhook_config is None:
             return
-        webhook = DiscordWebhook(url=webhook, content=subject)
+        if isinstance(webhook_config, str):
+            webhook_config = {
+                'url': webhook_config,
+                'thread_id': None,
+            }
+        webhook = DiscordWebhook(url=webhook_config['url'], content=subject, thread_id=webhook_config['thread_id'])
         # Discord has a limit 8 MB file size for normal server (without boost)
         # Use 7MB just for safe.
         webhook.add_file(file=message[:7 * 1024 * 1024], filename='log.txt')

--- a/judge/tasks/webhook.py
+++ b/judge/tasks/webhook.py
@@ -18,14 +18,19 @@ __all__ = ('on_new_ticket', 'on_new_comment', 'on_new_problem', 'on_new_tag_prob
            'on_new_blogpost', 'on_new_ticket_message', 'on_long_queue')
 
 
-def get_webhook_url(event_name):
-    default = settings.DISCORD_WEBHOOK.get('default', None)
-    webhook = settings.DISCORD_WEBHOOK.get(event_name, default)
+def get_webhook_config(event_name):
+    webhook = settings.DISCORD_WEBHOOK.get(event_name, None)
+    # for backward compatibility, we support both string and dict format for webhook config
+    if isinstance(webhook, str):
+        return {
+            'url': webhook,
+            'thread_id': None,
+        }
     return webhook
 
 
-def send_webhook(webhook, title, description, author, color='03b2f8', **kwargs):
-    webhook = DiscordWebhook(url=webhook)
+def send_webhook(webhook_config, title, description, author, color='03b2f8', **kwargs):
+    webhook = DiscordWebhook(url=webhook_config['url'], thread_id=webhook_config['thread_id'])
 
     embed = DiscordEmbed(
         title=title,
@@ -47,8 +52,8 @@ def send_webhook(webhook, title, description, author, color='03b2f8', **kwargs):
 
 @shared_task
 def on_new_ticket(ticket_id, content_type_id, object_id, message):
-    webhook = get_webhook_url('on_new_ticket')
-    if webhook is None or settings.SITE_FULL_URL is None:
+    webhook_config = get_webhook_config('on_new_ticket')
+    if webhook_config is None or settings.SITE_FULL_URL is None:
         return
 
     ticket = Ticket.objects.get(pk=ticket_id)
@@ -63,13 +68,13 @@ def on_new_ticket(ticket_id, content_type_id, object_id, message):
     ticket_url = settings.SITE_FULL_URL + '/ticket/' + str(ticket_id)
     title = f'Title: [{ticket.title}]({ticket_url})'
     message = f'Message: {message}'
-    send_webhook(webhook, f'New ticket on {url}', title + '\n' + message[:100], ticket.user)
+    send_webhook(webhook_config, f'New ticket on {url}', title + '\n' + message[:100], ticket.user)
 
 
 @shared_task
 def on_new_ticket_message(message_id, ticket_id, message):
-    webhook = get_webhook_url('on_new_ticket_message')
-    if webhook is None or settings.SITE_FULL_URL is None:
+    webhook_config = get_webhook_config('on_new_ticket_message')
+    if webhook_config is None or settings.SITE_FULL_URL is None:
         return
 
     ticket_message = TicketMessage.objects.get(pk=message_id)
@@ -77,25 +82,25 @@ def on_new_ticket_message(message_id, ticket_id, message):
     ticket_url = settings.SITE_FULL_URL + '/ticket/' + str(ticket_id)
     message = f'Message: {message}'
 
-    send_webhook(webhook, f'New ticket reply on {ticket_url}', message[:100], ticket_message.user)
+    send_webhook(webhook_config, f'New ticket reply on {ticket_url}', message[:100], ticket_message.user)
 
 
 @shared_task
 def on_new_comment(comment_id):
-    webhook = get_webhook_url('on_new_comment')
-    if webhook is None or settings.SITE_FULL_URL is None:
+    webhook_config = get_webhook_config('on_new_comment')
+    if webhook_config is None or settings.SITE_FULL_URL is None:
         return
 
     comment = Comment.objects.get(pk=comment_id)
     url = settings.SITE_FULL_URL + comment.get_absolute_url()
-    send_webhook(webhook, f'New comment {url}', comment.body[:200], comment.author)
+    send_webhook(webhook_config, f'New comment {url}', comment.body[:200], comment.author)
 
 
 @shared_task
 def on_new_problem(problem_code, is_suggested=False):
     event_name = 'on_new_suggested_problem' if is_suggested else 'on_new_problem'
-    webhook = get_webhook_url(event_name)
-    if webhook is None or settings.SITE_FULL_URL is None:
+    webhook_config = get_webhook_config(event_name)
+    if webhook_config is None or settings.SITE_FULL_URL is None:
         return
 
     problem = Problem.objects.get(code=problem_code)
@@ -118,13 +123,13 @@ def on_new_problem(problem_code, is_suggested=False):
 
     description = '\n'.join(f'{opt}: {val}' for opt, val in description)
 
-    send_webhook(webhook, title, description, author)
+    send_webhook(webhook_config, title, description, author)
 
 
 @shared_task
 def on_new_tag_problem(problem_code):
-    webhook = get_webhook_url('on_new_tag_problem')
-    if webhook is None or settings.SITE_FULL_URL is None:
+    webhook_config = get_webhook_config('on_new_tag_problem')
+    if webhook_config is None or settings.SITE_FULL_URL is None:
         return
 
     problem = TagProblem.objects.get(code=problem_code)
@@ -132,13 +137,13 @@ def on_new_tag_problem(problem_code):
     description = f'Title: {problem.name}\n'
     description += f'Judge: {problem.judge}'
 
-    send_webhook(webhook, f'New tag problem {url}', description, None)
+    send_webhook(webhook_config, f'New tag problem {url}', description, None)
 
 
 @shared_task
 def on_new_tag(problem_code, tag_list):
-    webhook = get_webhook_url('on_new_tag')
-    if webhook is None or settings.SITE_FULL_URL is None:
+    webhook_config = get_webhook_config('on_new_tag')
+    if webhook_config is None or settings.SITE_FULL_URL is None:
         return
 
     problem = TagProblem.objects.get(code=problem_code)
@@ -152,13 +157,13 @@ def on_new_tag(problem_code, tag_list):
     description = f'Title: {problem.name}\n'
     description += f'New tag: {", ".join(tags)}'
 
-    send_webhook(webhook, f'New tag added for problem {url}', description, None)
+    send_webhook(webhook_config, f'New tag added for problem {url}', description, None)
 
 
 @shared_task
 def on_new_contest(contest_key):
-    webhook = get_webhook_url('on_new_contest')
-    if webhook is None or settings.SITE_FULL_URL is None:
+    webhook_config = get_webhook_config('on_new_contest')
+    if webhook_config is None or settings.SITE_FULL_URL is None:
         return
 
     contest = Contest.objects.get(key=contest_key)
@@ -182,13 +187,13 @@ def on_new_contest(contest_key):
 
     description = '\n'.join(f'{opt}: {val}' for opt, val in description)
 
-    send_webhook(webhook, title, description, author)
+    send_webhook(webhook_config, title, description, author)
 
 
 @shared_task
 def on_new_blogpost(blog_id):
-    webhook = get_webhook_url('on_new_blogpost')
-    if webhook is None or settings.SITE_FULL_URL is None:
+    webhook_config = get_webhook_config('on_new_blogpost')
+    if webhook_config is None or settings.SITE_FULL_URL is None:
         return
 
     blog = BlogPost.objects.get(pk=blog_id)
@@ -196,22 +201,22 @@ def on_new_blogpost(blog_id):
 
     description = f'Title: {blog.title}\n'
     description += f'Description: {blog.content[:200]}'
-    send_webhook(webhook, f'New blog post {url}', description, blog.authors.first())
+    send_webhook(webhook_config, f'New blog post {url}', description, blog.authors.first())
 
 
 @shared_task
 def on_long_queue():
-    webhook = get_webhook_url('on_long_queue')
-    if webhook is None or settings.SITE_FULL_URL is None:
+    webhook_config = get_webhook_config('on_long_queue')
+    if webhook_config is None or settings.SITE_FULL_URL is None:
         return
 
-    send_webhook(webhook, 'Long queue alert', None, None, url=f'{settings.SITE_FULL_URL}/submissions/?status=QU')
+    send_webhook(webhook_config, 'Long queue alert', None, None, url=f'{settings.SITE_FULL_URL}/submissions/?status=QU')
 
 
 @shared_task
 def queue_time_stats():
-    webhook_url = get_webhook_url('queue_time_stats')
-    if webhook_url is None:
+    webhook_config = get_webhook_config('queue_time_stats')
+    if webhook_config is None:
         return
 
     end_time = (datetime.now(pytz.timezone(settings.CELERY_TIMEZONE))
@@ -266,7 +271,7 @@ def queue_time_stats():
 
     embed = DiscordEmbed(title=f'Queue time, {start_time:%Y-%m-%d}', color='03b2f8')
     embed.set_image('attachment://chart.png')
-    webhook = DiscordWebhook(url=webhook_url)
+    webhook = DiscordWebhook(url=webhook_config.webhook_url)
     webhook.add_file(chart_bytes, 'chart.png')
     webhook.add_embed(embed)
     webhook.execute()


### PR DESCRIPTION
- support sending to thread
- remove default webhook fallback

The reason for remove the default fallback is at this stage we don't really want to track all the events. With the old implementation, there is no way to do that without remove the default settings