### PR TITLE
bridge: use delta update for available problems

### DIFF
--- a/judge/bridge/judge_handler.py
+++ b/judge/bridge/judge_handler.py
@@ -326,12 +326,21 @@ class JudgeHandler(ZlibPacketHandler):
         if not Submission.objects.filter(id=id).update(batch=True):
             logger.warning('Unknown submission: %s', id)
 
-    def update_problems(self, problems, problem_ids):
+    def update_problems(
+        self,
+        new_problems=set(),
+        new_problem_ids=set(),
+        deleted_problems=set(),
+        deleted_problem_ids=set(),
+    ):
         logger.info('%s: Updating problem list', self.name)
-        self.problems = problems
-        self.judge.problems.set(problem_ids)
-        logger.info('%s: Updated %d problems', self.name, len(problem_ids))
-        json_log.info(self._make_json_log(action='update-problems', count=len(problem_ids)))
+        self.problems = (new_problems | self.problems) - deleted_problems
+        if new_problem_ids:
+            self.judge.problems.add(*new_problem_ids)
+        if deleted_problem_ids:
+            self.judge.problems.remove(*deleted_problem_ids)
+        logger.info('%s: Updated %d problems', self.name, len(self.problems))
+        json_log.info(self._make_json_log(action='update-problems', count=len(self.problems)))
 
     def on_supported_problems(self, packet):
         if self.ignore_problems_packet:

--- a/judge/bridge/judge_handler.py
+++ b/judge/bridge/judge_handler.py
@@ -335,10 +335,10 @@ class JudgeHandler(ZlibPacketHandler):
 
     def update_problems(
         self,
-        new_problems=frozenset(),
-        new_problem_ids=frozenset(),
-        deleted_problems=frozenset(),
-        deleted_problem_ids=frozenset(),
+        new_problems,
+        new_problem_ids,
+        deleted_problems,
+        deleted_problem_ids,
     ):
         logger.info('%s: Updating problem list', self.name)
         self.problems = (new_problems | self.problems) - deleted_problems

--- a/judge/bridge/judge_handler.py
+++ b/judge/bridge/judge_handler.py
@@ -326,12 +326,19 @@ class JudgeHandler(ZlibPacketHandler):
         if not Submission.objects.filter(id=id).update(batch=True):
             logger.warning('Unknown submission: %s', id)
 
+    def replace_problems(self, problems, problem_ids):
+        logger.info('%s: Replacing problem list', self.name)
+        self.problems = problems
+        self.judge.problems.set(problem_ids)
+        logger.info('%s: Replaced %d problems', self.name, len(self.problems))
+        json_log.info(self._make_json_log(action='update-problems', count=len(self.problems)))
+
     def update_problems(
         self,
-        new_problems=set(),
-        new_problem_ids=set(),
-        deleted_problems=set(),
-        deleted_problem_ids=set(),
+        new_problems=frozenset(),
+        new_problem_ids=frozenset(),
+        deleted_problems=frozenset(),
+        deleted_problem_ids=frozenset(),
     ):
         logger.info('%s: Updating problem list', self.name)
         self.problems = (new_problems | self.problems) - deleted_problems

--- a/judge/bridge/judge_list.py
+++ b/judge/bridge/judge_list.py
@@ -30,7 +30,7 @@ class JudgeList(object):
         self.lock = RLock()
         self.min_tier = None
         self.problems = set()
-        self.problem_ids = []
+        self.problem_ids = set()
 
     def _handle_free_judge(self, judge):
         with self.lock:
@@ -109,12 +109,22 @@ class JudgeList(object):
                 if judge.name == judge_id:
                     judge.disconnect(force=force)
 
-    def update_problems_all(self, problems, problem_ids):
+    def update_problems_all(
+        self,
+        new_problems=set(),
+        new_problem_ids=set(),
+        deleted_problems=set(),
+        deleted_problem_ids=set(),
+    ):
         with self.lock:
-            self.problems = problems
-            self.problem_ids = problem_ids
+            self.problems = (self.problems | new_problems) - deleted_problems
+            self.problem_ids = (
+                self.problem_ids | new_problem_ids
+            ) - deleted_problem_ids
             for judge in self.judges:
-                judge.update_problems(problems, problem_ids)
+                judge.update_problems(
+                    new_problems, new_problem_ids, deleted_problems, deleted_problem_ids,
+                )
                 if not judge.working:
                     self._handle_free_judge(judge)
 

--- a/judge/bridge/judge_list.py
+++ b/judge/bridge/judge_list.py
@@ -111,10 +111,10 @@ class JudgeList(object):
 
     def update_problems_all(
         self,
-        new_problems=frozenset(),
-        new_problem_ids=frozenset(),
-        deleted_problems=frozenset(),
-        deleted_problem_ids=frozenset(),
+        new_problems,
+        new_problem_ids,
+        deleted_problems,
+        deleted_problem_ids,
     ):
         with self.lock:
             self.problems = (self.problems | new_problems) - deleted_problems

--- a/judge/bridge/judge_list.py
+++ b/judge/bridge/judge_list.py
@@ -111,10 +111,10 @@ class JudgeList(object):
 
     def update_problems_all(
         self,
-        new_problems=set(),
-        new_problem_ids=set(),
-        deleted_problems=set(),
-        deleted_problem_ids=set(),
+        new_problems=frozenset(),
+        new_problem_ids=frozenset(),
+        deleted_problems=frozenset(),
+        deleted_problem_ids=frozenset(),
     ):
         with self.lock:
             self.problems = (self.problems | new_problems) - deleted_problems
@@ -130,7 +130,7 @@ class JudgeList(object):
 
     def update_problems(self, judge, problems, problem_ids):
         with self.lock:
-            judge.update_problems(problems, problem_ids)
+            judge.replace_problems(problems, problem_ids)
             if not judge.working:
                 self._handle_free_judge(judge)
 

--- a/judge/bridge/monitor.py
+++ b/judge/bridge/monitor.py
@@ -88,20 +88,24 @@ class Monitor:
                     problems.append(problem)
         problems = set(problems)
 
-        new_problems = self.problems ^ problems
+        new_problems = problems - self.problems
         deleted_problems = self.problems - problems
 
         _ensure_connection()
 
-        if new_problems:
-            new_problem_ids = list(Problem.objects.filter(code__in=list(new_problems)).values_list('id', flat=True))
-            self.judges.update_problems_all(new_problems=new_problems, new_problem_ids=new_problem_ids)
-
-        if deleted_problems:
-            deleted_problem_ids = list(
-                Problem.objects.filter(code__in=list(deleted_problems)).values_list('id', flat=True),
+        if new_problems or deleted_problems:
+            new_problem_ids = set(
+                Problem.objects.filter(code__in=new_problems).values_list('id', flat=True),
+            ) if new_problems else set()
+            deleted_problem_ids = set(
+                Problem.objects.filter(code__in=deleted_problems).values_list('id', flat=True),
+            ) if deleted_problems else set()
+            self.judges.update_problems_all(
+                new_problems=new_problems,
+                new_problem_ids=new_problem_ids,
+                deleted_problems=deleted_problems,
+                deleted_problem_ids=deleted_problem_ids,
             )
-            self.judges.update_problems_all(deleted_problems=deleted_problems, deleted_problem_ids=deleted_problem_ids)
 
         self.problems = problems
 

--- a/judge/bridge/monitor.py
+++ b/judge/bridge/monitor.py
@@ -65,6 +65,7 @@ class Monitor:
 
         self.judges = judges
         self.problem_globs = problem_globs
+        self.problems = set()
 
         self.updater_exit = False
         self.updater_signal = threading.Event()
@@ -87,9 +88,22 @@ class Monitor:
                     problems.append(problem)
         problems = set(problems)
 
+        new_problems = self.problems ^ problems
+        deleted_problems = self.problems - problems
+
         _ensure_connection()
-        problem_ids = list(Problem.objects.filter(code__in=list(problems)).values_list('id', flat=True))
-        self.judges.update_problems_all(problems, problem_ids)
+
+        if new_problems:
+            new_problem_ids = list(Problem.objects.filter(code__in=list(new_problems)).values_list('id', flat=True))
+            self.judges.update_problems_all(new_problems=new_problems, new_problem_ids=new_problem_ids)
+
+        if deleted_problems:
+            deleted_problem_ids = list(
+                Problem.objects.filter(code__in=list(deleted_problems)).values_list('id', flat=True),
+            )
+            self.judges.update_problems_all(deleted_problems=deleted_problems, deleted_problem_ids=deleted_problem_ids)
+
+        self.problems = problems
 
     def updater_thread(self) -> None:
         while True:


### PR DESCRIPTION
Instead of writing all the problem ids to the database (100k+ problems), we write only the new problems or the problems that get deleted.

- [x] tested