### PR TITLE
add dark mode support for modern blog UI

### DIFF
--- a/judge/jinja2/__init__.py
+++ b/judge/jinja2/__init__.py
@@ -3,7 +3,10 @@ import json
 from urllib.parse import quote
 
 from django.template.defaultfilters import filesizeformat
+from django.templatetags.static import static as django_static
+from jinja2 import pass_context
 from jinja2.ext import Extension
+from markupsafe import Markup
 from mptt.utils import get_cached_trees
 from statici18n.templatetags.statici18n import inlinei18n
 
@@ -28,6 +31,21 @@ registry.function('user_trans', gettext)
 @registry.function
 def counter(start=1):
     return itertools.count(start).__next__
+
+
+@registry.function
+@pass_context
+def select_css_theme(context, light, dark):
+    theme = context.get('SITE_THEME_NAME', 'auto')
+    if theme == 'dark':
+        return Markup(f'<link rel="stylesheet" href="{django_static(dark)}">')
+    elif theme == 'light':
+        return Markup(f'<link rel="stylesheet" href="{django_static(light)}">')
+    else:  # 'auto'
+        return Markup(
+            f'<link rel="stylesheet" href="{django_static(light)}">'
+            f'<link rel="stylesheet" href="{django_static(dark)}" media="(prefers-color-scheme: dark)">'
+        )
 
 
 class DMOJExtension(Extension):

--- a/judge/jinja2/__init__.py
+++ b/judge/jinja2/__init__.py
@@ -44,7 +44,7 @@ def select_css_theme(context, light, dark):
     else:  # 'auto'
         return Markup(
             f'<link rel="stylesheet" href="{django_static(light)}">'
-            f'<link rel="stylesheet" href="{django_static(dark)}" media="(prefers-color-scheme: dark)">'
+            f'<link rel="stylesheet" href="{django_static(dark)}" media="(prefers-color-scheme: dark)">',
         )
 
 

--- a/templates/blog/modern-content.html
+++ b/templates/blog/modern-content.html
@@ -24,7 +24,7 @@
 {% block media %}
     {% include "comments/media-css.html" %}
     {% compress css %}
-        <link rel="stylesheet" href="{{ static('blog-post.css') }}">
+        {{ select_css_theme('blog-post.css', 'dark/blog-post.css') }}
     {% endcompress %}
 {% endblock %}
 

--- a/templates/blog/modern-list.html
+++ b/templates/blog/modern-list.html
@@ -8,7 +8,7 @@
   <link rel="alternate" type="application/rss+xml" href="{{ url('blog_rss') }}" title="RSS Blog Feed">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   {% compress css %}
-    <link rel="stylesheet" href="{{ static('blog-modern.css') }}">
+    {{ select_css_theme('blog-modern.css', 'dark/blog-modern.css') }}
   {% endcompress %}
 {% endblock %}
 


### PR DESCRIPTION
Apparently it already supports dark mode, but the CSS didn't load

- Add `select_css_theme(light, dark)` jinja helper to help select the correct CSS file style for future use