### PR TITLE
Show more org details in org list for admin, add search

### DIFF
--- a/judge/jinja2/reference.py
+++ b/judge/jinja2/reference.py
@@ -151,7 +151,8 @@ def link_user(user):
     else:
         raise ValueError('Expected profile or user, got %s' % (type(user),))
 
-    if isinstance(profile, Profile) and profile.display_badge:
+    # only show display_badge if it is explicitly prefetched
+    if isinstance(profile, Profile) and 'display_badge' in profile.__dict__ and profile.display_badge:
         display_badge_img = f'<img src="{escape(profile.display_badge.mini)}"' \
                             f' title="{escape(profile.display_badge.name)}"' \
                             f' style="height: 1em; width: auto; margin-left: 0.25em;" />'

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -148,14 +148,62 @@ class BaseOrganizationListView(PublicOrganizationMixin, ListView):
         return super(BaseOrganizationListView, self).get_object(queryset)
 
 
-class OrganizationList(TitleMixin, ListView):
+class OrganizationList(DiggPaginatorMixin, TitleMixin, ListView):
     model = Organization
     context_object_name = 'organizations'
     template_name = 'organization/list.html'
     title = gettext_lazy('Organizations')
+    paginate_by = 200
+
+    @cached_property
+    def can_manage_organizations(self):
+        return self.request.user.has_perm('judge.edit_all_organization')
+
+    def GET_with_session(self, key):
+        if key not in self.request.GET:
+            return self.request.session.get(key, False)
+        return self.request.GET.get(key, None) == '1'
+
+    @cached_property
+    def show_all_orgs(self):
+        return self.can_manage_organizations and self.GET_with_session('show_all_orgs')
 
     def get_queryset(self):
-        return Organization.objects.filter(is_unlisted=False)
+        if self.show_all_orgs:
+            queryset = Organization.objects.prefetch_related('admins__user')
+        else:
+            queryset = Organization.objects.filter(is_unlisted=False)
+
+        self.search_query = None
+        if self.show_all_orgs and 'search' in self.request.GET:
+            self.search_query = search_query = ' '.join(self.request.GET.getlist('search')).strip()
+            if search_query:
+                queryset = queryset.filter(
+                    Q(name__icontains=search_query) |
+                    Q(slug__icontains=search_query) |
+                    Q(short_name__icontains=search_query) |
+                    Q(admins__user__username__icontains=search_query),
+                ).distinct()
+        return queryset
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['show_all_orgs'] = self.show_all_orgs
+        context['search_query'] = self.search_query
+        context.update(paginate_query_context(self.request))
+        if self.request.user.is_authenticated:
+            user_organizations = self.request.profile.organizations.all()
+            if self.show_all_orgs:
+                user_organizations = user_organizations.prefetch_related('admins__user')
+            context['user_organizations'] = user_organizations
+        return context
+
+    def post(self, request, *args, **kwargs):
+        if 'show_all_orgs' in request.GET:
+            request.session['show_all_orgs'] = request.GET.get('show_all_orgs') == '1'
+        else:
+            request.session.pop('show_all_orgs', None)
+        return HttpResponseRedirect(request.get_full_path())
 
 
 class OrganizationUsers(QueryStringSortMixin, DiggPaginatorMixin, BaseOrganizationListView):

--- a/templates/organization/list-tabs.html
+++ b/templates/organization/list-tabs.html
@@ -1,6 +1,13 @@
 {% extends "user/user-list-tabs.html" %}
 
 {% block tabs %}
+    {% if perms.judge.edit_all_organization %}
+        <form id="show-all-orgs-form" action="" method="get" style="display: inline-block; padding: 0.75em 1em 0.75em 0;">
+            <input id="show_all_orgs" type="checkbox" name="show_all_orgs" value="1"
+                   {% if show_all_orgs %}checked{% endif %}>
+            <label for="show_all_orgs">{{ _('Show all orgs') }}</label>
+        </form>
+    {% endif %}
     {% if perms.judge.add_organization %}
         {{ make_tab('create', 'fa-plus', url('organization_create'), _('Create new organization')) }}
     {% endif %}

--- a/templates/organization/list.html
+++ b/templates/organization/list.html
@@ -4,6 +4,13 @@
     <script type="text/javascript">
         $(function () {
             $('.organization-table').tablesorter({sortList: [[1, 1]]});
+
+            $('input#show_all_orgs').click(function () {
+                ($('<form>').attr('action', window.location.pathname + '?' + $('form#show-all-orgs-form').serialize())
+                    .append($('<input>').attr('type', 'hidden').attr('name', 'csrfmiddlewaretoken')
+                        .attr('value', $.cookie('csrftoken')))
+                    .attr('method', 'POST').appendTo($('body')).submit());
+            });
         });
     </script>
 {% endblock %}
@@ -15,14 +22,19 @@
     {% include "organization/list-tabs.html" %}
 {% endblock %}
 
-{% macro org_table(name, queryset) %}
+{% macro org_table(name, queryset, show_admin_info=False) %}
     <h4>{{ name }}</h4>
     <table class="organization-table table striped">
         <thead>
             <tr>
-                <th style="width:70%">{{ _('Name') }}</th>
-                <th style="width:15%">{{ _('Points') }}</th>
+                <th{% if not show_admin_info %} style="width:70%"{% endif %}>{{ _('Name') }}</th>
+                <th{% if not show_admin_info %} style="width:15%"{% endif %}>{{ _('Points') }}</th>
                 <th>{{ _('Members') }}</th>
+                {% if show_admin_info %}
+                    <th>{{ _('Short name') }}</th>
+                    <th>{{ _('Slug') }}</th>
+                    <th>{{ _('Admins') }}</th>
+                {% endif %}
             </tr>
         </thead>
         <tbody>
@@ -31,6 +43,11 @@
                 <td class="organization-name"><a href="{{ org.get_absolute_url() }}">{{ org.name }}</a></td>
                 <td><a href="{{ org.get_users_url() }}">{{ org.performance_points|floatformat(2) }}</a></td>
                 <td><a href="{{ org.get_users_url() }}">{{ org.member_count }}</a></td>
+                {% if show_admin_info %}
+                    <td>{{ org.short_name }}</td>
+                    <td>{{ org.slug }}</td>
+                    <td>{{ link_users(org.admins.all()) }}</td>
+                {% endif %}
             </tr>
         {% endfor %}
         </tbody>
@@ -39,13 +56,26 @@
 
 {% block body %}
     <div class="content-description">
-        {% if request.user.is_authenticated %}
-            {% with orgs=request.profile.organizations.all() %}
-                {% if orgs %}
-                    {{ org_table(_('Your organizations'), orgs) }}
-                {% endif %}
-            {% endwith %}
+        {% if user_organizations %}
+            {{ org_table(_('Your organizations'), user_organizations, show_admin_info=show_all_orgs) }}
         {% endif %}
-        {{ org_table(_('All organizations'), organizations) }}
+
+        {% if (page_obj and page_obj.has_other_pages()) or show_all_orgs %}
+            <div class="top-pagination-bar">
+                {% if page_obj and page_obj.has_other_pages() %}
+                    {% include "list-pages.html" %}
+                {% endif %}
+                {% if show_all_orgs %}
+                    <div style="display: flex; align-items: center; margin-left: auto;">
+                        <form id="search-form" name="form" action="" method="get">
+                            <input id="search" type="text" name="search" value="{{ search_query or '' }}"
+                                placeholder="{{ _('Search organization...') }}">
+                        </form>
+                    </div>
+                {% endif %}
+            </div>
+        {% endif %}
+
+        {{ org_table(_('All organizations'), organizations, show_admin_info=show_all_orgs) }}
     </div>
 {% endblock %}


### PR DESCRIPTION
If a user have `edit_all_organization` perm, we will show org name, short name, slug, admins in the table. It helps us quickly search an organization
