### PR TITLE
Limit BlogFeed to 25 blogs

### DIFF
--- a/judge/feed.py
+++ b/judge/feed.py
@@ -75,7 +75,9 @@ class BlogFeed(Feed):
     description = 'The latest blog posts from the %s' % settings.SITE_LONG_NAME
 
     def items(self):
-        return BlogPost.objects.filter(visible=True, publish_on__lte=timezone.now()).order_by('-sticky', '-publish_on')
+        return BlogPost.objects.filter(
+            visible=True, publish_on__lte=timezone.now(),
+        ).order_by('-sticky', '-publish_on')[:25]
 
     def item_title(self, post):
         return post.title


### PR DESCRIPTION
To make it the same length with other feeds, also avoid render all the available blog at once