### PR TITLE
Allow curators to bulk delete their problems in the org dashboard.

### DIFF
--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -651,7 +651,7 @@ class BulkDeleteOrganizationProblems(LoginRequiredMixin, AdminOrganizationMixin,
 
         if not request.user.is_superuser:
             all_count = problems.count()
-            problems = problems.filter(authors=request.profile)
+            problems = problems.filter(Q(authors=request.profile) | Q(curators=request.profile))
             skipped = all_count - problems.count()
             if skipped > 0:
                 messages.error(request, ngettext(
@@ -830,7 +830,7 @@ class OrganizationStorageDashboard(LoginRequiredMixin, TitleMixin, AdminOrganiza
             data_size=Coalesce(F('data_files__zipfile_size'), Value(0)),
         ).only(
             'code', 'name',
-        ).prefetch_related('authors__user')
+        ).prefetch_related('authors__user', 'curators__user')
 
         # Annotate with the latest submission date
 
@@ -843,7 +843,7 @@ class OrganizationStorageDashboard(LoginRequiredMixin, TitleMixin, AdminOrganiza
             try:
                 author_id = int(author_id)
                 if self.organization.admins.filter(id=author_id).exists():
-                    queryset = queryset.filter(authors__id=author_id)
+                    queryset = queryset.filter(Q(authors__id=author_id) | Q(curators__id=author_id))
             except ValueError:
                 pass
 

--- a/templates/organization/usage.html
+++ b/templates/organization/usage.html
@@ -424,7 +424,7 @@
                 <tr>
                     <td style="text-align: center; vertical-align: middle;">
                         <input type="checkbox" class="problem-select-checkbox" value="{{ problem.id }}"
-                               data-author-ids="{{ problem.authors.all()|map(attribute='id')|list|tojson }}"
+                               data-author-ids="{{ (problem.authors.all()|map(attribute='id')|list + problem.curators.all()|map(attribute='id')|list)|tojson }}"
                                style="transform: scale(1.2); cursor: pointer;">
                     </td>
                     <td class="problem-code">
@@ -434,7 +434,7 @@
                         <a href="{{ url('problem_detail', problem.code) }}">{{ problem.i18n_name or problem.name }}</a>
                     </td>
                     <td>
-                        {{ link_users(problem.authors.all()) }}
+                        {{ link_users((problem.authors.all()|list + problem.curators.all()|list)|unique(attribute='id')) }}
                     </td>
                     <td class="size-cell">
                         {{ problem.data_size|filesizeformat }}
@@ -445,7 +445,7 @@
                     <td>
                         <a href="{{ url('problem_download_full_package', problem.code) }}"
                            class="btn btn-xs delete-btn"
-                           data-author-ids="{{ problem.authors.all()|map(attribute='id')|list|tojson }}"
+                           data-author-ids="{{ (problem.authors.all()|map(attribute='id')|list + problem.curators.all()|map(attribute='id')|list)|tojson }}"
                            style="display:none;">
                             <i class="fa fa-download"></i> {{ _('Test data') }}
                         </a>
@@ -453,7 +453,7 @@
                     <td>
                         <a href="{{ url('problem_delete', problem.code) }}?next={{ request.path }}"
                            class="btn btn-xs btn-danger delete-btn"
-                           data-author-ids="{{ problem.authors.all()|map(attribute='id')|list|tojson }}"
+                           data-author-ids="{{ (problem.authors.all()|map(attribute='id')|list + problem.curators.all()|map(attribute='id')|list)|tojson }}"
                            style="display:none;">
                             <i class="fa fa-trash"></i> {{ _('Delete') }}
                         </a>


### PR DESCRIPTION
Apparently, when cloning problems, the actor is set to curators, not authors, which leads to a ton of problems not having authors.

This fix also aligns with the logic of `Problem.is_editable_by()`
