### PR TITLE
Allow contest editors to public problems

### DIFF
--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -1431,7 +1431,7 @@ class ContestProblemMakePublic(LoginRequiredMixin, ContestMixin, SingleObjectMix
     def post(self, request, *args, **kwargs):
         contest = self.get_object()
 
-        if not request.user.is_staff or not contest.is_editable_by(request.user):
+        if not contest.is_editable_by(request.user):
             raise PermissionDenied(_('You do not have permission to edit this contest.'))
 
         now = timezone.now()

--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -185,7 +185,7 @@
     {% if is_in_contest or contest.ended or request.user.is_superuser or is_editor or is_tester %}
         <div class="contest-problems">
             <h2 style="margin-bottom: 0.2em; float:left;"><i class="fa fa-fw fa-question-circle"></i>{{ _('Problems') }} </h2>
-            {% if can_edit and request.user.is_staff %}
+            {% if can_edit %}
                 <form method="post" action="{{ url('contest_problems_make_public', contest.key) }}" style="display: inline; float:right; margin-left: 10px;">
                     {% csrf_token %}
                     <button type="submit" class="button" onclick="return confirm('{{ _('Are you sure you want to make all problems in this contest public?') }}');">


### PR DESCRIPTION
Remove the staff status check; more organization authors could publish problems via the button.

This action is quite dangerous if the contest is ongoing, though. Should we have a 'Type X to confirm' instead of clicking OK? That's for another PR if needed.