### PR TITLE
Show org admin in org homepage

### DIFF
--- a/judge/jinja2/reference.py
+++ b/judge/jinja2/reference.py
@@ -4,6 +4,7 @@ from urllib.parse import urljoin
 
 from ansi2html import Ansi2HTMLConverter
 from django.contrib.auth.models import AbstractUser
+from django.db.models import QuerySet
 from django.urls import reverse
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
@@ -169,6 +170,10 @@ def link_user(user):
 @registry.function
 @registry.render_with('user/link-list.html')
 def link_users(users):
+    if isinstance(users, QuerySet) and users.model == Profile:
+        if not users.query.select_related:
+            users = users.select_related('user', 'display_badge')
+
     return {'users': users}
 
 

--- a/templates/organization/home.html
+++ b/templates/organization/home.html
@@ -132,6 +132,9 @@
                         <div>
                             <a href="{{ url('admin:judge_organization_change', organization.id) }}">{{ _('Admin organization') }}</a>
                         </div>
+                        <div>
+                            {{ link_users(organization.admins.all()) }}
+                        </div>
                     {% endif %}
                 </div>
             </div>


### PR DESCRIPTION
Also improve `link_users` to avoid n + 1 issue

<img width="397" height="280" alt="image" src="https://github.com/user-attachments/assets/baf5651f-a77c-45e5-b22d-41c0ad7f3d17" />
