### PR TITLE
Remove old partial AC logic

### DIFF
--- a/judge/models/problem.py
+++ b/judge/models/problem.py
@@ -484,7 +484,7 @@ class Problem(models.Model):
 
     def update_stats(self):
         all_queryset = self.submission_set.filter(user__is_unlisted=False)
-        ac_queryset = all_queryset.filter(points__gte=self.points, result='AC')
+        ac_queryset = all_queryset.filter(result='AC')
         self.user_count = ac_queryset.values('user').distinct().count()
         submissions = all_queryset.count()
         if submissions:

--- a/judge/models/profile.py
+++ b/judge/models/profile.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.validators import RegexValidator
 from django.db import models
-from django.db.models import F, Max, Sum
+from django.db.models import Max, Sum
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import force_bytes
@@ -401,8 +401,7 @@ class Profile(models.Model):
         bonus_function = settings.DMOJ_PP_BONUS_FUNCTION
         points = sum(data)
         problems = (
-            public_problems.filter(submission__user=self, submission__result='AC',
-                                   submission__case_points__gte=F('submission__case_total'))
+            public_problems.filter(submission__user=self, submission__result='AC')
             .values('id').distinct().count()
         )
         pp = sum(x * y for x, y in zip(table, data)) + bonus_function(problems)

--- a/judge/utils/problems.py
+++ b/judge/utils/problems.py
@@ -25,7 +25,7 @@ def contest_completed_ids(participation):
     key = 'contest_complete:%d' % participation.id
     result = cache.get(key)
     if result is None:
-        result = set(participation.submissions.filter(submission__result='AC', points__gte=F('problem__points'))
+        result = set(participation.submissions.filter(submission__result='AC')
                      .values_list('problem__problem_id', flat=True).distinct())
         cache.set(key, result, 86400)
     return result

--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.db import transaction
-from django.db.models import BooleanField, Case, F, Prefetch, Q, When
+from django.db.models import BooleanField, Case, Prefetch, Q, When
 from django.db.utils import ProgrammingError
 from django.http import Http404, HttpResponse, HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
@@ -620,7 +620,7 @@ class ProblemList(QueryStringSortMixin, TitleMixin, SolvedProblemMixin, Infinite
 
         if self.profile is not None and self.hide_solved:
             queryset = queryset.exclude(id__in=Submission.objects
-                                        .filter(user=self.profile, result='AC', case_points__gte=F('case_total'))
+                                        .filter(user=self.profile, result='AC')
                                         .values_list('problem_id', flat=True))
         if self.show_types:
             queryset = queryset.prefetch_related('types')


### PR DESCRIPTION
After #619, `case_points >= case_total` logic is no longer needed. The previous PR removed most of the related logic, but a few were missed. This PR removes them.
