### PR TITLE
Fix n+1 query issue for link_users

### DIFF
--- a/judge/jinja2/reference.py
+++ b/judge/jinja2/reference.py
@@ -170,10 +170,6 @@ def link_user(user):
 @registry.function
 @registry.render_with('user/link-list.html')
 def link_users(users):
-    if isinstance(users, QuerySet) and users.model == Profile:
-        if not users.query.select_related:
-            users = users.select_related('user', 'display_badge')
-
     return {'users': users}
 
 

--- a/judge/jinja2/reference.py
+++ b/judge/jinja2/reference.py
@@ -4,7 +4,6 @@ from urllib.parse import urljoin
 
 from ansi2html import Ansi2HTMLConverter
 from django.contrib.auth.models import AbstractUser
-from django.db.models import QuerySet
 from django.urls import reverse
 from django.utils.html import escape
 from django.utils.safestring import mark_safe

--- a/judge/views/blog.py
+++ b/judge/views/blog.py
@@ -154,7 +154,7 @@ class ModernBlogList(PostListBase):
 
     def get_queryset(self):
         queryset = super(ModernBlogList, self).get_queryset()
-        queryset = queryset.filter(global_post=True)
+        queryset = queryset.prefetch_related('tags').filter(global_post=True)
 
         # Search functionality
         search_query = self.request.GET.get('q', '').strip()
@@ -169,29 +169,12 @@ class ModernBlogList(PostListBase):
         tag_slug = self.request.GET.get('tag', '').strip()
         if not tag_slug and settings.VNOJ_MAGAZINE_TAG_SLUG:
             tag_slug = settings.VNOJ_MAGAZINE_TAG_SLUG
-        queryset = queryset.filter(tags__slug=tag_slug).distinct()
+        queryset = queryset.filter(tags__slug=tag_slug)
 
         # Sort functionality
         sort_by = self.request.GET.get('sort', 'latest').strip()
         if sort_by == 'top':
             queryset = queryset.order_by('-score', '-publish_on')
-        elif sort_by == 'discussed':
-            comment_counts = dict(
-                Comment.objects
-                .filter(page__startswith='b:', hidden=False)
-                .values_list('page')
-                .annotate(count=Count('page')),
-            )
-
-            post_comment_map = {}
-            for page, count in comment_counts.items():
-                post_id = int(page[2:])
-                post_comment_map[post_id] = count
-
-            posts = list(queryset)
-            posts.sort(key=lambda p: post_comment_map.get(p.id, 0), reverse=True)
-
-            return posts
         else:
             queryset = queryset.order_by('-sticky', '-publish_on')
 
@@ -211,21 +194,6 @@ class ModernBlogList(PostListBase):
             context['tags'] = BlogPostTag.objects.exclude(slug=settings.VNOJ_MAGAZINE_TAG_SLUG)
         else:
             context['tags'] = []
-
-        # Get vote information for each post
-        post_ids = [post.id for post in context['posts']]
-        post_votes = {}
-        for post_id in post_ids:
-            upvotes = BlogVote.objects.filter(blog_id=post_id, score=1).select_related('voter__user')
-            downvotes = BlogVote.objects.filter(blog_id=post_id, score=-1).select_related('voter__user')
-            post_votes[post_id] = {
-                'upvoters': list(upvotes.values_list('voter__user__username', flat=True)[:10]),
-                'downvoters': list(downvotes.values_list('voter__user__username', flat=True)[:10]),
-                'upvote_count': upvotes.count(),
-                'downvote_count': downvotes.count(),
-            }
-        context['post_votes'] = post_votes
-
         return context
 
 

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -54,7 +54,7 @@ class OrganizationMixin(object):
 
     @cached_property
     def organization(self):
-        return get_object_or_404(Organization, slug=self.kwargs['slug'])
+        return get_object_or_404(Organization.objects.prefetch_related('admins__user'), slug=self.kwargs['slug'])
 
     def dispatch(self, request, *args, **kwargs):
         if 'slug' not in kwargs:

--- a/templates/blog/modern-list.html
+++ b/templates/blog/modern-list.html
@@ -54,11 +54,8 @@
           <select id="sort-select" class="select">
             <option value="latest" {% if request.GET.sort == 'latest' or not request.GET.sort %}selected{% endif %}>{{ _('Latest') }}</option>
             <option value="top" {% if request.GET.sort == 'top' %}selected{% endif %}>{{ _('Top') }}</option>
-            <option value="discussed" {% if request.GET.sort == 'discussed' %}selected{% endif %}>{{ _('Discussed') }}</option>
           </select>
         </div>
-
-  
 
         {% if request.user.is_authenticated and perms.judge.manage_magazine_post %}
           <a href="{{ url('user_blog', request.user.username) }}" class="btn-top-bar">
@@ -112,7 +109,7 @@
               {% set authors = post.authors.all() %}
               {% if authors %}<i class="fa fa-user"></i>{{ link_users(authors) }}{% endif %}
             </div>
-            
+
             {# Card tags #}
             {% if post.tags.exists() %}
             <div class="card-tags">
@@ -121,16 +118,13 @@
               {% endfor %}
             </div>
             {% endif %}
-            
+
             <div class="card-actions">
               {% set logged_in = request.user.is_authenticated %}
-              {% set vote_info = post_votes[post.id] %}
-              
+
               <div class="stat-item vote-stat" data-post-id="{{ post.id }}">
                 <i class="fa fa-thumbs-up"></i>
-                <span id="post-score-{{ post.id }}" 
-                      title="{{ _('Total score:') }} {{ post.score }} ({{ vote_info.upvote_count }} {{ _('up') }}, {{ vote_info.downvote_count }} {{ _('down') }})"
-                      data-toggle="tooltip">
+                <span id="post-score-{{ post.id }}">
                   {{ post.score }}
                 </span>
                 {% if logged_in %}
@@ -156,7 +150,7 @@
                   </div>
                 {% endif %}
               </div>
-              
+
               <span class="stat-item"
                     title="{{ _('View') }} {{ post_comment_counts[post.id] | default(0) }} {{ _('comments') }}">
                 <i class="fa fa-comments"></i>

--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -81,7 +81,7 @@
         {% if contest.show_short_display %}
             <div id="details">
                 <ul>
-                    {% with authors=contest.authors.all() %}
+                    {% with authors=contest.authors.all().prefetch_related('user') %}
                         {% if not contest.hide_problem_authors and authors %}
                             <li>
                                 {% trans trimmed count=authors|length, link_authors=link_users(authors) %}
@@ -92,7 +92,7 @@
                             </li>
                         {% endif %}
                     {% endwith %}
-                    {% with testers=contest.testers.all() %}
+                    {% with testers=contest.testers.all().prefetch_related('user') %}
                         {% if not contest.hide_problem_authors and testers %}
                             <li>
                                 {% trans trimmed count=testers|length, link_testers=link_users(testers) %}


### PR DESCRIPTION
- **Fix n+1 query in morden bloglist, simplify the view**
- **Fix n+1 query in organizations admin**
- **fix n+1 problem in contest authors and testers**

Add prefetch_related/select_related before pass it to link_users