### PR TITLE
Change PrivateContestError to inherit from PermissionDenied

### DIFF
--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -156,7 +156,7 @@ class ContestList(InfinitePaginationMixin, TitleMixin, ContestListMixin, ListVie
         return context
 
 
-class PrivateContestError(Exception):
+class PrivateContestError(PermissionDenied):
     def __init__(self, name, is_private, is_organization_private, org):
         self.name = name
         self.is_private = is_private


### PR DESCRIPTION
Avoid this bug from #594 
<img width="1189" height="241" alt="image" src="https://github.com/user-attachments/assets/43fff79d-d964-4f55-9fcd-c5cc4c8c86f3" />

Now if user don't have permission, it will show the generic 403 page, which is below:
<img width="685" height="240" alt="image" src="https://github.com/user-attachments/assets/2a0c6436-a009-453b-9541-9c038ebfe723" />
