### PR TITLE
lazy load comments, support pagination

### DIFF
--- a/dmoj/urls.py
+++ b/dmoj/urls.py
@@ -120,6 +120,7 @@ urlpatterns = [
 
     path('problem/<str:problem>', include([
         path('', problem.ProblemDetail.as_view(), name='problem_detail'),
+        path('/comments', problem.ProblemComments.as_view(), name='problem_comments'),
         path('/edit', problem.ProblemEdit.as_view(), name='problem_edit'),
         path('/edit-type-group', problem.ProblemEditTypeGroup.as_view(), name='problem_edit_type_group'),
         path('/editorial', problem.ProblemSolution.as_view(), name='problem_editorial'),

--- a/dmoj/urls.py
+++ b/dmoj/urls.py
@@ -124,6 +124,7 @@ urlpatterns = [
         path('/edit', problem.ProblemEdit.as_view(), name='problem_edit'),
         path('/edit-type-group', problem.ProblemEditTypeGroup.as_view(), name='problem_edit_type_group'),
         path('/editorial', problem.ProblemSolution.as_view(), name='problem_editorial'),
+        path('/editorial/comments', problem.ProblemSolutionComments.as_view(), name='problem_editorial_comments'),
         path('/raw', xframe_options_sameorigin(problem.ProblemRaw.as_view()), name='problem_raw'),
         path('/pdf', problem.ProblemPdfView.as_view(), name='problem_pdf'),
         path('/pdf/<slug:language>', problem.ProblemPdfView.as_view(), name='problem_pdf'),
@@ -173,6 +174,7 @@ urlpatterns = [
 
     path('tag/<str:tagproblem>', include([
         path('', tag.TagProblemDetail.as_view(), name='tagproblem_detail'),
+        path('/comments', tag.TagProblemComments.as_view(), name='tagproblem_comments'),
         path('/assign', tag.TagProblemAssign.as_view(), name='tagproblem_assign'),
         path('/', lambda _, tagproblem: HttpResponsePermanentRedirect(reverse('tagproblem_detail', args=[tagproblem]))),
     ])),
@@ -242,6 +244,7 @@ urlpatterns = [
 
     path('contest/<str:contest>', include([
         path('', contests.ContestDetail.as_view(), name='contest_view'),
+        path('/comments', contests.ContestComments.as_view(), name='contest_comments'),
         path('/all', contests.ContestAllProblems.as_view(), name='contest_all_problems'),
         path('/edit', contests.EditContest.as_view(), name='contest_edit'),
         path('/moss', contests.ContestMossView.as_view(), name='contest_moss'),
@@ -344,6 +347,7 @@ urlpatterns = [
     path('post/<int:id>-<slug:slug>', include([
         path('', blog.PostView.as_view(), name='blog_post'),
         path('/modern', blog.PostModernView.as_view(), name='blog_post_modern'),
+        path('/comments', blog.PostComments.as_view(), name='blog_post_comments'),
         path('/edit', blog.BlogPostEdit.as_view(), name='blog_post_edit'),
         path('/delete', blog.BlogPostDelete.as_view(), name='blog_post_delete'),
         path('/', lambda _, id, slug: HttpResponsePermanentRedirect(reverse('blog_post', args=[id, slug]))),

--- a/judge/comments.py
+++ b/judge/comments.py
@@ -20,6 +20,7 @@ from reversion.models import Revision, Version
 
 from judge.dblock import LockModel
 from judge.models import Comment, CommentLock
+from judge.utils.diggpaginator import DiggPaginator
 from judge.widgets import MartorWidget
 
 
@@ -84,6 +85,13 @@ class CommentForm(ModelForm):
 
 class CommentedDetailView(TemplateResponseMixin, SingleObjectMixin, View):
     comment_page = None
+    comments_per_page = 20
+    # True by default: most CommentedDetailView subclasses are host pages whose
+    # template doesn't render comment_list/comment_form directly (comments are
+    # lazy-loaded through a separate fragment view), so skip building the comment
+    # queryset on GET. Still built when a comment_form with errors needs to be
+    # redisplayed. The fragment views themselves set this back to False.
+    skip_comment_list = True
 
     def get_comment_page(self):
         if self.comment_page is None:
@@ -130,7 +138,7 @@ class CommentedDetailView(TemplateResponseMixin, SingleObjectMixin, View):
                 revisions.set_user(request.user)
                 revisions.set_comment(_('Posted comment'))
                 comment.save()
-            return HttpResponseRedirect(request.path)
+            return HttpResponseRedirect(request.path + '#comments')
 
         context = self.get_context_data(object=self.object, comment_form=form)
         return self.render_to_response(context)
@@ -144,9 +152,38 @@ class CommentedDetailView(TemplateResponseMixin, SingleObjectMixin, View):
 
     def get_context_data(self, **kwargs):
         context = super(CommentedDetailView, self).get_context_data(**kwargs)
+        context['comment_lock'] = self.is_comment_locked()
+
+        # A comment_form with errors must always be redisplayed with the full
+        # comment list around it (see the comment-error fallback in templates),
+        # so only skip the query when there's nothing to redisplay.
+        comment_form = kwargs.get('comment_form')
+        if comment_form and comment_form.errors:
+            # A failed reply is bound with its parent id, so the error can be
+            # surfaced next to the comment being replied to (see reply_comment()
+            # in base-media-js.html) instead of only in the page-bottom "New
+            # comment" box, which is easy to miss.
+            raw_parent = comment_form.data.get('parent')
+            if raw_parent:
+                try:
+                    context['reply_parent_id'] = int(raw_parent)
+                except (TypeError, ValueError):
+                    pass
+        elif self.skip_comment_list:
+            return context
+
         queryset = Comment.objects.filter(hidden=False, page=self.get_comment_page())
         context['has_comments'] = queryset.exists()
-        context['comment_lock'] = self.is_comment_locked()
+
+        if self.comments_per_page:
+            root_tree_ids = queryset.filter(parent=None).values_list('tree_id', flat=True)
+            paginator = DiggPaginator(root_tree_ids, self.comments_per_page, body=6, padding=2, orphans=5)
+            page = paginator.get_page(self.request.GET.get('page'))
+            queryset = queryset.filter(tree_id__in=list(page.object_list))
+            context['comments_page_obj'] = page
+            context['page_prefix'] = '?page='
+            context['first_page_href'] = '?page=1'
+
         queryset = queryset.select_related('author__user', 'author__display_badge').defer('author__about')
 
         if self.request.user.is_authenticated:

--- a/judge/views/blog.py
+++ b/judge/views/blog.py
@@ -331,6 +331,23 @@ class PostModernView(PostView):
     template_name = 'blog/modern-content.html'
 
 
+class PostComments(CommentedDetailView):
+    model = BlogPost
+    pk_url_kwarg = 'id'
+    context_object_name = 'post'
+    template_name = 'blog/comments-tab.html'
+    skip_comment_list = False
+
+    def get_comment_page(self):
+        return 'b:%s' % self.object.id
+
+    def get_object(self, queryset=None):
+        post = super(PostComments, self).get_object(queryset)
+        if not post.can_see(self.request.user):
+            raise Http404()
+        return post
+
+
 class BlogPostCreate(TitleMixin, CreateView):
     template_name = 'blog/edit.html'
     model = BlogPost

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -365,6 +365,22 @@ class ContestDetail(ContestMixin, TitleMixin, CommentedDetailView):
         return context
 
 
+class ContestComments(ContestMixin, CommentedDetailView):
+    template_name = 'contest/comments-tab.html'
+    skip_comment_list = False
+
+    def is_comment_locked(self):
+        if self.object.use_clarifications:
+            now = timezone.now()
+            if self.is_in_contest or (self.object.start_time <= now and now <= self.object.end_time):
+                return True
+
+        return super(ContestComments, self).is_comment_locked()
+
+    def get_comment_page(self):
+        return 'c:%s' % self.object.key
+
+
 class ContestAllProblems(ContestMixin, TitleMixin, DetailView):
     template_name = 'contest/contest-all-problems.html'
 

--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -29,11 +29,10 @@ from reversion import revisions
 from judge.comments import CommentedDetailView
 from judge.forms import LanguageLimitFormSet, ProblemCloneForm, ProblemEditForm, ProblemEditTypeGroupForm, \
     ProblemImportPolygonForm, ProblemImportPolygonStatementFormSet, ProblemSubmitForm, ProposeProblemSolutionFormSet
-from judge.models import Comment, Contest, ContestSubmission, Judge, Language, Problem, ProblemGroup, \
+from judge.models import Contest, ContestSubmission, Judge, Language, Problem, ProblemGroup, \
     ProblemTranslation, ProblemType, RuntimeVersion, Solution, Submission, SubmissionSource
 from judge.template_context import misc_config
 from judge.utils.codeforces_polygon import ImportPolygonError, PolygonImporter
-from judge.utils.diggpaginator import DiggPaginator
 from judge.utils.infinite_paginator import InfinitePaginationMixin
 from judge.utils.opengraph import generate_opengraph
 from judge.utils.pdfoid import PDF_RENDERING_ENABLED, render_pdf
@@ -58,6 +57,18 @@ def get_contest_problem(problem, profile):
 def get_contest_submission_count(problem, profile, virtual):
     return profile.current_contest.submissions.exclude(submission__status__in=['IE']) \
                   .filter(problem__problem=problem, participation__virtual=virtual).count()
+
+
+def get_accessible_solution(problem, request):
+    """Fetch the editorial for `problem`, or 404 if the requesting user can't see it.
+
+    Shared by ProblemSolution and ProblemSolutionComments so the comments AJAX
+    endpoint can't leak editorial comments to someone who can't see the editorial.
+    """
+    solution = get_object_or_404(Solution, problem=problem)
+    if not solution.is_accessible_by(request.user) or request.in_contest:
+        raise Http404()
+    return solution
 
 
 class ProblemDeleted(Exception):
@@ -133,11 +144,7 @@ class ProblemSolution(SolvedProblemMixin, ProblemMixin, TitleMixin, CommentedDet
     def get_context_data(self, **kwargs):
         context = super(ProblemSolution, self).get_context_data(**kwargs)
 
-        solution = get_object_or_404(Solution, problem=self.object)
-
-        if not solution.is_accessible_by(self.request.user) or self.request.in_contest:
-            raise Http404()
-        context['solution'] = solution
+        context['solution'] = get_accessible_solution(self.object, self.request)
         context['has_solved_problem'] = self.object.id in self.get_completed_problems()
         return context
 
@@ -150,13 +157,29 @@ class ProblemSolution(SolvedProblemMixin, ProblemMixin, TitleMixin, CommentedDet
                                _('Could not find an editorial with the code "%s".') % code, status=404)
 
 
-class ProblemComments(ProblemMixin, CommentedDetailView):
+class ProblemSolutionComments(ProblemMixin, CommentedDetailView):
     context_object_name = 'problem'
-    template_name = 'problem/comments-tab.html'
-    comments_per_page = 20
+    template_name = 'problem/editorial-comments-tab.html'
+    skip_comment_list = False
+
+    def get_comment_page(self):
+        return 's:' + self.object.code
+
+    def get_context_data(self, **kwargs):
+        # Enforce the same access rule as the editorial page itself, so this AJAX
+        # endpoint can't leak editorial comments to someone who can't see it.
+        get_accessible_solution(self.object, self.request)
+        return super(ProblemSolutionComments, self).get_context_data(**kwargs)
+
+
+class ProblemClarificationsMixin(object):
+    """Shared contest-problem/clarifications detection, used by both the main
+    problem page and its lazy-loaded comments fragment."""
+
+    contest_problem = None
 
     def get_object(self, queryset=None):
-        problem = super(ProblemComments, self).get_object(queryset)
+        problem = super(ProblemClarificationsMixin, self).get_object(queryset)
         user = self.request.user
         authed = user.is_authenticated
         self.contest_problem = (None if not authed or user.profile.current_contest is None else
@@ -166,29 +189,29 @@ class ProblemComments(ProblemMixin, CommentedDetailView):
     def is_comment_locked(self):
         if self.contest_problem and self.contest_problem.contest.use_clarifications:
             return True
-        return super(ProblemComments, self).is_comment_locked()
+        return super(ProblemClarificationsMixin, self).is_comment_locked()
 
     def get_comment_page(self):
         return 'p:%s' % self.object.code
 
-    def get_context_data(self, **kwargs):
-        context = super(ProblemComments, self).get_context_data(**kwargs)
+    def get_clarifications_context(self):
         if self.contest_problem and self.contest_problem.contest.use_clarifications:
             clarifications = self.object.clarifications
-            context['has_clarifications'] = clarifications.count() > 0
-            context['clarifications'] = clarifications.order_by('-date')
+            return {
+                'has_clarifications': clarifications.count() > 0,
+                'clarifications': clarifications.order_by('-date'),
+            }
+        return {}
 
-        queryset = context['comment_list']
-        root_tree_ids = Comment.objects.filter(
-            hidden=False, page=self.get_comment_page(), parent=None,
-        ).values_list('tree_id', flat=True)
-        paginator = DiggPaginator(root_tree_ids, self.comments_per_page,
-                                  body=6, padding=2, orphans=5)
-        page = paginator.get_page(self.request.GET.get('page'))
-        context['comment_list'] = queryset.filter(tree_id__in=list(page.object_list))
-        context['comments_page_obj'] = page
-        context['page_prefix'] = '?page='
-        context['first_page_href'] = '?page=1'
+
+class ProblemComments(ProblemMixin, ProblemClarificationsMixin, CommentedDetailView):
+    context_object_name = 'problem'
+    template_name = 'problem/comments-tab.html'
+    skip_comment_list = False
+
+    def get_context_data(self, **kwargs):
+        context = super(ProblemComments, self).get_context_data(**kwargs)
+        context.update(self.get_clarifications_context())
         return context
 
 
@@ -418,28 +441,10 @@ class ProblemSubmitMixin:
         return HttpResponseRedirect(reverse('submission_status', args=(new_submission.id,))), None
 
 
-class ProblemDetail(ProblemMixin, SolvedProblemMixin, ProblemSubmitMixin, CommentedDetailView):
+class ProblemDetail(ProblemMixin, ProblemClarificationsMixin, SolvedProblemMixin, ProblemSubmitMixin,
+                    CommentedDetailView):
     context_object_name = 'problem'
     template_name = 'problem/problem.html'
-
-    def get_object(self, queryset=None):
-        problem = super(ProblemDetail, self).get_object(queryset)
-
-        user = self.request.user
-        authed = user.is_authenticated
-        self.contest_problem = (None if not authed or user.profile.current_contest is None else
-                                get_contest_problem(problem, user.profile))
-
-        return problem
-
-    def is_comment_locked(self):
-        if self.contest_problem and self.contest_problem.contest.use_clarifications:
-            return True
-
-        return super(ProblemDetail, self).is_comment_locked()
-
-    def get_comment_page(self):
-        return 'p:%s' % self.object.code
 
     def get_context_data(self, **kwargs):
         context = super(ProblemDetail, self).get_context_data(**kwargs)
@@ -449,10 +454,8 @@ class ProblemDetail(ProblemMixin, SolvedProblemMixin, ProblemSubmitMixin, Commen
         context['has_submissions'] = authed and Submission.objects.filter(user=user.profile,
                                                                           problem=self.object).exists()
         context['contest_problem'] = contest_problem
+        context.update(self.get_clarifications_context())
         if contest_problem:
-            clarifications = self.object.clarifications
-            context['has_clarifications'] = clarifications.count() > 0
-            context['clarifications'] = clarifications.order_by('-date')
             context['submission_limit'] = contest_problem.max_submissions
             if contest_problem.max_submissions:
                 context['submissions_left'] = max(contest_problem.max_submissions -

--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -149,6 +149,35 @@ class ProblemSolution(SolvedProblemMixin, ProblemMixin, TitleMixin, CommentedDet
                                _('Could not find an editorial with the code "%s".') % code, status=404)
 
 
+class ProblemComments(ProblemMixin, CommentedDetailView):
+    context_object_name = 'problem'
+    template_name = 'problem/comments-tab.html'
+
+    def get_object(self, queryset=None):
+        problem = super(ProblemComments, self).get_object(queryset)
+        user = self.request.user
+        authed = user.is_authenticated
+        self.contest_problem = (None if not authed or user.profile.current_contest is None else
+                                get_contest_problem(problem, user.profile))
+        return problem
+
+    def is_comment_locked(self):
+        if self.contest_problem and self.contest_problem.contest.use_clarifications:
+            return True
+        return super(ProblemComments, self).is_comment_locked()
+
+    def get_comment_page(self):
+        return 'p:%s' % self.object.code
+
+    def get_context_data(self, **kwargs):
+        context = super(ProblemComments, self).get_context_data(**kwargs)
+        if self.contest_problem and self.contest_problem.contest.use_clarifications:
+            clarifications = self.object.clarifications
+            context['has_clarifications'] = clarifications.count() > 0
+            context['clarifications'] = clarifications.order_by('-date')
+        return context
+
+
 class ProblemRaw(ProblemMixin, TitleMixin, TemplateResponseMixin, SingleObjectMixin, View):
     context_object_name = 'problem'
     template_name = 'problem/raw.html'

--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -29,7 +29,7 @@ from reversion import revisions
 from judge.comments import CommentedDetailView
 from judge.forms import LanguageLimitFormSet, ProblemCloneForm, ProblemEditForm, ProblemEditTypeGroupForm, \
     ProblemImportPolygonForm, ProblemImportPolygonStatementFormSet, ProblemSubmitForm, ProposeProblemSolutionFormSet
-from judge.models import Contest, ContestSubmission, Judge, Language, Problem, ProblemGroup, \
+from judge.models import Comment, Contest, ContestSubmission, Judge, Language, Problem, ProblemGroup, \
     ProblemTranslation, ProblemType, RuntimeVersion, Solution, Submission, SubmissionSource
 from judge.template_context import misc_config
 from judge.utils.codeforces_polygon import ImportPolygonError, PolygonImporter
@@ -179,10 +179,13 @@ class ProblemComments(ProblemMixin, CommentedDetailView):
             context['clarifications'] = clarifications.order_by('-date')
 
         queryset = context['comment_list']
-        paginator = DiggPaginator(queryset.filter(parent=None), self.comments_per_page,
+        root_tree_ids = Comment.objects.filter(
+            hidden=False, page=self.get_comment_page(), parent=None,
+        ).values_list('tree_id', flat=True)
+        paginator = DiggPaginator(root_tree_ids, self.comments_per_page,
                                   body=6, padding=2, orphans=5)
         page = paginator.get_page(self.request.GET.get('page'))
-        context['comment_list'] = queryset.filter(tree_id__in=[node.tree_id for node in page.object_list])
+        context['comment_list'] = queryset.filter(tree_id__in=list(page.object_list))
         context['comments_page_obj'] = page
         context['page_prefix'] = '?page='
         context['first_page_href'] = '?page=1'

--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -33,6 +33,7 @@ from judge.models import Contest, ContestSubmission, Judge, Language, Problem, P
     ProblemTranslation, ProblemType, RuntimeVersion, Solution, Submission, SubmissionSource
 from judge.template_context import misc_config
 from judge.utils.codeforces_polygon import ImportPolygonError, PolygonImporter
+from judge.utils.diggpaginator import DiggPaginator
 from judge.utils.infinite_paginator import InfinitePaginationMixin
 from judge.utils.opengraph import generate_opengraph
 from judge.utils.pdfoid import PDF_RENDERING_ENABLED, render_pdf
@@ -152,6 +153,7 @@ class ProblemSolution(SolvedProblemMixin, ProblemMixin, TitleMixin, CommentedDet
 class ProblemComments(ProblemMixin, CommentedDetailView):
     context_object_name = 'problem'
     template_name = 'problem/comments-tab.html'
+    comments_per_page = 20
 
     def get_object(self, queryset=None):
         problem = super(ProblemComments, self).get_object(queryset)
@@ -175,6 +177,15 @@ class ProblemComments(ProblemMixin, CommentedDetailView):
             clarifications = self.object.clarifications
             context['has_clarifications'] = clarifications.count() > 0
             context['clarifications'] = clarifications.order_by('-date')
+
+        queryset = context['comment_list']
+        paginator = DiggPaginator(queryset.filter(parent=None), self.comments_per_page,
+                                  body=6, padding=2, orphans=5)
+        page = paginator.get_page(self.request.GET.get('page'))
+        context['comment_list'] = queryset.filter(tree_id__in=[node.tree_id for node in page.object_list])
+        context['comments_page_obj'] = page
+        context['page_prefix'] = '?page='
+        context['first_page_href'] = '?page=1'
         return context
 
 

--- a/judge/views/tag.py
+++ b/judge/views/tag.py
@@ -248,3 +248,12 @@ class TagProblemDetail(TagProblemMixin, TitleMixin, CommentedDetailView):
 
         return super(TagProblemDetail, self).get_queryset() \
             .prefetch_related(Prefetch('tagdata_set', queryset=queryset))
+
+
+class TagProblemComments(TagProblemMixin, CommentedDetailView):
+    context_object_name = 'problem'
+    template_name = 'tag/comments-tab.html'
+    skip_comment_list = False
+
+    def get_comment_page(self):
+        return 't:%s' % self.object.code

--- a/resources/comments.scss
+++ b/resources/comments.scss
@@ -204,3 +204,9 @@ a {
         transform: translatez(0);
     }
 }
+
+.comments-loading {
+    padding: 1em 0;
+    text-align: center;
+    color: #888;
+}

--- a/templates/blog/comments-tab.html
+++ b/templates/blog/comments-tab.html
@@ -1,0 +1,4 @@
+{% if not comment_lock %}
+    {% include "comments/media-js.html" %}
+{% endif %}
+{% include "comments/list.html" %}

--- a/templates/blog/content.html
+++ b/templates/blog/content.html
@@ -5,7 +5,12 @@
 
 {% block js_media %}
     {% include "blog/media-js.html" %}
-    {% include "comments/media-js.html" %}
+    {% if comment_form and comment_form.errors %}
+        {# comments/list.html is SSR'd directly below (not via the AJAX fragment) in
+           this case, so it needs its own media JS (martor editor, vote/hide/edit). #}
+        {% include "comments/media-js.html" %}
+    {% endif %}
+    {% include "comments/lazy-load-js.html" %}
 {% endblock %}
 
 {% block media %}
@@ -77,7 +82,15 @@
         {{ post_to_facebook(request, post, '<i class="fa fa-facebook-official"></i>') }}
         {{ post_to_twitter(request, SITE_NAME + ':', post, '<i class="fa fa-twitter"></i>') }}
     </span>
-    {% include "comments/list.html" %}
+    <div id="comments" data-comments-url="{{ url('blog_post_comments', post.id, post.slug) }}"
+         data-comments-trigger="auto"
+         data-comments-preloaded="{{ 'true' if comment_form and comment_form.errors else 'false' }}">
+        {% if comment_form and comment_form.errors %}
+            {% include "comments/list.html" %}
+        {% else %}
+            <div class="comments-loading">{{ _('Loading...') }}</div>
+        {% endif %}
+    </div>
     <div style="clear: both;"></div>
 {% endblock %}
 

--- a/templates/blog/modern-content.html
+++ b/templates/blog/modern-content.html
@@ -5,7 +5,12 @@
 
 {% block js_media %}
     {% include "blog/media-js.html" %}
-    {% include "comments/media-js.html" %}
+    {% if comment_form and comment_form.errors %}
+        {# comments/list.html is SSR'd directly below (not via the AJAX fragment) in
+           this case, so it needs its own media JS (martor editor, vote/hide/edit). #}
+        {% include "comments/media-js.html" %}
+    {% endif %}
+    {% include "comments/lazy-load-js.html" %}
     <script src="{{ static('blog-toc.js') }}"></script>
     <script>
         // Reading progress bar
@@ -127,7 +132,15 @@
 
     <!-- Comments -->
     <div class="blog-post-comments">
-        {% include "comments/list.html" %}
+        <div id="comments" data-comments-url="{{ url('blog_post_comments', post.id, post.slug) }}"
+             data-comments-trigger="auto"
+             data-comments-preloaded="{{ 'true' if comment_form and comment_form.errors else 'false' }}">
+            {% if comment_form and comment_form.errors %}
+                {% include "comments/list.html" %}
+            {% else %}
+                <div class="comments-loading">{{ _('Loading...') }}</div>
+            {% endif %}
+        </div>
     </div>
 </div>
 {% endblock %}

--- a/templates/comments/base-media-js.html
+++ b/templates/comments/base-media-js.html
@@ -51,8 +51,14 @@
 
     $(document).ready(function () {
         sort_top_level_comments_by_status();
-        window.reply_comment = function (parent) {
+        // keepContent: true when restoring a failed submission (see the
+        // reply-error auto-open below) - in that case #new-comment already has
+        // the submitted body and the validation errors rendered into it (it's
+        // the same bound comment_form), so cloning it must NOT wipe them.
+        window.reply_comment = function (parent, keepContent) {
             var $comment_reply = $('#comment-' + parent + '-reply');
+            if ($comment_reply.length === 0)
+                return;
             var reply_id = 'reply-' + parent;
             if ($comment_reply.find('#' + reply_id).length == 0) {
                 var $reply_form = $('#new-comment').clone(false).prop('id', reply_id);
@@ -61,7 +67,8 @@
                 $reply_form.appendTo($comment_reply);
                 $reply_form.find('form.comment-submit-form input#id_parent').val(parent);
                 rename_martor_widget($reply_form, 'body', reply_id);
-                ace.edit('martor-' + reply_id).setValue('');
+                if (!keepContent)
+                    ace.edit('martor-' + reply_id).setValue('');
             }
             $comment_reply.fadeIn();
 
@@ -70,9 +77,33 @@
             }, 500);
         };
 
-        $(document).on('click', '.close', function() {
-            $(this).closest('.reply-comment').fadeOut();
-        });
+        {% if reply_parent_id %}
+            // A reply to this comment just failed validation (see get_context_data
+            // in judge/comments.py); open its reply box automatically instead of
+            // leaving the error only visible in the page-bottom "New comment" box.
+            reply_comment({{ reply_parent_id }}, true);
+        {% endif %}
+
+        // This whole script re-runs every time a comment fragment is (re)loaded via AJAX
+        // (pagination, lazy-load). Delegated `document`-level handlers must only ever be
+        // bound once, or they accumulate one duplicate per reload.
+        if (!window.__commentsMediaBound) {
+            window.__commentsMediaBound = true;
+
+            $(document).on('click', '.close', function() {
+                $(this).closest('.reply-comment').fadeOut();
+            });
+
+            var code_regex = [/input\(/, /#include/, /void\s+main/, /fn\s+main/, /func\s+main/];
+            $(document).on('click', 'form.comment-warn-code .button[type=submit]', function (e) {
+                var text = $(this).parents('form').find('#id_body').val();
+                if (code_regex.some(function (regex) {return regex.test(text);})) {
+                    if (!confirm({{ _('Looks like you\'re trying to post some source code!\n\nThe comment section is not for posting source code.\nIf you want to submit your solution, please use the "Submit solution" button.\n\nAre you sure you want to post this?')|htmltojs }})) {
+                        e.preventDefault();
+                    }
+                }
+            });
+        }
 
         function update_math($comment) {
             if ('MathJax' in window) {
@@ -296,18 +327,18 @@
             });
         }
 
-        $(window).on('load', function() {
+        // Was unconditionally `$(window).on('load', ...)`: the native `load` event only
+        // fires once per real page load, so on every reload after the first (pagination,
+        // lazy-load) that registered a callback for an event that would never fire again,
+        // and the "Show more/Show less" toggle silently never initialized. Still wait for
+        // `load` the first time (so image layout has settled before measuring
+        // scrollHeight), but call directly on later reloads since `load` has already
+        // fired by then and initializeCommentToggle is idempotent per comment body
+        // (guarded by the 'toggle-initialized' data flag above).
+        if (document.readyState === 'complete') {
             initializeCommentToggle();
-        });
-
-        var code_regex = [/input\(/, /#include/, /void\s+main/, /fn\s+main/, /func\s+main/];
-        $(document).on('click', 'form.comment-warn-code .button[type=submit]', function (e) {
-            var text = $(this).parents('form').find('#id_body').val();
-            if (code_regex.some(function (regex) {return regex.test(text);})) {
-                if (!confirm({{ _('Looks like you\'re trying to post some source code!\n\nThe comment section is not for posting source code.\nIf you want to submit your solution, please use the "Submit solution" button.\n\nAre you sure you want to post this?')|htmltojs }})) {
-                    e.preventDefault();
-                }
-            }
-        });
+        } else {
+            $(window).on('load', initializeCommentToggle);
+        }
     });
 </script>

--- a/templates/comments/lazy-load-js.html
+++ b/templates/comments/lazy-load-js.html
@@ -1,0 +1,65 @@
+<script type="text/javascript">
+    $(function () {
+        var $container = $('#comments').first();
+        var url = $container.data('comments-url');
+        if (!$container.length || !url)
+            return;
+
+        var mode = $container.data('comments-trigger');
+        // When the server already rendered the full comment list inline (the
+        // comment_form-errors fallback, so a failed submission stays visible),
+        // treat comments as already loaded so nothing here re-fetches and
+        // clobbers it with a fresh, error-free AJAX fragment.
+        var loaded = !!$container.data('comments-preloaded');
+        var pendingScrollHash = null;
+
+        function fetchComments(page, scrollToContainer) {
+            var fetchUrl = page ? url + '?page=' + page : url;
+            $container.html('<div class="comments-loading">{{ _('Loading...') }}</div>');
+            $container.load(fetchUrl, function () {
+                if (window.MathJax && MathJax.typesetPromise)
+                    MathJax.typesetPromise([$container[0]]);
+                if (pendingScrollHash && $(pendingScrollHash).length) {
+                    $(pendingScrollHash)[0].scrollIntoView({behavior: 'instant', block: 'start'});
+                    pendingScrollHash = null;
+                } else if (scrollToContainer) {
+                    $container[0].scrollIntoView({behavior: 'instant', block: 'start'});
+                }
+            });
+        }
+
+        function loadComments() {
+            if (loaded) return;
+            loaded = true;
+            fetchComments(null, false);
+        }
+
+        // Exposed so a host page with its own trigger UI (e.g. problem.html's
+        // .problem-tabs click handler / initial-hash handling) can hook in without
+        // reimplementing the fetch/pagination logic.
+        $container.data('load-comments', loadComments);
+        $container.data('set-pending-scroll', function (hash) {
+            pendingScrollHash = hash;
+        });
+
+        // Paginate comments without reloading the page.
+        $container.on('click', '.comments-pagination a', function (e) {
+            var match = /page=(\d+)/.exec($(this).attr('href'));
+            if (!match) return;
+            e.preventDefault();
+            fetchComments(match[1], true);
+        });
+
+        // Tab-mode pages (problem.html) load comments themselves once the
+        // comments tab becomes active (via click or on initial load if it's
+        // already the default tab), using the hooks exposed above. Every other
+        // page has no tab to wait on, so just fetch immediately.
+        if (mode === 'tab') return;
+
+        var hash = window.location.hash;
+        if (/^#comment-\d+$/.test(hash)) {
+            pendingScrollHash = hash;
+        }
+        loadComments();
+    });
+</script>

--- a/templates/comments/list.html
+++ b/templates/comments/list.html
@@ -140,6 +140,13 @@
             </ul>
         {% endif %}
 
+        {% if comments_page_obj and comments_page_obj.paginator.num_pages > 1 %}
+            <div class="bottom-pagination-bar comments-pagination">
+                {% set page_obj = comments_page_obj %}
+                {% include "list-pages.html" %}
+            </div>
+        {% endif %}
+
         {% if request.user.is_authenticated and comment_form and not comment_lock %}
             <div id="new-comment" class="form-area comment-submit">
                 {% block comment_submit_title %}

--- a/templates/contest/comments-tab.html
+++ b/templates/contest/comments-tab.html
@@ -1,0 +1,4 @@
+{% if not comment_lock %}
+    {% include "comments/media-js.html" %}
+{% endif %}
+{% include "comments/list.html" %}

--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -26,7 +26,12 @@
     </script>
     {% include "contest/media-js.html" %}
     {% if not comment_lock %}
-        {% include "comments/media-js.html" %}
+        {% if comment_form and comment_form.errors %}
+            {# comments/list.html is SSR'd directly below (not via the AJAX fragment) in
+               this case, so it needs its own media JS (martor editor, vote/hide/edit). #}
+            {% include "comments/media-js.html" %}
+        {% endif %}
+        {% include "comments/lazy-load-js.html" %}
     {% endif %}
 {% endblock %}
 
@@ -352,7 +357,15 @@
 
 
     {% if not comment_lock %}
-        {% include "comments/list.html" %}
+        <div id="comments" data-comments-url="{{ url('contest_comments', contest.key) }}"
+             data-comments-trigger="auto"
+             data-comments-preloaded="{{ 'true' if comment_form and comment_form.errors else 'false' }}">
+            {% if comment_form and comment_form.errors %}
+                {% include "comments/list.html" %}
+            {% else %}
+                <div class="comments-loading">{{ _('Loading...') }}</div>
+            {% endif %}
+        </div>
     {% endif %}
 
     <div style="clear: both;"></div>

--- a/templates/problem/comments-tab.html
+++ b/templates/problem/comments-tab.html
@@ -1,0 +1,24 @@
+{% if not comment_lock %}
+    {% include "comments/media-js.html" %}
+{% endif %}
+{% if comment_lock %}
+    <div class="clarifications-area">
+        <h2><i class="fa fa-question-circle"></i> {{ _('Clarifications') }}</h2>
+        {% if has_clarifications %}
+            {% for clarification in clarifications %}
+                <div class="problem-clarification">
+                    <div class="time">{{ relative_time(clarification.date) }}</div>
+                    <span class="body">
+                        {{ clarification.description|markdown('problem', MATH_ENGINE)|reference }}
+                    </span>
+                </div>
+            {% endfor %}
+        {% else %}
+            <p class="no-comments-message">{{ _('No clarifications have been made at this time.') }}</p>
+        {% endif %}
+    </div>
+{% else %}
+    {% with comment_warn_code=true %}
+        {% include "comments/list.html" %}
+    {% endwith %}
+{% endif %}

--- a/templates/problem/editorial-comments-tab.html
+++ b/templates/problem/editorial-comments-tab.html
@@ -1,0 +1,4 @@
+{% if not comment_lock %}
+    {% include "comments/media-js.html" %}
+{% endif %}
+{% include "comments/list.html" %}

--- a/templates/problem/editorial.html
+++ b/templates/problem/editorial.html
@@ -1,7 +1,12 @@
 {% extends "common-content.html" %}
 
 {% block content_js_media %}
-    {% include "comments/media-js.html" %}
+    {% if comment_form and comment_form.errors %}
+        {# comments/list.html is SSR'd directly below (not via the AJAX fragment) in
+           this case, so it needs its own media JS (martor editor, vote/hide/edit). #}
+        {% include "comments/media-js.html" %}
+    {% endif %}
+    {% include "comments/lazy-load-js.html" %}
 {% endblock %}
 
 {% block content_media %}
@@ -39,7 +44,15 @@
         {{ solution.content|markdown('solution', MATH_ENGINE)|reference|str|safe }}
     </div>
     <hr>
-    {% include "comments/list.html" %}
+    <div id="comments" data-comments-url="{{ url('problem_editorial_comments', problem.code) }}"
+         data-comments-trigger="auto"
+         data-comments-preloaded="{{ 'true' if comment_form and comment_form.errors else 'false' }}">
+        {% if comment_form and comment_form.errors %}
+            {% include "comments/list.html" %}
+        {% else %}
+            <div class="comments-loading">{{ _('Loading...') }}</div>
+        {% endif %}
+    </div>
 {% endblock %}
 
 {% block bodyend %}

--- a/templates/problem/problem.html
+++ b/templates/problem/problem.html
@@ -54,21 +54,16 @@
             position: absolute;
             left: -999em;
         }
-
-        .comments-loading {
-            padding: 1em 0;
-            text-align: center;
-            color: #888;
-        }
-
-        .show-comments-wrapper {
-            padding: 1.5em 0;
-            text-align: center;
-        }
     </style>
 {% endblock %}
 
 {% block content_js_media %}
+    {% if comment_form and comment_form.errors %}
+        {# comments/list.html is SSR'd directly below (not via the AJAX fragment) in
+           this case, so it needs its own media JS (martor editor, vote/hide/edit). #}
+        {% include "comments/media-js.html" %}
+    {% endif %}
+    {% include "comments/lazy-load-js.html" %}
     {% if request.user.is_authenticated and form %}
         {% include "problem/submit-js.html" %}
     {% endif %}
@@ -85,43 +80,6 @@
                 frames['raw_problem'].print();
             });
 
-            // Lazily load the comments tab only when it's first opened.
-            var comments_loaded = false;
-            function fetch_comments(page, scroll) {
-                // First match is the outer tab container (the fragment renders an
-                // inner #comments div of its own).
-                var $comments = $('#comments').first();
-                var url = $comments.data('comments-url');
-                if (page)
-                    url += '?page=' + page;
-                $comments.html('<div class="comments-loading">{{ _('Loading...') }}</div>');
-                $comments.load(url, function() {
-                    if (window.MathJax && MathJax.typesetPromise)
-                        MathJax.typesetPromise([$comments[0]]);
-                    if (scroll)
-                        $comments[0].scrollIntoView({behavior: 'instant', block: 'start'});
-                });
-            }
-
-            function load_comments() {
-                if (comments_loaded) return;
-                comments_loaded = true;
-                fetch_comments(null, false);
-            }
-
-            // Paginate comments without reloading the page.
-            $('#comments').on('click', '.comments-pagination a', function(e) {
-                var match = /page=(\d+)/.exec($(this).attr('href'));
-                if (!match) return;
-                e.preventDefault();
-                fetch_comments(match[1], true);
-            });
-
-            // Comments are only fetched when explicitly requested.
-            $('#comments').on('click', '#show-comments-button', function() {
-                load_comments();
-            });
-
             // Tab switching functionality
             $('.problem-tabs a').click(function(e) {
                 e.preventDefault();
@@ -136,7 +94,8 @@
                 $(target).addClass('active');
 
                 if (target === '#comments') {
-                    load_comments();
+                    var loadComments = $('#comments').data('load-comments');
+                    if (loadComments) loadComments();
                 }
 
                 // Update URL hash without scrolling
@@ -147,10 +106,23 @@
                 }
             });
 
-            // Handle initial hash in URL
+            // Handle initial hash in URL. A #comment-<id> permalink (e.g. from the
+            // recent-comments widget) isn't a tab id, so it needs its own handling:
+            // open the comments tab and let lazy-load-js.html scroll to it once loaded.
             var hash = window.location.hash;
-            if (hash && $(hash).length) {
+            if (/^#comment-\d+$/.test(hash)) {
+                var setPendingScroll = $('#comments').data('set-pending-scroll');
+                if (setPendingScroll) setPendingScroll(hash);
+                $('.problem-tabs a[href="#comments"]').click();
+            } else if (hash && $(hash).length) {
                 $('.problem-tabs a[href="' + hash + '"]').click();
+            } else if ($('#comments').hasClass('active')) {
+                // No hash-driven tab switch happened, but the comments tab is
+                // already the default active tab (anonymous users have no
+                // "Submit Solution" tab) - load it now instead of waiting for a
+                // click that will never come.
+                var loadComments = $('#comments').data('load-comments');
+                if (loadComments) loadComments();
             }
         });
     </script>
@@ -446,29 +418,40 @@
 {% endblock %}
 
 {% block comments %}
+    {# A failed comment submission must land on the Comments tab so the error is
+       actually visible, even for authenticated users (whose default tab is
+       otherwise Submit Solution). #}
+    {% set comments_tab_active = not request.user.is_authenticated or (comment_form and comment_form.errors) %}
     <div class="problem-tabs">
         <ul>
             {% if request.user.is_authenticated %}
-                <li><a href="#submit" class="active">{{ _('Submit Solution') }}</a></li>
+                <li><a href="#submit" {% if not comments_tab_active %}class="active"{% endif %}>{{ _('Submit Solution') }}</a></li>
             {% endif %}
-            <li><a href="#comments" {% if not request.user.is_authenticated %}class="active"{% endif %}>{{ _('Comments') }}</a></li>
+            <li><a href="#comments" {% if comments_tab_active %}class="active"{% endif %}>{{ _('Comments') }}</a></li>
         </ul>
     </div>
 
     {% if request.user.is_authenticated %}
-        <div id="submit" class="tab-content active">
+        <div id="submit" class="tab-content {% if not comments_tab_active %}active{% endif %}">
             <div class="submit-tab-content">
                 {% include "problem/submit-form.html" %}
             </div>
         </div>
     {% endif %}
 
-    <div id="comments" class="tab-content {% if not request.user.is_authenticated %}active{% endif %}"
-         data-comments-url="{{ url('problem_comments', problem.code) }}">
-        <div class="show-comments-wrapper">
-            <button id="show-comments-button" class="unselectable button">
-                <i class="fa fa-comments"></i> {{ _('Show comments') }}
-            </button>
-        </div>
+    <div id="comments" class="tab-content {% if comments_tab_active %}active{% endif %}"
+         data-comments-url="{{ url('problem_comments', problem.code) }}" data-comments-trigger="tab"
+         data-comments-preloaded="{{ 'true' if comment_form and comment_form.errors else 'false' }}">
+        {% if comment_form and comment_form.errors %}
+            {# A failed comment submission needs its error shown; render the full list
+               instead of the placeholder so comment_form.errors is actually visible.
+               data-comments-preloaded above tells lazy-load-js.html not to clobber
+               this with an AJAX fetch (which would build a fresh, error-free form). #}
+            {% with comment_warn_code=true %}
+                {% include "comments/list.html" %}
+            {% endwith %}
+        {% else %}
+            <div class="comments-loading">{{ _('Loading...') }}</div>
+        {% endif %}
     </div>
 {% endblock %}

--- a/templates/problem/problem.html
+++ b/templates/problem/problem.html
@@ -60,6 +60,11 @@
             text-align: center;
             color: #888;
         }
+
+        .show-comments-wrapper {
+            padding: 1.5em 0;
+            text-align: center;
+        }
     </style>
 {% endblock %}
 
@@ -82,15 +87,40 @@
 
             // Lazily load the comments tab only when it's first opened.
             var comments_loaded = false;
+            function fetch_comments(page, scroll) {
+                // First match is the outer tab container (the fragment renders an
+                // inner #comments div of its own).
+                var $comments = $('#comments').first();
+                var url = $comments.data('comments-url');
+                if (page)
+                    url += '?page=' + page;
+                $comments.html('<div class="comments-loading">{{ _('Loading...') }}</div>');
+                $comments.load(url, function() {
+                    if (window.MathJax && MathJax.typesetPromise)
+                        MathJax.typesetPromise([$comments[0]]);
+                    if (scroll)
+                        $comments[0].scrollIntoView({behavior: 'instant', block: 'start'});
+                });
+            }
+
             function load_comments() {
                 if (comments_loaded) return;
                 comments_loaded = true;
-                var $comments = $('#comments');
-                $comments.load($comments.data('comments-url'), function() {
-                    if (window.MathJax && MathJax.typesetPromise)
-                        MathJax.typesetPromise([$comments[0]]);
-                });
+                fetch_comments(null, false);
             }
+
+            // Paginate comments without reloading the page.
+            $('#comments').on('click', '.comments-pagination a', function(e) {
+                var match = /page=(\d+)/.exec($(this).attr('href'));
+                if (!match) return;
+                e.preventDefault();
+                fetch_comments(match[1], true);
+            });
+
+            // Comments are only fetched when explicitly requested.
+            $('#comments').on('click', '#show-comments-button', function() {
+                load_comments();
+            });
 
             // Tab switching functionality
             $('.problem-tabs a').click(function(e) {
@@ -121,11 +151,6 @@
             var hash = window.location.hash;
             if (hash && $(hash).length) {
                 $('.problem-tabs a[href="' + hash + '"]').click();
-            }
-
-            // If the comments tab is the active one on load (e.g. anonymous users), load it now.
-            if ($('#comments').hasClass('active')) {
-                load_comments();
             }
         });
     </script>
@@ -440,6 +465,10 @@
 
     <div id="comments" class="tab-content {% if not request.user.is_authenticated %}active{% endif %}"
          data-comments-url="{{ url('problem_comments', problem.code) }}">
-        <div class="comments-loading">{{ _('Loading...') }}</div>
+        <div class="show-comments-wrapper">
+            <button id="show-comments-button" class="unselectable button">
+                <i class="fa fa-comments"></i> {{ _('Show comments') }}
+            </button>
+        </div>
     </div>
 {% endblock %}

--- a/templates/problem/problem.html
+++ b/templates/problem/problem.html
@@ -54,13 +54,16 @@
             position: absolute;
             left: -999em;
         }
+
+        .comments-loading {
+            padding: 1em 0;
+            text-align: center;
+            color: #888;
+        }
     </style>
 {% endblock %}
 
 {% block content_js_media %}
-    {% if not comment_lock %}
-        {% include "comments/media-js.html" %}
-    {% endif %}
     {% if request.user.is_authenticated and form %}
         {% include "problem/submit-js.html" %}
     {% endif %}
@@ -77,6 +80,18 @@
                 frames['raw_problem'].print();
             });
 
+            // Lazily load the comments tab only when it's first opened.
+            var comments_loaded = false;
+            function load_comments() {
+                if (comments_loaded) return;
+                comments_loaded = true;
+                var $comments = $('#comments');
+                $comments.load($comments.data('comments-url'), function() {
+                    if (window.MathJax && MathJax.typesetPromise)
+                        MathJax.typesetPromise([$comments[0]]);
+                });
+            }
+
             // Tab switching functionality
             $('.problem-tabs a').click(function(e) {
                 e.preventDefault();
@@ -90,6 +105,10 @@
                 $('.tab-content').removeClass('active');
                 $(target).addClass('active');
 
+                if (target === '#comments') {
+                    load_comments();
+                }
+
                 // Update URL hash without scrolling
                 if (history.pushState) {
                     history.pushState(null, null, target);
@@ -102,6 +121,11 @@
             var hash = window.location.hash;
             if (hash && $(hash).length) {
                 $('.problem-tabs a[href="' + hash + '"]').click();
+            }
+
+            // If the comments tab is the active one on load (e.g. anonymous users), load it now.
+            if ($('#comments').hasClass('active')) {
+                load_comments();
             }
         });
     </script>
@@ -414,27 +438,8 @@
         </div>
     {% endif %}
 
-    <div id="comments" class="tab-content {% if not request.user.is_authenticated %}active{% endif %}">
-        {% if comment_lock %}
-            <div class="clarifications-area">
-                <h2><i class="fa fa-question-circle"></i> {{ _('Clarifications') }}</h2>
-                {% if has_clarifications %}
-                    {% for clarification in clarifications %}
-                        <div class="problem-clarification">
-                            <div class="time">{{ relative_time(clarification.date) }}</div>
-                            <span class="body">
-                                {{ clarification.description|markdown('problem', MATH_ENGINE)|reference }}
-                            </span>
-                        </div>
-                    {% endfor %}
-                {% else %}
-                    <p class="no-comments-message">{{ _('No clarifications have been made at this time.') }}</p>
-                {% endif %}
-            </div>
-        {% else %}
-            {% with comment_warn_code=true %}
-                {% include "comments/list.html" %}
-            {% endwith %}
-        {% endif %}
+    <div id="comments" class="tab-content {% if not request.user.is_authenticated %}active{% endif %}"
+         data-comments-url="{{ url('problem_comments', problem.code) }}">
+        <div class="comments-loading">{{ _('Loading...') }}</div>
     </div>
 {% endblock %}

--- a/templates/tag/comments-tab.html
+++ b/templates/tag/comments-tab.html
@@ -1,0 +1,4 @@
+{% if not comment_lock %}
+    {% include "comments/media-js.html" %}
+{% endif %}
+{% include "comments/list.html" %}

--- a/templates/tag/problem.html
+++ b/templates/tag/problem.html
@@ -9,7 +9,12 @@
 {% endblock %}
 
 {% block js_media %}
-    {% include "comments/media-js.html" %}
+    {% if comment_form and comment_form.errors %}
+        {# comments/list.html is SSR'd directly below (not via the AJAX fragment) in
+           this case, so it needs its own media JS (martor editor, vote/hide/edit). #}
+        {% include "comments/media-js.html" %}
+    {% endif %}
+    {% include "comments/lazy-load-js.html" %}
 {% endblock %}
 
 {% block title_ruler %}{% endblock %}
@@ -55,7 +60,15 @@
             {% endfor %}
         </tbody>
     </table>
-    {% include "comments/list.html" %}
+    <div id="comments" data-comments-url="{{ url('tagproblem_comments', problem.code) }}"
+         data-comments-trigger="auto"
+         data-comments-preloaded="{{ 'true' if comment_form and comment_form.errors else 'false' }}">
+        {% if comment_form and comment_form.errors %}
+            {% include "comments/list.html" %}
+        {% else %}
+            <div class="comments-loading">{{ _('Loading...') }}</div>
+        {% endif %}
+    </div>
 {% endblock %}
 
 {% block bodyend %}


### PR DESCRIPTION
# Description

lazy load comments, support pagination for all comments view

Type of change: new feature

## Why

Generate comment to slow

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Seed 2k comments and manual testing

<img width="1004" height="387" alt="Screenshot 2026-07-07 at 00 32 56" src="https://github.com/user-attachments/assets/75c8cc89-e41d-4d7a-bfda-b6c8fc4b9979" />
<img width="1010" height="166" alt="Screenshot 2026-07-07 at 00 33 17" src="https://github.com/user-attachments/assets/e4f599ea-129a-4572-b2c1-a6ead383fcc0" />


# Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Informed of breaking changes, testing and migrations (if applicable).
- [x] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
