### PR TITLE
Throw error in case checker_args is not provided for the bridged checker

### DIFF
--- a/judge/utils/problem_data.py
+++ b/judge/utils/problem_data.py
@@ -145,6 +145,8 @@ class ProblemDataCompiler(object):
 
                 if checker_ext not in ['cpp', 'pas', 'java']:
                     raise ProblemDataError(_('Only C++, Pascal, or Java checkers are supported.'))
+                if not case.checker_args:
+                    raise ProblemDataError(_('How did you corrupt the checker arguments?'))
 
             if case.checker_args:
                 return {


### PR DESCRIPTION
I have no idea how this could happend in normal UI cases, maybe the user was messing with the js?
