### PR TITLE
Feat/tusd service resumable uploads

### DIFF
--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -260,6 +260,21 @@ DMOJ_CAMO_EXCLUDE = ()
 
 DMOJ_PROBLEM_DATA_ROOT = None
 
+# Resumable upload settings
+TUSD_ENDPOINT = None                              # Disable by default
+TUSD_DATA_DIR = None                              # tusd storage dir
+TUSD_HOOK_SECRET = None                           # Shared secret to verify webhook requests
+TUSD_JWT_SECRET = None                            # JWT signing key (fallback: SECRET_KEY)
+TUSD_JWT_EXPIRY_SECONDS = 7200
+TUSD_UPLOAD_THRESHOLD_BYTES = 100 * 1024 * 1024
+TUSD_ALLOWED_FILE_TYPES = (
+    'zipfile',
+    'generator',
+    'custom_checker',
+    'custom_grader',
+    'custom_header',
+)
+
 DMOJ_PROBLEM_MIN_TIME_LIMIT = 0.01  # seconds
 DMOJ_PROBLEM_MAX_TIME_LIMIT = 60  # seconds
 DMOJ_PROBLEM_MIN_MEMORY_LIMIT = 0  # kilobytes
@@ -482,6 +497,7 @@ else:
 INSTALLED_APPS += (
     'django.contrib.admin',
     'judge',
+    'resumable_upload',
     'urlshortener',
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/dmoj/urls.py
+++ b/dmoj/urls.py
@@ -111,6 +111,9 @@ urlpatterns = [
     # URL Shortener management (on main domain)
     path('shorteners/', include('urlshortener.urls')),
 
+    # Resumable upload (tusd integration)
+    path('upload/', include('resumable_upload.urls')),
+
     path('problems', include([
         path('/', problem.ProblemList.as_view(), name='problem_list'),
         path('/random/', problem.RandomProblem.as_view(), name='problem_random'),

--- a/judge/views/problem_data.py
+++ b/judge/views/problem_data.py
@@ -206,6 +206,14 @@ class ProblemDataView(TitleMixin, ProblemManagerMixin):
         try:
             if post and 'problem-data-zipfile-clear' in self.request.POST:
                 return []
+            # File was already moved to data dir by tusd pre-finish hook.
+            # Use the existing zip on disk to derive valid_files without re-uploading.
+            elif post and self.request.POST.get('tus_upload_completed'):
+                filename = os.path.basename(self.request.POST.get('tus_upload_completed'))
+                zip_path = os.path.join(settings.DMOJ_PROBLEM_DATA_ROOT, data.problem.code, filename)
+                if os.path.exists(zip_path):
+                    return ZipFile(zip_path).namelist()
+                return []
             elif post and 'problem-data-zipfile' in self.request.FILES:
                 return ZipFile(self.request.FILES['problem-data-zipfile']).namelist()
             elif data.zipfile:
@@ -237,6 +245,10 @@ class ProblemDataView(TitleMixin, ProblemManagerMixin):
             add_quota_context(problem.organization, context)
 
         context['quota_warning_suffix'] = settings.VNOJ_QUOTA_WARNING_SUFFIX
+        if settings.TUSD_ENDPOINT:
+            context['tusd_upload_threshold_bytes'] = settings.TUSD_UPLOAD_THRESHOLD_BYTES
+        else:
+            context['tusd_upload_threshold_bytes'] = None
         return context
 
     def check_valid(self, data_form, cases_formset):
@@ -273,8 +285,21 @@ class ProblemDataView(TitleMixin, ProblemManagerMixin):
         data_form = self.get_data_form(post=True)
         valid_files = self.get_valid_files(data_form.instance, post=True)
         data_form.zip_valid = valid_files is not False
+
+        # When the zip was already moved to disk by tusd, bypass the in-memory
+        # zip-field required check — the model zipfile field already points to the
+        # correct file and was NOT re-uploaded through the form.
+        tus_completed = request.POST.get('tus_upload_completed')
+        if tus_completed:
+            data_form.zip_valid = True
+
         cases_formset = self.get_case_formset(valid_files, post=True)
         if self.check_valid(data_form, cases_formset):
+            if tus_completed:
+                filename = os.path.basename(tus_completed)
+                relative_path = f'{problem.code}/{filename}'
+                data_form.cleaned_data['zipfile'] = relative_path
+                data_form.instance.zipfile = relative_path
             data = data_form.save()
             for case in cases_formset.save(commit=False):
                 case.dataset_id = problem.id

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,3 +44,4 @@ django-admin-sortable2
 icalendar
 # This is a celery dependency whose latest major version is breaking everything.
 importlib-metadata<5
+PyJWT>=2.0

--- a/resumable_upload/__init__.py
+++ b/resumable_upload/__init__.py
@@ -1,0 +1,1 @@
+"""Resumable upload app."""

--- a/resumable_upload/apps.py
+++ b/resumable_upload/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class ResumableUploadConfig(AppConfig):
+    name = 'resumable_upload'
+    verbose_name = 'Resumable Upload'

--- a/resumable_upload/tests/__init__.py
+++ b/resumable_upload/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Resumable upload app tests."""

--- a/resumable_upload/tests/test_views.py
+++ b/resumable_upload/tests/test_views.py
@@ -1,0 +1,264 @@
+import json
+import os
+import tempfile
+
+import jwt
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from resumable_upload.views import create_upload_intent_token
+
+from judge.models import Problem, ProblemGroup, ProblemType, Profile
+
+User = get_user_model()
+
+_JWT_SECRET = 'test-jwt-secret'
+_HOOK_SECRET = 'test-hook-secret'
+_SETTINGS = {
+    'TUSD_JWT_SECRET': _JWT_SECRET,
+    'TUSD_JWT_EXPIRY_SECONDS': 7200,
+    'TUSD_HOOK_SECRET': _HOOK_SECRET,
+    'TUSD_ENDPOINT': 'http://localhost:8080/files/',
+    'TUSD_ALLOWED_FILE_TYPES': ('zipfile', 'generator', 'custom_checker', 'custom_grader', 'custom_header'),
+    'TUSD_DATA_DIR': None,
+}
+
+
+def _make_user(username, password='pw', perms=()):
+    user = User.objects.create_user(username=username, password=password)
+    Profile.objects.create(user=user)
+    for perm in perms:
+        from django.contrib.auth.models import Permission
+        user.user_permissions.add(Permission.objects.get(codename=perm))
+    return user
+
+
+def _make_problem(code='testproblem'):
+    group = ProblemGroup.objects.get_or_create(name='g', defaults={'full_name': 'Group'})[0]
+    ptype = ProblemType.objects.get_or_create(name='t', defaults={'full_name': 'Type'})[0]
+    problem = Problem.objects.create(
+        code=code,
+        name='Test Problem',
+        description='',
+        group=group,
+        time_limit=1,
+        memory_limit=65536,
+        points=100,
+        partial=False,
+        is_public=True,
+    )
+    problem.types.set([ptype])
+    return problem
+
+
+def _make_token(problem_code='testproblem', file_type='zipfile', file_name='tests.zip', **kwargs):
+    """Create a valid JWT for use in hook payloads."""
+    return create_upload_intent_token(1, problem_code, file_type, file_name)
+
+
+def _hook_body(hook_type, token, storage_path=''):
+    return json.dumps({
+        'Type': hook_type,
+        'Event': {
+            'Upload': {
+                'MetaData': {'token': token},
+                'Storage': {'Path': storage_path},
+            },
+        },
+    })
+
+
+@override_settings(**_SETTINGS)
+class UploadIntentViewTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.problem = _make_problem()
+        cls.editor = _make_user('editor', perms=['edit_own_problem', 'edit_all_problem'])
+        cls.regular = _make_user('regular', perms=['edit_own_problem'])
+        cls.intent_url = reverse('resumable_upload:upload_intent')
+
+    def _post(self, user, data):
+        self.client.force_login(user)
+        return self.client.post(
+            self.intent_url,
+            data=json.dumps(data),
+            content_type='application/json',
+        )
+
+    def test_intent_requires_login(self):
+        response = self.client.post(
+            self.intent_url,
+            data=json.dumps({'problem_code': 'testproblem', 'file_type': 'zipfile', 'file_name': 'x.zip'}),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_intent_valid_request(self):
+        resp = self._post(self.editor, {
+            'problem_code': 'testproblem',
+            'file_type': 'zipfile',
+            'file_name': 'tests.zip',
+        })
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn('token', data)
+        self.assertIn('tusd_endpoint', data)
+        payload = jwt.decode(data['token'], _JWT_SECRET, algorithms=['HS256'])
+        self.assertEqual(payload['problem_code'], 'testproblem')
+
+    def test_intent_invalid_problem_code(self):
+        resp = self._post(self.editor, {
+            'problem_code': 'does_not_exist',
+            'file_type': 'zipfile',
+            'file_name': 'x.zip',
+        })
+        self.assertEqual(resp.status_code, 404)
+
+    def test_intent_requires_edit_permission(self):
+        resp = self._post(self.regular, {
+            'problem_code': 'testproblem',
+            'file_type': 'zipfile',
+            'file_name': 'x.zip',
+        })
+        self.assertEqual(resp.status_code, 404)
+
+    def test_intent_invalid_file_type(self):
+        resp = self._post(self.editor, {
+            'problem_code': 'testproblem',
+            'file_type': 'malware',
+            'file_name': 'x.zip',
+        })
+        self.assertEqual(resp.status_code, 400)
+
+    def test_intent_missing_fields(self):
+        resp = self._post(self.editor, {'problem_code': 'testproblem'})
+        self.assertEqual(resp.status_code, 400)
+
+
+@override_settings(**_SETTINGS)
+class TusdHookViewTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.problem = _make_problem()
+
+    def setUp(self):
+        self.hooks_url = reverse('resumable_upload:tusd_hooks')
+
+    def _post(self, body, secret=_HOOK_SECRET):
+        headers = {}
+        if secret is not None:
+            headers['HTTP_X_TUSD_HOOK_SECRET'] = secret
+        return self.client.post(
+            self.hooks_url,
+            data=body,
+            content_type='application/json',
+            **headers,
+        )
+
+    def test_hook_missing_secret(self):
+        token = _make_token()
+        resp = self._post(_hook_body('pre-create', token), secret=None)
+        self.assertEqual(resp.status_code, 403)
+
+    def test_hook_wrong_secret(self):
+        token = _make_token()
+        resp = self._post(_hook_body('pre-create', token), secret='wrong')
+        self.assertEqual(resp.status_code, 403)
+
+    def test_hook_pre_create_valid_token(self):
+        token = _make_token()
+        resp = self._post(_hook_body('pre-create', token))
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertNotIn('RejectUpload', data)
+
+    def test_hook_pre_create_invalid_token(self):
+        resp = self._post(_hook_body('pre-create', 'not.a.jwt'))
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertTrue(data.get('RejectUpload'))
+
+    def test_hook_pre_finish_moves_file(self):
+        with tempfile.TemporaryDirectory() as data_root:
+            src_file = os.path.join(data_root, 'upload-id')
+            with open(src_file, 'wb') as f:
+                f.write(b'zip content')
+
+            token = _make_token(problem_code='testproblem', file_name='tests.zip')
+            body = _hook_body('pre-finish', token, storage_path=src_file)
+            with override_settings(DMOJ_PROBLEM_DATA_ROOT=data_root):
+                resp = self._post(body)
+
+            self.assertEqual(resp.status_code, 200)
+            dest = os.path.join(data_root, 'testproblem', 'tests.zip')
+            self.assertTrue(os.path.exists(dest))
+
+    def test_hook_pre_finish_error_rejects(self):
+        """If the source file does not exist, pre-finish returns RejectUpload."""
+        token = _make_token()
+        body = _hook_body('pre-finish', token, storage_path='/nonexistent/path/upload-id')
+        with tempfile.TemporaryDirectory() as data_root:
+            with override_settings(DMOJ_PROBLEM_DATA_ROOT=data_root):
+                resp = self._post(body)
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json().get('RejectUpload'))
+
+    def test_hook_unknown_type(self):
+        token = _make_token()
+        resp = self._post(_hook_body('post-terminate', token))
+        self.assertEqual(resp.status_code, 400)
+
+
+@override_settings(**_SETTINGS)
+class ProblemDataViewIntegrationTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.problem = _make_problem('testproblem')
+        cls.editor = _make_user('editor', perms=['edit_own_problem', 'edit_all_problem'])
+        cls.url = reverse('problem_data', args=[cls.problem.code])
+
+    def test_post_with_tus_upload_completed(self):
+        import zipfile
+        from judge.models import ProblemData
+        from judge.models.problem_data import problem_data_storage
+
+        with tempfile.TemporaryDirectory() as data_root:
+            prob_dir = os.path.join(data_root, self.problem.code)
+            os.makedirs(prob_dir, exist_ok=True)
+
+            zip_path = os.path.join(prob_dir, 'tests.zip')
+            with zipfile.ZipFile(zip_path, 'w') as zf:
+                zf.writestr('init.yml', 'testcases: []')
+
+            self.client.force_login(self.editor)
+
+            post_data = {
+                'problem-data-checker': 'standard',
+                'problem-data-grader': 'standard',
+                'problem-data-checker_type': 'testlib',
+                'problem-data-io_method': 'standard',
+                'problem-data-output_limit': '',
+                'cases-TOTAL_FORMS': '0',
+                'cases-INITIAL_FORMS': '0',
+                'cases-MIN_NUM_FORMS': '0',
+                'cases-MAX_NUM_FORMS': '1',
+                'tus_upload_completed': 'tests.zip',
+            }
+
+            old_location = problem_data_storage._location
+            old_base_location = problem_data_storage.base_location
+            problem_data_storage._location = data_root
+            problem_data_storage.base_location = data_root
+
+            try:
+                with override_settings(DMOJ_PROBLEM_DATA_ROOT=data_root):
+                    resp = self.client.post(self.url, data=post_data)
+            finally:
+                problem_data_storage._location = old_location
+                problem_data_storage.base_location = old_base_location
+
+            self.assertEqual(resp.status_code, 302)
+
+            prob_data = ProblemData.objects.get(problem=self.problem)
+            self.assertEqual(prob_data.zipfile.name, 'testproblem/tests.zip')
+            self.assertTrue(prob_data.zipfile_size > 0)

--- a/resumable_upload/urls.py
+++ b/resumable_upload/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+from resumable_upload.views import TusdHookView, UploadIntentView
+
+app_name = 'resumable_upload'
+
+urlpatterns = [
+    path('intent/', UploadIntentView.as_view(), name='upload_intent'),
+    path('hooks/', TusdHookView.as_view(), name='tusd_hooks'),
+]

--- a/resumable_upload/views.py
+++ b/resumable_upload/views.py
@@ -1,0 +1,145 @@
+import datetime
+import json
+import logging
+import os
+import shutil
+import uuid
+
+import jwt
+from django.conf import settings
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.http import Http404, JsonResponse
+from django.shortcuts import get_object_or_404
+from django.utils.decorators import method_decorator
+from django.views import View
+from django.views.decorators.csrf import csrf_exempt
+
+from judge.models import Problem
+
+logger = logging.getLogger(__name__)
+
+
+def _get_jwt_secret():
+    return getattr(settings, 'TUSD_JWT_SECRET', None) or settings.SECRET_KEY
+
+
+def create_upload_intent_token(user_id, problem_code, file_type, file_name):
+    expiry_seconds = getattr(settings, 'TUSD_JWT_EXPIRY_SECONDS', 7200)
+    payload = {
+        'sub': str(user_id),
+        'problem_code': problem_code,
+        'file_type': file_type,
+        'file_name': file_name,
+        'jti': str(uuid.uuid4()),
+        'exp': datetime.datetime.utcnow() + datetime.timedelta(seconds=expiry_seconds),
+    }
+    return jwt.encode(payload, _get_jwt_secret(), algorithm='HS256')
+
+
+def decode_upload_intent_token(token):
+    return jwt.decode(token, _get_jwt_secret(), algorithms=['HS256'])
+
+
+def move_uploaded_file(source_path, problem_code, file_name):
+    if not os.path.exists(source_path):
+        raise FileNotFoundError(f'tusd source file not found: {source_path}')
+
+    dest_dir = os.path.join(settings.DMOJ_PROBLEM_DATA_ROOT, problem_code)
+    os.makedirs(dest_dir, exist_ok=True)
+
+    dest_path = os.path.join(dest_dir, file_name)
+    shutil.move(source_path, dest_path)
+
+    info_path = source_path + '.info'
+    if os.path.exists(info_path):
+        try:
+            os.remove(info_path)
+        except OSError:
+            pass
+
+    return dest_path
+
+
+class UploadIntentView(LoginRequiredMixin, View):
+    http_method_names = ['post']
+    raise_exception = True
+
+    def post(self, request, *args, **kwargs):
+        try:
+            body = json.loads(request.body)
+        except (ValueError, TypeError):
+            return JsonResponse({'error': 'Invalid JSON body.'}, status=400)
+
+        problem_code = body.get('problem_code', '').strip()
+        file_type = body.get('file_type', '').strip()
+        file_name = body.get('file_name', '').strip()
+
+        if not problem_code or not file_type or not file_name:
+            return JsonResponse({'error': 'problem_code, file_type, and file_name are required.'}, status=400)
+
+        allowed_file_types = getattr(settings, 'TUSD_ALLOWED_FILE_TYPES', ())
+        if file_type not in allowed_file_types:
+            return JsonResponse(
+                {'error': f'file_type must be one of: {", ".join(allowed_file_types)}.'},
+                status=400,
+            )
+
+        problem = get_object_or_404(Problem, code=problem_code)
+        if not problem.is_editable_by(request.user):
+            raise Http404
+
+        token = create_upload_intent_token(request.user.pk, problem_code, file_type, file_name)
+        return JsonResponse({
+            'token': token,
+            'tusd_endpoint': settings.TUSD_ENDPOINT,
+        })
+
+
+@method_decorator(csrf_exempt, name='dispatch')
+class TusdHookView(View):
+    http_method_names = ['post']
+
+    def _verify_secret(self, request):
+        hook_secret = getattr(settings, 'TUSD_HOOK_SECRET', None)
+        if not hook_secret:
+            return True
+        return request.headers.get('X-Tusd-Hook-Secret') == hook_secret
+
+    def post(self, request, *args, **kwargs):
+        if not self._verify_secret(request):
+            return JsonResponse({'error': 'Forbidden.'}, status=403)
+
+        try:
+            body = json.loads(request.body)
+        except (ValueError, TypeError):
+            return JsonResponse({'error': 'Invalid JSON body.'}, status=400)
+
+        hook_type = body.get('Type', '')
+        token = body.get('Event', {}).get('Upload', {}).get('MetaData', {}).get('token', '')
+
+        try:
+            payload = decode_upload_intent_token(token)
+        except jwt.InvalidTokenError:
+            return JsonResponse({'RejectUpload': True}, status=200)
+
+        if hook_type == 'pre-create':
+            return JsonResponse({}, status=200)
+
+        elif hook_type == 'pre-finish':
+            upload_event = body.get('Event', {}).get('Upload', {})
+            source_path = upload_event.get('Storage', {}).get('Path', '')
+            if not source_path:
+                return JsonResponse({'RejectUpload': True}, status=200)
+
+            if getattr(settings, 'TUSD_DATA_DIR', None):
+                source_path = os.path.join(settings.TUSD_DATA_DIR, os.path.basename(source_path))
+
+            try:
+                move_uploaded_file(source_path, payload['problem_code'], payload['file_name'])
+            except Exception:
+                logger.exception('pre-finish: failed to move file')
+                return JsonResponse({'RejectUpload': True}, status=200)
+
+            return JsonResponse({}, status=200)
+
+        return JsonResponse({'error': f'Unsupported hook type: {hook_type!r}.'}, status=400)

--- a/templates/problem/data.html
+++ b/templates/problem/data.html
@@ -6,10 +6,14 @@
     <script type="text/javascript" src="{{ static('vnoj/jquery-ui/jquery-ui.min.js') }}"></script>
     <script type="text/javascript" src="{{ static('libs/featherlight/featherlight.min.js') }}"></script>
     <script type="text/javascript" src="{{ static('vnoj/jszip/jszip.min.js') }}"></script>
+    <script src="https://cdn.jsdelivr.net/npm/tus-js-client@latest/dist/tus.min.js"></script>
     <script type="text/javascript">
         window.valid_files = {{valid_files_json}}.sort();
         window.testcase_limit = {{testcase_limit}};
         window.testcase_soft_limit = {{testcase_soft_limit}};
+        {% if tusd_upload_threshold_bytes is not none %}
+        window.TUSD_UPLOAD_THRESHOLD_BYTES = {{ tusd_upload_threshold_bytes }};
+        {% endif %}
 
         $(function () {
             function autofill_if_exists($select, file) {
@@ -577,31 +581,123 @@
                 return lower === '.ds_store' || lower.indexOf('._') === 0 || path.indexOf('__MACOSX/') === 0;
             }
 
+            // --- Resumable upload (tus) ---
+            var tusUploadThreshold = window.TUSD_UPLOAD_THRESHOLD_BYTES;
+            var problemCode = '{{ object.code }}';
+            var activeTusUpload = null;
+
+            var $tusProgress = $('#tus-upload-progress');
+            var $tusBar = $('#tus-upload-bar');
+            var $tusStatus = $('#tus-upload-status');
+            var $tusPauseBtn = $('#tus-pause-btn');
+            var $tusCompletedInput = $('input[name="tus_upload_completed"]');
+            var $saveBtn = $('#zip-save-btn');
+
+            $tusPauseBtn.click(function () {
+                if (!activeTusUpload) return;
+                if ($tusPauseBtn.data('state') === 'paused') {
+                    activeTusUpload.start();
+                    $tusPauseBtn.data('state', 'running').text({{ _('Pause')|htmltojs }});
+                } else {
+                    activeTusUpload.abort();
+                    $tusPauseBtn.data('state', 'paused').text({{ _('Resume')|htmltojs }});
+                }
+            });
+
+            function startTusUpload(file) {
+                $tusProgress.show();
+                $tusBar.css('width', '0%');
+                $tusStatus.text({{ _('Requesting upload token...')|htmltojs }});
+                $saveBtn.prop('disabled', true);
+                $tusPauseBtn.data('state', 'running').text({{ _('Pause')|htmltojs }}).show();
+                $tusCompletedInput.val('');
+
+                var csrfToken = $('[name=csrfmiddlewaretoken]').val();
+
+                fetch('/upload/intent/', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': csrfToken,
+                    },
+                    body: JSON.stringify({
+                        problem_code: problemCode,
+                        file_type: 'zipfile',
+                        file_name: file.name,
+                    }),
+                }).then(function (resp) {
+                    if (!resp.ok) {
+                        return resp.json().then(function (data) {
+                            throw new Error(data.error || 'Failed to get upload token.');
+                        });
+                    }
+                    return resp.json();
+                }).then(function (data) {
+                    var upload = new tus.Upload(file, {
+                        endpoint: data.tusd_endpoint,
+                        retryDelays: [0, 1000, 3000, 5000],
+                        chunkSize: 50 * 1024 * 1024,
+                        metadata: {
+                            filename: file.name,
+                            filetype: file.type || 'application/zip',
+                            token: data.token,
+                        },
+                        onProgress: function (bytesUploaded, bytesTotal) {
+                            var pct = (bytesUploaded / bytesTotal * 100).toFixed(1);
+                            $tusBar.css('width', pct + '%');
+                            var mb = (bytesUploaded / (1024 * 1024)).toFixed(1);
+                            var total = (bytesTotal / (1024 * 1024)).toFixed(1);
+                            $tusStatus.text(mb + ' / ' + total + ' MB (' + pct + '%)');
+                        },
+                        onSuccess: function () {
+                            activeTusUpload = null;
+                            $tusBar.css('width', '100%');
+                            $tusStatus.text({{ _('Upload complete! You can now save.')|htmltojs }});
+                            $tusPauseBtn.hide();
+                            $saveBtn.prop('disabled', false);
+                            $tusCompletedInput.val(file.name);
+                        },
+                        onError: function (error) {
+                            activeTusUpload = null;
+                            console.error('tus upload error:', error);
+                            $tusStatus.text({{ _('Upload failed:')|htmltojs }} + ' ' + error);
+                            $tusPauseBtn.hide();
+                            $saveBtn.prop('disabled', false);
+                        },
+                    });
+                    activeTusUpload = upload;
+                    upload.start();
+                }).catch(function (err) {
+                    console.error(err);
+                    $tusStatus.text({{ _('Error:')|htmltojs }} + ' ' + err.message);
+                    $tusProgress.hide();
+                    $saveBtn.prop('disabled', false);
+                });
+            }
+
             $("#id_problem-data-zipfile").change((event) => {
                 let fileInput = event.target.files[0];
+                if (!fileInput) return;
 
-                // 100 MB limit (Cloudflare's request body size limit)
-                if (fileInput && fileInput.size > 100 * 1024 * 1024) {
-                    alert({{ _('File too large!')|htmltojs }} + ' ' +
-                        {{ _('Your file is')|htmltojs }} + ' ' + (fileInput.size / (1024 * 1024)).toFixed(2) + ' MB. ' +
-                        {{ _('Maximum allowed is 100 MB.')|htmltojs }});
-                    event.target.value = "";
+                if (tusUploadThreshold && fileInput.size >= tusUploadThreshold) {
+                    // Large file: use resumable tus upload
+                    startTusUpload(fileInput);
                     return;
                 }
 
+                // Small file: traditional form upload — read zip to populate test case list
                 var reader = new FileReader();
                 reader.onload = function(ev) {
                     JSZip.loadAsync(ev.target.result).then(function(zip) {
                         let all_files = Object.keys(zip.files).sort();
                         window.valid_files = all_files.filter(file => !shouldIgnoreFile(file));
-
                         fill_testcases();
                     }).catch(function(err) {
                         console.log(err);
                         console.error("Failed to open as ZIP file");
                         alert({{ _('Test file must be a ZIP file')|htmltojs }});
                         event.target.value = "";
-                    })
+                    });
                 };
                 reader.readAsArrayBuffer(fileInput);
             });
@@ -1018,9 +1114,21 @@
     <form action="" method="POST" enctype="multipart/form-data">
         {% csrf_token %}
         {{ cases_formset.management_form }}
+        <input type="hidden" name="tus_upload_completed" value="">
         <table class="table">
             {{ data_form.as_table() }}
         </table>
+
+        {# tus resumable upload progress UI #}
+        <div id="tus-upload-progress" style="display: none; margin: 0.5em 0;">
+            <div style="background: var(--input-bg, #e8e8e8); border-radius: 4px; height: 10px; overflow: hidden;">
+                <div id="tus-upload-bar" style="height: 100%; width: 0%; background: #2196f3; transition: width 0.2s;"></div>
+            </div>
+            <div style="display: flex; justify-content: space-between; align-items: center; margin-top: 0.25em;">
+                <span id="tus-upload-status" style="font-size: 0.85em;"></span>
+                <button type="button" id="tus-pause-btn" class="button" style="display: none;">{{ _('Pause') }}</button>
+            </div>
+        </div>
         <div class="alert alert-warning alert-dismissable" id="fill-test-case-noti" style="display: none;">
             <a class="close">x</a>
             <b>{{ _('Test cases have been filled automatically!') }}</b>
@@ -1093,7 +1201,7 @@
             {% endfor %}
             </tbody>
         </table>
-        <input type="submit" value="{{ _('Save') }}" class="button" id="submit-button">
+        <input type="submit" value="{{ _('Save') }}" class="button" id="zip-save-btn">
         <a id="add-case-row" href="#" style="display: None;"><i class="fa fa-plus"></i> {{ _('Add new case') }}</a>
     </form>
     <div style="display: none" class="generator-args-editor"><textarea></textarea><a class="button">{{ _('Save') }}</a></div>


### PR DESCRIPTION
# Description

Implement resumable uploads via the tus protocol (`tusd`) for large test data files, mitigating reverse-proxy request body limitations.

Type of change: New feature

## What

- Introduces a standalone Django app, `resumable_upload`, responsible for generating JWT upload intents (`/upload/intent/`) and handling incoming `tusd` webhooks (`/upload/hooks/`).
- Incorporates `tus-js-client` into `templates/problem/data.html`. This enables chunked, resumable uploads for ZIP files exceeding the defined threshold (default: 100MB).
- Refactors `ProblemDataView.post()` in `judge/views/problem_data.py`. The view now correctly handles files that have already been relocated to `DMOJ_PROBLEM_DATA_ROOT` by the `pre-finish` blocking hook from `tusd`.
- Exposes new variables in `dmoj/settings.py` for TUSD configurations (endpoints, JWT secrets, hook secrets, and thresholds). Adds `PyJWT>=2.0` to `requirements.txt` for secure token signing and verification.
- Handles Docker-to-Host path translation (`TUSD_LOCAL_DATA_DIR`) in the `pre-finish` webhook to resolve file system path mismatches between the `tusd` container and the Django host environment.
- Triggers metadata recalculation (file size and hash updates) within `ProblemDataView.post()` to ensure the database stays perfectly synced after the file is stealthily moved into the system by the webhook.

## Why

Currently, uploading test data (ZIP files) for problems on VNOJ is processed directly via standard Django forms. However, reverse proxies like Cloudflare impose strict request body limits (e.g., 200MB) which cause direct uploads of large datasets (sometimes spanning several gigabytes) to fail.

By utilizing **tusd** as a dedicated upload server and the **tus protocol** for chunked, resumable uploads, we bypass these proxy constraints, resulting in a stable and reliable upload pipeline. Crucially, the implementation utilizes blocking `pre-finish` hooks, ensuring file processing and relocation are fully synchronized with Django, thereby completely eliminating race conditions before the client receives a success response.

```mermaid
sequenceDiagram
    participant Browser
    participant Django
    participant tusd

    Note over Browser,Django: Phase 1: Request Upload Intent
    Browser->>Django: POST /upload/intent/ (problem_code, file_type)
    Django->>Django: Check permissions (session/cookie)<br>Check if problem exists & editable<br>Check quota
    Django-->>Browser: JWT token (contains intent metadata)

    Note over Browser,tusd: Phase 2: Chunked Upload
    Browser->>tusd: POST /files/ (tus protocol, JWT in metadata)
    tusd->>Django: pre-create hook → POST /upload/hooks/
    Django->>Django: Decode JWT, verify expiration
    Django-->>tusd: 200 OK (allow upload creation)
    loop Each chunk
        Browser->>tusd: PATCH /files/{id} (chunk data)
    end

    Note over tusd,Django: Phase 3: Pre-finish (BLOCKING)
    tusd->>Django: pre-finish hook → POST /upload/hooks/
    Django->>Django: Decode JWT from metadata<br>Move file from tusd → DMOJ_PROBLEM_DATA_ROOT/{problem_code}/
    Django-->>tusd: 200 OK
    Note over tusd: Now it returns 204 to Browser
    tusd-->>Browser: HTTP 204 (upload complete)
    Note over Browser: onSuccess fires
```

Fixes #484

## Deployment & Testing Notes

### Local Testing with Docker
To test this setup locally, spin up a `tusd` container with the appropriate hooks pointing to your local Django server:
```bash
docker run -p 8080:8080 -v /home/whlong/Documents/VNOI-Admin/tusd-data:/srv/tusd-data \
  --add-host=host.docker.internal:host-gateway \
  tusproject/tusd \
  -hooks-http http://host.docker.internal:8000/upload/hooks/ \
  -hooks-enabled-events pre-create,pre-finish \
  -cors-allow-origin ".*"
```

### Production Setup
- **Nginx Configuration:** In production, Nginx will need to be configured to correctly route traffic to both the Django application and the `tusd` server, ensuring CORS and max body size settings are correctly handled for the `/files/` endpoint.
- **Environment Variables:** The following settings must be configured in `dmoj/local_settings.py` for production:
  - `TUSD_ENDPOINT`: The public URL of the tusd server (e.g., `https://judge.example.com/files/`).
  - `TUSD_DATA_DIR`: Path to the directory where tusd stores chunks (needs to be accessible by Django).
  - `TUSD_HOOK_SECRET`: A shared secret string used to authenticate webhooks sent from tusd to Django.
  - `TUSD_JWT_SECRET`: The secret key used to sign the upload intent JWTs (can fallback to Django's `SECRET_KEY`).
  - `TUSD_JWT_EXPIRY_SECONDS`: TTL for the intent token (default: 7200s).
  - `TUSD_UPLOAD_THRESHOLD_BYTES`: File size threshold to trigger tus uploads (default: 100MB).
  - `TUSD_ALLOWED_FILE_TYPES`: Tuple of permitted file types for the upload hooks.

# How Has This Been Tested?

- [x] Wrote and executed unit tests (`resumable_upload/tests/test_views.py`) for the `resumable_upload` app, testing JWT token logic, views, intent generation, and webhook validation.
- [x] Spun up a local `tusd` container via Docker with hooks configured (`-hooks-enabled-events pre-create,pre-finish`) pointing to the local Django instance.
- [x] Manually tested uploading a file > 100MB on the problem data edit page to verify the progress bar, chunking, and that the file is correctly moved to `DMOJ_PROBLEM_DATA_ROOT/{problem_code}/` upon completion.
- [x] Verified edge cases: Files < 100MB still use the traditional form upload flow, network interruptions successfully resume, and pre-finish failures correctly return errors to the frontend via `onError`.

# Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the README/documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Informed of breaking changes, testing and migrations (if applicable).
- [ ] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
