### PR TITLE
admin: fix n+1 query in various form, add infinite pagination for huge table

### DIFF
--- a/judge/admin/contest.py
+++ b/judge/admin/contest.py
@@ -376,7 +376,7 @@ class ContestAdmin(NoBatchDeleteMixin, SortableAdminBase, VersionAdmin):
 class ContestParticipationForm(ModelForm):
     class Meta:
         widgets = {
-            'contest': AdminSelect2Widget(),
+            'contest': AdminHeavySelect2Widget(data_view='contest_select2'),
             'user': AdminHeavySelect2Widget(data_view='profile_select2'),
         }
 

--- a/judge/admin/contest.py
+++ b/judge/admin/contest.py
@@ -19,7 +19,7 @@ from judge.models import Contest, ContestAnnouncement, ContestProblem, ContestSu
 from judge.ratings import rate_contest
 from judge.utils.views import NoBatchDeleteMixin
 from judge.widgets import AdminAceWidget, AdminHeavySelect2MultipleWidget, AdminHeavySelect2Widget, \
-    AdminMartorWidget, AdminSelect2MultipleWidget, AdminSelect2Widget
+    AdminMartorWidget, AdminSelect2MultipleWidget
 
 
 class AdminHeavySelect2Widget(AdminHeavySelect2Widget):

--- a/judge/admin/contest.py
+++ b/judge/admin/contest.py
@@ -75,14 +75,14 @@ class ContestProblemInline(SortableInlineAdminMixin, admin.TabularInline):
         if obj.id is None:
             return ''
         return format_html('<a class="button rejudge-link action-link" href="{0}">{1}</a>',
-                           reverse('admin:judge_contest_rejudge', args=(obj.contest.id, obj.id)), _('Rejudge'))
+                           reverse('admin:judge_contest_rejudge', args=(obj.contest_id, obj.id)), _('Rejudge'))
 
     @admin.display(description='')
     def rescore_column(self, obj):
         if obj.id is None:
             return ''
         return format_html('<a class="button rescore-link action-link" href="{}">Rescore</a>',
-                           reverse('admin:judge_contest_rescore', args=(obj.contest.id, obj.id)))
+                           reverse('admin:judge_contest_rescore', args=(obj.contest_id, obj.id)))
 
 
 class ContestAnnouncementInlineForm(ModelForm):
@@ -102,7 +102,7 @@ class ContestAnnouncementInline(admin.StackedInline):
         if obj.id is None:
             return 'Not available'
         return format_html('<a class="button resend-link action-link" href="{}">Resend</a>',
-                           reverse('admin:judge_contest_resend', args=(obj.contest.id, obj.id)))
+                           reverse('admin:judge_contest_resend', args=(obj.contest_id, obj.id)))
 
 
 class ContestForm(ModelForm):
@@ -111,9 +111,15 @@ class ContestForm(ModelForm):
         if 'rate_exclude' in self.fields:
             if self.instance and self.instance.id:
                 self.fields['rate_exclude'].queryset = \
-                    Profile.objects.filter(contest_history__contest=self.instance).distinct()
+                    Profile.objects.filter(contest_history__contest=self.instance).select_related('user').distinct()
             else:
                 self.fields['rate_exclude'].queryset = Profile.objects.none()
+        profile_qs = Profile.objects.select_related('user')
+        for field in (
+            'authors', 'curators', 'testers', 'private_contestants', 'banned_users', 'view_contest_scoreboard',
+        ):
+            if field in self.fields:
+                self.fields[field].queryset = profile_qs
         self.fields['banned_users'].widget.can_add_related = False
         self.fields['view_contest_scoreboard'].widget.can_add_related = False
         self.fields['banned_judges'].widget.can_add_related = False
@@ -364,13 +370,6 @@ class ContestAdmin(NoBatchDeleteMixin, SortableAdminBase, VersionAdmin):
             form.base_fields['problem_label_script'].widget = AdminAceWidget(
                 mode='lua', theme=request.profile.resolved_ace_theme,
             )
-
-        perms = ('edit_own_contest', 'edit_all_contest')
-        form.base_fields['curators'].queryset = Profile.objects.filter(
-            Q(user__is_superuser=True) |
-            Q(user__groups__permissions__codename__in=perms) |
-            Q(user__user_permissions__codename__in=perms),
-        ).distinct()
         return form
 
 

--- a/judge/admin/contest.py
+++ b/judge/admin/contest.py
@@ -14,6 +14,7 @@ from django.utils.translation import gettext_lazy as _, ngettext
 from django.views.decorators.http import require_POST
 from reversion.admin import VersionAdmin
 
+from judge.admin.utils import AdminFastPaginationMixin
 from judge.models import Contest, ContestAnnouncement, ContestProblem, ContestSubmission, Profile, Rating, Submission
 from judge.ratings import rate_contest
 from judge.utils.views import NoBatchDeleteMixin
@@ -144,7 +145,7 @@ class ContestForm(ModelForm):
         }
 
 
-class ContestAdmin(NoBatchDeleteMixin, SortableAdminBase, VersionAdmin):
+class ContestAdmin(AdminFastPaginationMixin, NoBatchDeleteMixin, SortableAdminBase, VersionAdmin):
     fieldsets = (
         (None, {'fields': ('key', 'name', 'authors', 'curators', 'testers')}),
         (_('Settings'), {'fields': ('is_visible', 'use_clarifications', 'push_announcements', 'disallow_virtual',

--- a/judge/admin/interface.py
+++ b/judge/admin/interface.py
@@ -91,6 +91,9 @@ class BlogPostAdmin(VersionAdmin):
     form = BlogPostForm
     date_hierarchy = 'publish_on'
 
+    def get_queryset(self, request):
+        return super().get_queryset(request).prefetch_related('authors__user')
+
     def has_change_permission(self, request, obj=None):
         if obj is None:
             return request.user.has_perm('judge.change_blogpost')

--- a/judge/admin/problem.py
+++ b/judge/admin/problem.py
@@ -10,6 +10,7 @@ from django.utils.html import format_html
 from django.utils.translation import gettext, gettext_lazy as _, ngettext
 from reversion.admin import VersionAdmin
 
+from judge.admin.utils import AdminFastPaginationMixin
 from judge.models import LanguageLimit, Problem, ProblemClarification, ProblemTranslation, Profile, Solution
 from judge.utils.views import NoBatchDeleteMixin
 from judge.widgets import AdminHeavySelect2MultipleWidget, AdminHeavySelect2Widget, AdminMartorWidget, \
@@ -118,7 +119,7 @@ class ProblemTranslationInline(admin.StackedInline):
     has_add_permission = has_change_permission = has_delete_permission = has_permission_full_markup
 
 
-class ProblemAdmin(NoBatchDeleteMixin, VersionAdmin):
+class ProblemAdmin(AdminFastPaginationMixin, NoBatchDeleteMixin, VersionAdmin):
     fieldsets = (
         (None, {
             'fields': (
@@ -140,7 +141,6 @@ class ProblemAdmin(NoBatchDeleteMixin, VersionAdmin):
     ordering = ['code']
     search_fields = ('code', 'name', 'authors__user__username', 'curators__user__username')
     inlines = [LanguageLimitInline, ProblemClarificationInline, ProblemSolutionInline, ProblemTranslationInline]
-    list_max_show_all = 1000
     actions_on_top = True
     actions_on_bottom = True
     list_filter = ('is_public', ProblemCreatorListFilter)

--- a/judge/admin/problem.py
+++ b/judge/admin/problem.py
@@ -203,7 +203,8 @@ class ProblemAdmin(NoBatchDeleteMixin, VersionAdmin):
                                             count) % count)
 
     def get_queryset(self, request):
-        return Problem.get_editable_problems(request.user).prefetch_related('authors__user').distinct()
+        editable_ids = Problem.get_editable_problems(request.user).values('id')
+        return Problem.objects.filter(id__in=editable_ids).prefetch_related('authors__user')
 
     def has_change_permission(self, request, obj=None):
         if obj is None:

--- a/judge/admin/profile.py
+++ b/judge/admin/profile.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as OldUserAdmin
+from django.contrib.auth.models import Permission
 from django.forms import ModelForm
 from django.urls import reverse_lazy
 from django.utils.html import format_html
@@ -161,6 +162,18 @@ class ProfileAdmin(NoBatchDeleteMixin, VersionAdmin):
 
 
 class UserAdmin(OldUserAdmin):
+    def formfield_for_manytomany(self, db_field, request, **kwargs):
+        if db_field.name == 'user_permissions':
+            kwargs['queryset'] = Permission.objects.select_related('content_type').order_by(
+                'content_type__app_label', 'codename',
+            )
+            field = super().formfield_for_manytomany(db_field, request, **kwargs)
+            field.label_from_instance = lambda obj: (
+                f'{obj.content_type.app_label}.{obj.codename} | {_(obj.name)}'
+            )
+            return field
+        return super().formfield_for_manytomany(db_field, request, **kwargs)
+
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)
         if not change:

--- a/judge/admin/profile.py
+++ b/judge/admin/profile.py
@@ -162,6 +162,9 @@ class ProfileAdmin(NoBatchDeleteMixin, VersionAdmin):
 
 
 class UserAdmin(OldUserAdmin):
+    def view_on_site(self, obj):
+        return obj.profile.get_absolute_url()
+
     def formfield_for_manytomany(self, db_field, request, **kwargs):
         if db_field.name == 'user_permissions':
             kwargs['queryset'] = Permission.objects.select_related('content_type').order_by(

--- a/judge/admin/submission.py
+++ b/judge/admin/submission.py
@@ -15,6 +15,7 @@ from django.utils.translation import gettext, gettext_lazy as _, ngettext, pgett
 from django.views.decorators.http import require_POST
 from reversion.admin import VersionAdmin
 
+from judge.admin.utils import AdminFastPaginationMixin
 from judge.models import ContestParticipation, ContestProblem, ContestSubmission, Profile, Submission, \
     SubmissionSource, SubmissionTestCase
 from judge.utils.raw_sql import use_straight_join
@@ -117,7 +118,7 @@ class SubmissionSourceInline(admin.StackedInline):
         return super().get_formset(request, obj, **kwargs)
 
 
-class SubmissionAdmin(VersionAdmin):
+class SubmissionAdmin(AdminFastPaginationMixin, VersionAdmin):
     readonly_fields = ('user', 'problem', 'date', 'judged_date')
     fields = ('user', 'problem', 'date', 'judged_date', 'locked_after', 'time', 'memory', 'points', 'language',
               'status', 'result', 'case_points', 'case_total', 'judged_on', 'error')
@@ -139,7 +140,7 @@ class SubmissionAdmin(VersionAdmin):
     def get_queryset(self, request):
         queryset = Submission.objects.select_related('problem', 'user__user', 'language').only(
             'problem__code', 'problem__name', 'user__user__username', 'language__name',
-            'time', 'memory', 'points', 'status', 'result',
+            'time', 'memory', 'points', 'status', 'result', 'locked_after',
         )
         use_straight_join(queryset)
         if not request.user.has_perm('judge.edit_all_problem'):

--- a/judge/admin/ticket.py
+++ b/judge/admin/ticket.py
@@ -42,4 +42,4 @@ class TicketAdmin(ModelAdmin):
     date_hierarchy = 'time'
 
     def get_queryset(self, request):
-        return super().get_queryset(request).select_related('user__user', 'content_type').prefetch_related('linked_item')
+        return super().get_queryset(request).select_related('user__user').prefetch_related('linked_item')

--- a/judge/admin/ticket.py
+++ b/judge/admin/ticket.py
@@ -21,6 +21,9 @@ class TicketMessageInline(StackedInline):
     fields = ('user', 'body', 'action')
     readonly_fields = ('action',)
 
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related('user__user')
+
 
 class TicketForm(ModelForm):
     class Meta:
@@ -37,3 +40,6 @@ class TicketAdmin(ModelAdmin):
     inlines = [TicketMessageInline]
     form = TicketForm
     date_hierarchy = 'time'
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related('user__user', 'content_type').prefetch_related('linked_item')

--- a/judge/admin/utils.py
+++ b/judge/admin/utils.py
@@ -1,0 +1,62 @@
+from functools import cached_property
+
+from django.contrib.admin.views.main import PAGE_VAR
+from django.core.paginator import Paginator
+
+
+# Source - https://stackoverflow.com/a/58929378
+# Posted by Paul
+# Retrieved 2026-06-19, License - CC BY-SA 4.0
+class FastCountPaginator(Paginator):
+    """A faster paginator that avoids COUNT(*) by using the requested page
+    to generate a synthetic count. Fetches per_page+1 rows to detect
+    whether a next page exists.
+    """
+    use_fast_pagination = True
+
+    def __init__(self, page_number, *args, **kwargs):
+        self.page_number = page_number
+        super().__init__(*args, **kwargs)
+
+    @cached_property
+    def count(self):
+        return self.populate_object_list()
+
+    def page(self, page_number):
+        page_number = self.validate_number(page_number)
+        return self._get_page(self.object_list, page_number, self)
+
+    def populate_object_list(self):
+        bottom = self.page_number * self.per_page
+        top = bottom + self.per_page + 1
+        object_list = list(self.object_list[bottom:top])
+        if len(object_list) == self.per_page + 1:
+            object_list = object_list[:-1]
+        else:
+            top = bottom + len(object_list)
+        self.object_list = object_list
+        return top
+
+
+class AdminFastPaginationMixin:
+    show_full_result_count = False
+    list_max_show_all = 1
+
+    def changelist_view(self, request, extra_context=None):
+        request.GET = request.GET.copy()
+        request.GET.paginator_count_all = request.GET.pop('count_all', False)
+        return super().changelist_view(request, extra_context)
+
+    def get_paginator(self, request, queryset, per_page, orphans=0, allow_empty_first_page=True):
+        if getattr(request.GET, 'paginator_count_all', False):
+            return Paginator(queryset, per_page, orphans, allow_empty_first_page)
+        page = self._get_page_number(request.GET.get(PAGE_VAR, '0'))
+        return FastCountPaginator(page, queryset, per_page, orphans, allow_empty_first_page)
+
+    @staticmethod
+    def _get_page_number(number):
+        try:
+            number = int(number)
+        except (TypeError, ValueError):
+            return 0
+        return max(number, 0)


### PR DESCRIPTION
This pull request addresses several issues in the admin view, particularly the n+1 query issues on the contest detail page.

Additionally, the default admin view performs a full scan for pagination/count. This update introduces fast pagination, utilizing a similar approach to our infinite pagination for migration.


- **Improve permission selector in admin ui**
- **admin: Add view on site for user**
- **admin: fix n+1 query issue in contest**
- **admin: fix n+1 query issue in contest participation**
- **admin: fix n+1 query issue in blog view**
- **admin: fix n+1 query issue in ticket**
- **admin: improve queryset for problem list**
- **Add AdminFastPaginationMixin**
- **Add fast pagination for problem, contest and submission**
- **fix lint**
