### PR TITLE
bridged: use 3 decimals for points, fix #495

### DIFF
--- a/judge/bridge/judge_handler.py
+++ b/judge/bridge/judge_handler.py
@@ -436,8 +436,8 @@ class JudgeHandler(ZlibPacketHandler):
             points += batches[i][0]
             total += batches[i][1]
 
-        points = round(points, 1)
-        total = round(total, 1)
+        points = round(points, 3)
+        total = round(total, 3)
         submission.case_points = points
         submission.case_total = total
 


### PR DESCRIPTION
Site and other place are using 3 decimals for point precision, however bridge is still using 1, which is unexpected for a lot of users

fix #495 