### PR TITLE
fix: remove extra format arg in MOSS error

### DIFF
--- a/judge/tasks/contest.py
+++ b/judge/tasks/contest.py
@@ -76,7 +76,7 @@ def run_moss(self, contest_key):
                         result.url = moss_call.process()
                         result.submission_count = len(users)
                     except Exception:
-                        logger.exception('Error running MOSS for %s - %s: %s', contest.key, problem.code)
+                        logger.exception('Error running MOSS for %s - %s', contest.key, problem.code)
 
                 moss_results.append(result)
                 p.did(1)


### PR DESCRIPTION
The extra format arg in MOSS error log is causing an uncatched error, leads to failed job