### PR TITLE
Show generic message page for 403 error, add go back

### DIFF
--- a/judge/views/error.py
+++ b/judge/views/error.py
@@ -9,7 +9,6 @@ def error(request, context, status):
 
 
 def error404(request, exception=None):
-    # TODO: "panic: go back"
     return render(request, 'generic-message.html', {
         'title': _('404 error'),
         'message': _('Could not find page "%s"') % request.path,
@@ -17,11 +16,10 @@ def error404(request, exception=None):
 
 
 def error403(request, exception=None):
-    return error(request, {
-        'id': 'unauthorized_access',
-        'description': _('no permission for %s') % request.path,
-        'code': 403,
-    }, 403)
+    return render(request, 'generic-message.html', {
+        'title': _('403 error'),
+        'message': _('No permission for "%s"') % request.path,
+    }, status=403)
 
 
 def error500(request):

--- a/templates/generic-message.html
+++ b/templates/generic-message.html
@@ -2,4 +2,5 @@
 
 {% block body %}
     <pre style="font-weight: 400; font-size: 1.4em;">{{ message }}</pre>
+    <a href="javascript:history.back()">{{ _('Go back') }}</a>
 {% endblock %}


### PR DESCRIPTION
the old page scared a lot of users, they thought that it's our issue 
<img width="457" height="170" alt="image" src="https://github.com/user-attachments/assets/5f09a24a-9df2-4902-ae29-19cdf01fd0da" />

After:
<img width="727" height="191" alt="image" src="https://github.com/user-attachments/assets/30b6c75b-76f4-4eb7-9751-7e41f1b2289f" />
