### PR TITLE
Add autofill replies in tickets

### DIFF
--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -66,6 +66,33 @@ VNOJ_CP_COMMENT = 1   # Each comment vote equals 1 CP
 VNOJ_CP_TICKET = 10   # Each good ticket equals CP
 VNOJ_CP_PROBLEM = 20  # Each suggested problem equal 20 CP
 
+TICKET_AUTOFILL_REPLIES = [
+    {'en': 'No comments',
+     'vi': 'Không có nhận xét'},
+    {'en': 'Read the problem statement',
+     'vi': 'Đọc đề bài'},
+    {'en': 'Yes',
+     'vi': 'Có'},
+    {'en': 'No',
+     'vi': 'Không'},
+    {'en': 'Use English, please',
+     'vi': 'Vui lòng sử dụng tiếng Anh'},
+    {'en': 'Use Vietnamese, please',
+     'vi': 'Vui lòng sử dụng tiếng Việt'},
+    {'en': 'We could not understand your question',
+     'vi': 'Chúng tôi không hiểu câu hỏi của bạn'},
+    {'en': 'Read the global announcement',
+     'vi': 'Đọc thông báo chung'},
+    {'en': 'Unfortunately, we cannot answer this, as it will give you an unfair advantage',
+     'vi': 'Rất tiếc, chúng tôi không thể trả lời vì điều này sẽ tạo ra lợi thế không công bằng cho bạn'},
+    {'en': 'Your logic or calculations are incorrect, please check carefully',
+     'vi': 'Logic hoặc tính toán của bạn không chính xác, vui lòng kiểm tra lại'},
+    {'en': 'The examples and notes are correct',
+     'vi': 'Các ví dụ và ghi chú đều đúng'},
+    {'en': 'There is a queue of submissions being judged, please wait for your turn',
+     'vi': 'Đang có hàng đợi chấm bài, vui lòng chờ đến lượt của bạn'},
+]
+
 VNOJ_HOMEPAGE_TOP_USERS_COUNT = 5
 
 VNOJ_DISPLAY_RANKS = (

--- a/judge/views/ticket.py
+++ b/judge/views/ticket.py
@@ -194,6 +194,8 @@ class TicketView(TitleMixin, TicketMixin, SingleObjectFormView):
         context = super(TicketView, self).get_context_data(**kwargs)
         context['ticket_messages'] = self.object.messages.select_related('user__user')
         context['assignees'] = self.object.assignees.select_related('user', 'display_badge')
+        if self.request.user.is_staff:
+            context['autofill_replies'] = json.dumps(getattr(settings, 'TICKET_AUTOFILL_REPLIES', []))
         return context
 
 

--- a/resources/ticket.scss
+++ b/resources/ticket.scss
@@ -222,3 +222,12 @@ div.ticket-title {
 .new-message .button, #edit-notes .submit {
     margin: 10px 0 0 auto;
 }
+
+.auto-reply {
+    margin: 10px 0;
+    padding: 10px;
+    border: 1px $color_primary50 solid;
+    border-radius: 5px;
+    background: $color_primary10;
+    cursor: pointer;
+}

--- a/resources/ticket.scss
+++ b/resources/ticket.scss
@@ -231,3 +231,98 @@ div.ticket-title {
     background: $color_primary10;
     cursor: pointer;
 }
+
+.autofill-popup-wrap { position: relative; }
+
+.autofill-trigger {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: #fff;
+    border: 1px solid $color_primary25;
+    border-radius: $widget_border_radius;
+    padding: 6px 10px;
+    cursor: pointer;
+    width: 100%;
+    box-sizing: border-box;
+    user-select: none;
+    color: $color_primary33;
+    font-size: 0.88rem;
+
+    .trigger-text {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        flex: 1;
+    }
+
+    &.has-value { color: $color_primary90; }
+}
+
+.autofill-popup {
+    display: none;
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    min-width: 300px;
+    background: $color_primary0;
+    border: 1px solid $color_primary25;
+    border-radius: $widget_border_radius;
+    box-shadow: 0 4px 16px rgba(0,0,0,.15);
+    z-index: 9999;
+
+    &.open { display: block; }
+}
+
+.autofill-search {
+    width: 100%;
+    border: none;
+    border-bottom: 1px solid $color_primary10;
+    padding: 8px 10px;
+    outline: none;
+    box-sizing: border-box;
+}
+
+.autofill-list { max-height: 280px; overflow-y: auto; }
+
+.autofill-item {
+    padding: 8px 12px;
+    cursor: pointer;
+    border-bottom: 1px solid $color_primary5;
+
+    &:last-child { border-bottom: none; }
+    &:hover, &.active { background: $color_info25; }
+
+    .item-vi { font-size: 0.78rem; color: $color_primary50; margin-top: 1px; }
+}
+
+.autofill-no-results { padding: 10px; color: $color_primary33; font-size: 0.85rem; text-align: center; }
+
+.autofill-controls { display: flex; align-items: center; gap: 0.4rem; margin-top: 0.4rem; }
+
+.lang-toggle { padding: 3px 10px; font-size: 0.75rem; }
+.lang-toggle:not(.active) { opacity: 0.45; }
+
+@media (max-width: 768px) {
+    .ticket-messages {
+        width: 100% !important;
+        margin-bottom: 1rem;
+    }
+
+    .new-message .detail { padding: 0.75rem; }
+    .new-message form { width: 100%; }
+
+    .body-block textarea,
+    .body-block .form-control {
+        width: 100% !important;
+        max-width: 100% !important;
+        box-sizing: border-box;
+    }
+}
+
+@media (max-width: 480px) {
+    .new-message { flex-direction: column; }
+    .new-message .info .user-info { display: none; }
+    .new-message .detail { width: 100%; padding: 0.5rem; }
+}

--- a/templates/ticket/ticket.html
+++ b/templates/ticket/ticket.html
@@ -1,5 +1,45 @@
 {% extends "base.html" %}
-{% block media %}{{ form.media.css }}{% endblock %}
+{% block media %}
+    {{ form.media.css }}
+    <style>
+        @media (max-width: 768px) {
+            .ticket-messages {
+                width: 100% !important;
+                margin-bottom: 1rem;
+            }
+
+            .new-message .detail {
+                padding: 0.75rem;
+            }
+
+            .new-message form {
+                width: 100%;
+            }
+
+            .body-block textarea,
+            .body-block .form-control {
+                width: 100% !important;
+                max-width: 100% !important;
+                box-sizing: border-box;
+            }
+        }
+
+        @media (max-width: 480px) {
+            .new-message {
+                flex-direction: column;
+            }
+
+            .new-message .info .user-info {
+                display: none;
+            }
+
+            .new-message .detail {
+                width: 100%;
+                padding: 0.5rem;
+            }
+        }
+    </style>
+{% endblock %}
 
 {% block js_media %}
     {{ form.media.js }}
@@ -155,7 +195,7 @@
             }
 
             window.add_autofill_reply = function (message) {
-                $('#id_body').val(message);
+                ace.edit('martor-body').setValue(message);
             }
 
             $('.autofill-options').select2({
@@ -223,11 +263,20 @@
                 {% endfor %}
             </main>
             <hr>
+
             <section class="ticket-message new-message">
                 <div class="info">
-                    <a href="{{ url('user_page', request.user.username) }}" class="user">
-                        <img src="{{ gravatar(request.user, 80) }}" class="user-gravatar">
-                    </a>
+                    <div class="user-info">
+                        <a href="{{ url('user_page', request.user.username) }}" class="user">
+                            <img src="{{ gravatar(request.user, 80) }}" class="user-gravatar">
+                        </a>
+                    </div>
+                    <div class="autofill">
+                        <h4 style="margin-top: 1.2em;">Autofill</h4>
+                        <select class="autofill-options" style="width: 100%;">
+                        </select>
+                        <button onclick="add_reply()">Add</button>
+                    </div>
                 </div>
                 <div class="detail">
                     <form action="" method="post">
@@ -294,12 +343,6 @@
                         {% if not ticket.is_open %}style="display: none"{% endif %}>{{ _('Close ticket') }}</button>
                 <button data-ajax="{{ url('ticket_open', ticket.id) }}" data-open="1" class="open-ticket"
                         {% if ticket.is_open %}style="display: none"{% endif %}>{{ _('Reopen ticket') }}</button>
-            </div>
-            <div>
-                <h4 style="margin-top: 1.2em;">Autofill</h4>
-                <select class="autofill-options" style="width: 100%;">
-                </select>
-                <button onclick="add_reply()">Add</button>
             </div>
         </aside>
     </div>

--- a/templates/ticket/ticket.html
+++ b/templates/ticket/ticket.html
@@ -153,6 +153,42 @@
                     }
                 );
             }
+
+            window.add_autofill_reply = function (message) {
+                $('#id_body').val(message);
+            }
+
+            $('.autofill-options').select2({
+                theme: '{{ DMOJ_SELECT2_THEME }}',
+                multiple: false,
+                closeOnSelect: true,
+                placeholder: '{{ _('Select reply') }}',
+            });
+
+            const selection = $('.autofill-options').data().select2.selection;
+            const results = $('.autofill-options').data().select2.results;
+
+            $('.autofill-options').on('select2:selecting', function(e) {
+                console.log(e);
+            });
+
+            window.get_options = function() {
+                const options = ["No coments", "Read the problem statement", "Yes", "No", "Question is unclear", "Read the global announcement"];
+                let reply_options = $('.autofill-options');
+                reply_options.empty();
+                options.forEach(function(option) {
+                    reply_options.append($('<option>', {
+                        value: option,
+                        text: option
+                    }));
+                });
+            }
+            window.get_options();
+
+            window.add_reply = function() {
+                const reply = $('.autofill-options').val();
+                add_autofill_reply(reply);
+            }
         });
     </script>
 
@@ -258,6 +294,12 @@
                         {% if not ticket.is_open %}style="display: none"{% endif %}>{{ _('Close ticket') }}</button>
                 <button data-ajax="{{ url('ticket_open', ticket.id) }}" data-open="1" class="open-ticket"
                         {% if ticket.is_open %}style="display: none"{% endif %}>{{ _('Reopen ticket') }}</button>
+            </div>
+            <div>
+                <h4 style="margin-top: 1.2em;">Autofill</h4>
+                <select class="autofill-options" style="width: 100%;">
+                </select>
+                <button onclick="add_reply()">Add</button>
             </div>
         </aside>
     </div>

--- a/templates/ticket/ticket.html
+++ b/templates/ticket/ticket.html
@@ -1,45 +1,5 @@
 {% extends "base.html" %}
-{% block media %}
-    {{ form.media.css }}
-    <style>
-        @media (max-width: 768px) {
-            .ticket-messages {
-                width: 100% !important;
-                margin-bottom: 1rem;
-            }
-
-            .new-message .detail {
-                padding: 0.75rem;
-            }
-
-            .new-message form {
-                width: 100%;
-            }
-
-            .body-block textarea,
-            .body-block .form-control {
-                width: 100% !important;
-                max-width: 100% !important;
-                box-sizing: border-box;
-            }
-        }
-
-        @media (max-width: 480px) {
-            .new-message {
-                flex-direction: column;
-            }
-
-            .new-message .info .user-info {
-                display: none;
-            }
-
-            .new-message .detail {
-                width: 100%;
-                padding: 0.5rem;
-            }
-        }
-    </style>
-{% endblock %}
+{% block media %}{{ form.media.css }}{% endblock %}
 
 {% block js_media %}
     {{ form.media.js }}
@@ -198,37 +158,81 @@
                 ace.edit('martor-body').setValue(message);
             }
 
-            $('.autofill-options').select2({
-                theme: '{{ DMOJ_SELECT2_THEME }}',
-                multiple: false,
-                closeOnSelect: true,
-                placeholder: '{{ _('Select reply') }}',
-            });
+            const AUTOFILL_OPTIONS = {{ autofill_replies|safe }};
 
-            const selection = $('.autofill-options').data().select2.selection;
-            const results = $('.autofill-options').data().select2.results;
+            var selectedIdx = null;
 
-            $('.autofill-options').on('select2:selecting', function(e) {
-                console.log(e);
-            });
+            function updateTriggerText() {
+                if (selectedIdx === null) return;
+                var opt = AUTOFILL_OPTIONS[selectedIdx];
+                var lang = $('.lang-toggle.active').data('lang');
+                $('.autofill-trigger').addClass('has-value')
+                    .find('.trigger-text').text(lang === 'vi' ? opt.vi : opt.en);
+            }
 
-            window.get_options = function() {
-                const options = ["No coments", "Read the problem statement", "Yes", "No", "Question is unclear", "Read the global announcement"];
-                let reply_options = $('.autofill-options');
-                reply_options.empty();
-                options.forEach(function(option) {
-                    reply_options.append($('<option>', {
-                        value: option,
-                        text: option
-                    }));
+            function renderList(filter) {
+                var $list = $('.autofill-list').empty();
+                var query = (filter || '').toLowerCase();
+                var count = 0;
+                AUTOFILL_OPTIONS.forEach(function(opt, i) {
+                    if (query && !opt.en.toLowerCase().includes(query) && !opt.vi.toLowerCase().includes(query)) return;
+                    var $item = $('<div class="autofill-item">').attr('data-idx', i);
+                    if (i === selectedIdx) $item.addClass('active');
+                    $item.append($('<div class="item-en">').text(opt.en));
+                    $item.append($('<div class="item-vi">').text(opt.vi));
+                    $item.on('click', function() {
+                        selectedIdx = i;
+                        updateTriggerText();
+                        closePopup();
+                        insertSelected();
+                    });
+                    $list.append($item);
+                    count++;
                 });
+                if (count === 0) {
+                    $list.append($('<div class="autofill-no-results">').text('No results'));
+                }
             }
-            window.get_options();
 
-            window.add_reply = function() {
-                const reply = $('.autofill-options').val();
-                add_autofill_reply(reply);
+            function openPopup() {
+                renderList('');
+                $('.autofill-search').val('');
+                $('.autofill-popup').addClass('open');
+                $('.autofill-search').focus();
             }
+
+            function closePopup() {
+                $('.autofill-popup').removeClass('open');
+            }
+
+            $('.autofill-trigger').on('click', function(e) {
+                e.stopPropagation();
+                $('.autofill-popup').hasClass('open') ? closePopup() : openPopup();
+            });
+
+            $('.autofill-popup').on('click', function(e) {
+                e.stopPropagation();
+            });
+
+            $('.autofill-search').on('input', function() {
+                renderList($(this).val());
+            });
+
+            $(document).on('click', closePopup);
+
+            function insertSelected() {
+                if (selectedIdx === null) return;
+                var option = AUTOFILL_OPTIONS[selectedIdx];
+                var lang = $('.lang-toggle.active').data('lang');
+                add_autofill_reply(lang === 'vi' ? option.vi : option.en);
+            }
+
+            $('.lang-toggle').on('click', function() {
+                $('.lang-toggle').removeClass('active');
+                $(this).addClass('active');
+                updateTriggerText();
+                insertSelected();
+            });
         });
     </script>
 
@@ -271,12 +275,25 @@
                             <img src="{{ gravatar(request.user, 80) }}" class="user-gravatar">
                         </a>
                     </div>
-                    <div class="autofill">
-                        <h4 style="margin-top: 1.2em;">Autofill</h4>
-                        <select class="autofill-options" style="width: 100%;">
-                        </select>
-                        <button onclick="add_reply()">Add</button>
-                    </div>
+                    {% if autofill_replies %}
+                        <div class="autofill">
+                            <h4 style="margin-top: 1.2em;">Autofill</h4>
+                            <div class="autofill-popup-wrap">
+                                <div class="autofill-trigger" tabindex="0" role="combobox">
+                                    <span class="trigger-text">Select reply...</span>
+                                    <i class="fa fa-chevron-down" style="font-size:0.7rem;margin-left:6px;"></i>
+                                </div>
+                                <div class="autofill-popup">
+                                    <input class="autofill-search" type="text" placeholder="Search...">
+                                    <div class="autofill-list"></div>
+                                </div>
+                            </div>
+                            <div class="autofill-controls">
+                                <button class="lang-toggle active" data-lang="en">EN</button>
+                                <button class="lang-toggle" data-lang="vi">VI</button>
+                            </div>
+                        </div>
+                    {% endif %}
                 </div>
                 <div class="detail">
                     <form action="" method="post">


### PR DESCRIPTION
- **Add autofill replies in tickets (#359)**
- **[misc] improve css for small screen in ticket, fix bug autofill**
- **Improve UI, use autofil from settings**

Improve the old #359 that merged into icpc branch

Now the autofill can be choose between vi/en language, the selection looks nicer too

<img width="627" height="526" alt="image" src="https://github.com/user-attachments/assets/51413c5f-4a7f-440a-b714-1a495c26804a" />


The options could be set by changing the `TICKET_AUTOFILL_REPLIES` in the settings

