### PR TITLE
Use filesizeformat from django instead of jinja default

### DIFF
--- a/judge/jinja2/__init__.py
+++ b/judge/jinja2/__init__.py
@@ -2,6 +2,7 @@ import itertools
 import json
 from urllib.parse import quote
 
+from django.template.defaultfilters import filesizeformat
 from jinja2.ext import Extension
 from mptt.utils import get_cached_trees
 from statici18n.templatetags.statici18n import inlinei18n
@@ -35,3 +36,5 @@ class DMOJExtension(Extension):
         env.globals.update(registry.globals)
         env.filters.update(registry.filters)
         env.tests.update(registry.tests)
+
+        env.filters['filesizeformat'] = filesizeformat


### PR DESCRIPTION
jinja's `filesizeformat` bydefault is using Mega, Giga, etc. (aka 1 MB = 1000 KB), which is not what we want

We could pass in `value | filesizeformat(binary = True)`, however that require too much code changes and it's not compatible with django built-in `filesizeformat`.


The implementation is yank from `DjangoExtraFiltersExtension` of django_jinja [here](https://github.com/niwinz/django-jinja/blob/e7a971f41619f6785ad83c9a78904751998acba8/django_jinja/builtins/extensions.py#L249)
