### PR TITLE
Improve performance for new contests and new problems on the organization home page

### DIFF
--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -526,14 +526,14 @@ class OrganizationHome(TitleMixin, PublicOrganizationMixin, PostListBase):
            user.has_perm('judge.see_organization_problem') or \
            user.has_perm('judge.edit_all_problem'):
             context['new_problems'] = Problem.objects.filter(
-                is_public=True, is_organization_private=True,
+                is_public=True,
                 organization=self.object) \
-                .order_by('-date', '-id')[:settings.DMOJ_BLOG_NEW_PROBLEM_COUNT]
+                .order_by('-id')[:settings.DMOJ_BLOG_NEW_PROBLEM_COUNT]
 
         see_private_contest = user.has_perm('judge.see_private_contest') or user.has_perm('judge.edit_all_contest')
         if context['is_member'] or see_private_contest:
             new_contests = Contest.objects.filter(
-                is_visible=True, is_organization_private=True,
+                is_visible=True,
                 organization=self.object) \
                 .order_by('-end_time', '-id')
 


### PR DESCRIPTION
Don't need to query for `is_organization_private`, since all org problem and contest have that set to True, so filter by org is enough