### PR TITLE
Support ghost participations

### DIFF
--- a/judge/management/commands/merge_replay_data.py
+++ b/judge/management/commands/merge_replay_data.py
@@ -6,7 +6,7 @@ from django.core.management.base import BaseCommand, CommandError
 def merge_replay(a, b):
     """Merge replay data b into a (mutating a), marking b's participations as ghosts.
 
-    Both dicts are in ContestReplayData._build_data shape. b's problem ids are remapped
+    Both dicts are in build_contest_replay_data shape. b's problem ids are remapped
     to a's by position in the ordered `problems` list; b's participation ids are offset
     past a's to avoid collisions.
     """
@@ -33,15 +33,23 @@ def merge_replay(a, b):
 
 
 class Command(BaseCommand):
-    help = 'merge one contest replay JSON (b, shown as ghosts) into another (a), overwriting a'
+    help = "patch contest A's replay data with contest B's participations shown as ghosts"
 
     def add_arguments(self, parser):
-        parser.add_argument('a_json', help='replay data to merge into (overwritten)')
+        parser.add_argument('contest', help="key of contest A (this server's contest) to patch")
         parser.add_argument('b_json', help='replay data whose participations become ghosts')
 
     def handle(self, *args, **options):
-        with open(options['a_json']) as f:
-            a = json.load(f)
+        from judge.models import Contest
+        from judge.views.contests import build_contest_replay_data, write_contest_replay_data
+
+        try:
+            contest = Contest.objects.get(key=options['contest'])
+        except Contest.DoesNotExist:
+            raise CommandError('No contest with key "%s".' % options['contest'])
+
+        # Regenerate A fresh from the DB so re-running is idempotent (no duplicate ghosts).
+        a = build_contest_replay_data(contest)
         with open(options['b_json']) as f:
             b = json.load(f)
 
@@ -53,9 +61,13 @@ class Command(BaseCommand):
 
         merge_replay(a, b)
 
-        with open(options['a_json'], 'w') as f:
-            json.dump(a, f, separators=(',', ':'))
+        # Bump the version so the (immutable-cached) replay URL changes and clients refetch.
+        contest.replay_version += 1
+        filepath, _ = write_contest_replay_data(contest, a)  # path uses the new version
+
+        contest.csv_ranking = 'ghost'  # sentinel the ranking page reads to show the ghost toggle
+        contest.save(update_fields=['csv_ranking', 'replay_version'])
 
         self.stdout.write(self.style.SUCCESS(
-            'Merged %d ghost participations into %s.' % (len(b['participations']), options['a_json']),
+            'Merged %d ghost participations into %s.' % (len(b['participations']), filepath),
         ))

--- a/judge/management/commands/merge_replay_data.py
+++ b/judge/management/commands/merge_replay_data.py
@@ -68,7 +68,7 @@ class Command(BaseCommand):
         contest.replay_version += 1
         filepath, _ = write_contest_replay_data(contest, a)  # path uses the new version
 
-        contest.csv_ranking = 'ghost'  # sentinel the ranking page reads to show the ghost toggle
+        contest.csv_ranking = Contest.HAS_GHOST_PARTICIPATION  # ranking page reads this to show the ghost toggle
         contest.save(update_fields=['csv_ranking', 'replay_version'])
 
         self.stdout.write(self.style.SUCCESS(

--- a/judge/management/commands/merge_replay_data.py
+++ b/judge/management/commands/merge_replay_data.py
@@ -1,0 +1,61 @@
+import json
+
+from django.core.management.base import BaseCommand, CommandError
+
+
+def merge_replay(a, b):
+    """Merge replay data b into a (mutating a), marking b's participations as ghosts.
+
+    Both dicts are in ContestReplayData._build_data shape. b's problem ids are remapped
+    to a's by position in the ordered `problems` list; b's participation ids are offset
+    past a's to avoid collisions.
+    """
+    a_problems, b_problems = a.get('problems'), b.get('problems')
+    if a_problems is None or b_problems is None:
+        raise CommandError('Both files must contain a "problems" list; regenerate the replay data.')
+    if len(a_problems) != len(b_problems):
+        raise CommandError('Contests have a different number of problems (%d vs %d).'
+                           % (len(a_problems), len(b_problems)))
+    pmap = dict(zip(b_problems, a_problems))
+
+    offset = max([p['id'] for p in a['participations']] +
+                 [s[0] for s in a['subs']] + [0]) + 1
+
+    for p in b['participations']:
+        p['id'] += offset
+        p['ghost'] = True
+        a['participations'].append(p)
+
+    for part_id, prob_id, points, t in b['subs']:
+        a['subs'].append([part_id + offset, pmap[prob_id], points, t])
+
+    return a
+
+
+class Command(BaseCommand):
+    help = 'merge one contest replay JSON (b, shown as ghosts) into another (a), overwriting a'
+
+    def add_arguments(self, parser):
+        parser.add_argument('a_json', help='replay data to merge into (overwritten)')
+        parser.add_argument('b_json', help='replay data whose participations become ghosts')
+
+    def handle(self, *args, **options):
+        with open(options['a_json']) as f:
+            a = json.load(f)
+        with open(options['b_json']) as f:
+            b = json.load(f)
+
+        if a.get('duration') != b.get('duration'):
+            self.stderr.write(self.style.WARNING(
+                'Warning: durations differ (%s vs %s); ghosts may not line up with the contest.'
+                % (a.get('duration'), b.get('duration')),
+            ))
+
+        merge_replay(a, b)
+
+        with open(options['a_json'], 'w') as f:
+            json.dump(a, f, separators=(',', ':'))
+
+        self.stdout.write(self.style.SUCCESS(
+            'Merged %d ghost participations into %s.' % (len(b['participations']), options['a_json']),
+        ))

--- a/judge/management/commands/merge_replay_data.py
+++ b/judge/management/commands/merge_replay_data.py
@@ -27,6 +27,9 @@ def merge_replay(a, b):
         a['participations'].append(p)
 
     for part_id, prob_id, points, t in b['subs']:
+        if prob_id not in pmap:
+            raise CommandError('Submission references problem id %s not in the "problems" list; '
+                               'regenerate the replay data.' % prob_id)
         a['subs'].append([part_id + offset, pmap[prob_id], points, t])
 
     return a

--- a/judge/models/contest.py
+++ b/judge/models/contest.py
@@ -72,6 +72,9 @@ class Contest(models.Model):
         (SCOREBOARD_AFTER_CONTEST, _('Hidden for duration of contest')),
         (SCOREBOARD_AFTER_PARTICIPATION, _('Hidden for duration of participation')),
     )
+    # Sentinel stored in csv_ranking to flag that the replay data has ghost participations
+    # merged in (set by the merge_replay_data command), rather than real CSV ranking data.
+    HAS_GHOST_PARTICIPATION = 'ghost'
     key = models.CharField(max_length=32, verbose_name=_('contest id'), unique=True,
                            validators=[RegexValidator('^[a-z0-9_]+$', _('Contest id must be ^[a-z0-9_]+$'))])
     name = models.CharField(max_length=100, verbose_name=_('contest name'), db_index=True)

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -1143,7 +1143,7 @@ class ContestRanking(ContestRankingBase):
         context = super().get_context_data(**kwargs)
         context['has_rating'] = self.object.ratings.exists()
         context['show_virtual'] = self.show_virtual
-        context['has_ghosts'] = self.object.csv_ranking == 'ghost' and self.object.can_replay
+        context['has_ghosts'] = self.object.csv_ranking == Contest.HAS_GHOST_PARTICIPATION and self.object.can_replay
         context['is_frozen'] = self.is_frozen
         context['cache_timeout'] = 0 if self.bypass_cache_ranking else self.object.scoreboard_cache_timeout
         context['can_see_full_submission_list'] = self.object.can_see_full_submission_list(self.request.user)
@@ -1220,7 +1220,8 @@ class ContestOfficialRanking(ContestRankingBase):
 
     def get(self, request, *args, **kwargs):
         self.object = self.get_object()
-        if not self.object.csv_ranking:
+        # HAS_GHOST_PARTICIPATION is a sentinel for the ghost-participations toggle, not real CSV data.
+        if not self.object.csv_ranking or self.object.csv_ranking == Contest.HAS_GHOST_PARTICIPATION:
             raise Http404()
 
         # If the csv_ranking is an url, redirect to it

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -1321,6 +1321,7 @@ class ContestReplayData(ContestMixin, SingleObjectMixin, View):
             'start': int(contest.start_time.timestamp()),
             'duration': duration,
             'frozen': 0,
+            'problems': [prob.id for prob in problems],
             'participations': participations_data,
             'subs': subs,
         }

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -1143,6 +1143,7 @@ class ContestRanking(ContestRankingBase):
         context = super().get_context_data(**kwargs)
         context['has_rating'] = self.object.ratings.exists()
         context['show_virtual'] = self.show_virtual
+        context['has_ghosts'] = self.object.csv_ranking == 'ghost' and self.object.can_replay
         context['is_frozen'] = self.is_frozen
         context['cache_timeout'] = 0 if self.bypass_cache_ranking else self.object.scoreboard_cache_timeout
         context['can_see_full_submission_list'] = self.object.can_see_full_submission_list(self.request.user)
@@ -1249,6 +1250,62 @@ class ContestParticipationDisqualify(ContestMixin, SingleObjectMixin, View):
         return HttpResponseRedirect(reverse('contest_ranking', args=(self.object.key,)))
 
 
+def contest_replay_data_path(contest):
+    replay_dir = os.path.join(settings.MEDIA_ROOT, settings.CONTEST_REPLAY_MEDIA_DIR)
+    filename = f'{contest.key}_v{contest.replay_version}.json'
+    return os.path.join(replay_dir, filename), filename
+
+
+def build_contest_replay_data(contest):
+    duration = int((contest.end_time - contest.start_time).total_seconds())
+
+    problems = list(
+        contest.contest_problems
+        .select_related('problem').defer('problem__description').order_by('order'),
+    )
+
+    parts_qs = contest.users.filter(virtual=ContestParticipation.LIVE)
+    participations_data = make_contest_ranking_json(contest, problems, parts_qs)
+    for p in participations_data:
+        del p['score'], p['cumtime'], p['tiebreaker'], p['format_data']
+
+    subs_qs = (
+        ContestSubmission.objects
+        .filter(
+            participation__contest=contest,
+            participation__virtual=ContestParticipation.LIVE,
+        )
+        .values_list('participation_id', 'problem_id', 'points', 'submission__result', 'submission__date')
+        .order_by('submission__date')
+    )
+
+    subs = []
+    for part_id, prob_id, points, result, sub_date in subs_qs:
+        if result in (None, 'CE', 'IE'):
+            continue
+        t = (sub_date - contest.start_time).total_seconds()
+        subs.append([part_id, prob_id, float(points), round(t, 3)])
+
+    return {
+        'start': int(contest.start_time.timestamp()),
+        'duration': duration,
+        'frozen': 0,
+        'problems': [prob.id for prob in problems],
+        'participations': participations_data,
+        'subs': subs,
+    }
+
+
+def write_contest_replay_data(contest, data):
+    filepath, filename = contest_replay_data_path(contest)
+    os.makedirs(os.path.dirname(filepath), exist_ok=True)
+    tmp = filepath + '.tmp'
+    with open(tmp, 'w') as f:
+        json.dump(data, f, separators=(',', ':'))
+    os.replace(tmp, filepath)
+    return filepath, filename
+
+
 class ContestReplayData(ContestMixin, SingleObjectMixin, View):
     def get(self, request, *args, **kwargs):
         contest = self.get_object()
@@ -1273,58 +1330,10 @@ class ContestReplayData(ContestMixin, SingleObjectMixin, View):
         return response
 
     def prepare_replay_data(self, contest):
-        replay_dir = os.path.join(settings.MEDIA_ROOT, settings.CONTEST_REPLAY_MEDIA_DIR)
-        filename = f'{contest.key}_v{contest.replay_version}.json'
-        filepath = os.path.join(replay_dir, filename)
-
+        filepath, filename = contest_replay_data_path(contest)
         if not os.path.exists(filepath):
-            os.makedirs(replay_dir, exist_ok=True)
-            data = self._build_data(contest)
-            tmp = filepath + '.tmp'
-            with open(tmp, 'w') as f:
-                json.dump(data, f, separators=(',', ':'))
-            os.replace(tmp, filepath)
-
+            write_contest_replay_data(contest, build_contest_replay_data(contest))
         return filepath, filename
-
-    def _build_data(self, contest):
-        duration = int((contest.end_time - contest.start_time).total_seconds())
-
-        problems = list(
-            contest.contest_problems
-            .select_related('problem').defer('problem__description').order_by('order'),
-        )
-
-        parts_qs = contest.users.filter(virtual=ContestParticipation.LIVE)
-        participations_data = make_contest_ranking_json(contest, problems, parts_qs)
-        for p in participations_data:
-            del p['score'], p['cumtime'], p['tiebreaker'], p['format_data']
-
-        subs_qs = (
-            ContestSubmission.objects
-            .filter(
-                participation__contest=contest,
-                participation__virtual=ContestParticipation.LIVE,
-            )
-            .values_list('participation_id', 'problem_id', 'points', 'submission__result', 'submission__date')
-            .order_by('submission__date')
-        )
-
-        subs = []
-        for part_id, prob_id, points, result, sub_date in subs_qs:
-            if result in (None, 'CE', 'IE'):
-                continue
-            t = (sub_date - contest.start_time).total_seconds()
-            subs.append([part_id, prob_id, float(points), round(t, 3)])
-
-        return {
-            'start': int(contest.start_time.timestamp()),
-            'duration': duration,
-            'frozen': 0,
-            'problems': [prob.id for prob in problems],
-            'participations': participations_data,
-            'subs': subs,
-        }
 
 
 class ContestMossMixin(ContestMixin, PermissionRequiredMixin):

--- a/resources/contest-ranking.js
+++ b/resources/contest-ranking.js
@@ -131,14 +131,14 @@
     // ─── Shared rendering helpers ────────────────────────────────────────────
 
     function makeSubmissionUrl(meta, problemCode) {
-        if (!meta.contest.url_templates) return null;
+        if (meta.ghost || !meta.contest.url_templates) return null;
         return meta.contest.url_templates.problem_submissions
             .replace('__USERNAME__', meta.username)
             .replace('__PROBLEM__', problemCode);
     }
 
     function makeAllSubmissionsUrl(meta) {
-        if (!meta.contest.url_templates) return null;
+        if (meta.ghost || !meta.contest.url_templates) return null;
         return meta.contest.url_templates.all_submissions
             .replace('__USERNAME__', meta.username);
     }
@@ -408,10 +408,15 @@
         return html;
     }
 
-    function buildUserLink(u) {
-        var html = '<span class="' + escapeHtml(u.css_class) + '">' +
-            '<a href="' + escapeHtml(u.url) + '" style="display: inline-block;">' +
-            escapeHtml(u.display_name) + '</a>';
+    function buildUserLink(u, isGhost) {
+        // Ghosts keep their rating color but get a ghost icon prefix and no link
+        // (they come from another server, so any URL here would be broken).
+        var spanClass = u.css_class + (isGhost ? ' ghost-user' : '');
+        var name = escapeHtml(u.display_name);
+        var inner = isGhost
+            ? '<span style="display: inline-block;">' + name + '</span>'
+            : '<a href="' + escapeHtml(u.url) + '" style="display: inline-block;">' + name + '</a>';
+        var html = '<span class="' + escapeHtml(spanClass) + '">' + inner;
         if (u.badge) {
             html += '<img src="' + escapeHtml(u.badge.mini) + '"' +
                 ' title="' + escapeHtml(u.badge.name) + '"' +
@@ -425,7 +430,10 @@
         var p = participation;
         var u = p.user;
 
-        var rowClass = p.is_disqualified ? ' class="disqualified"' : '';
+        var classes = [];
+        if (p.is_disqualified) classes.push('disqualified');
+        if (p.ghost) classes.push('ghost');
+        var rowClass = classes.length ? ' class="' + classes.join(' ') + '"' : '';
         var html = '<tr id="user-' + escapeHtml(u.username) + '"' + rowClass + '>';
 
         // Rank cell
@@ -445,7 +453,7 @@
         // Username cell
         html += '<td class="user-name"><div>';
         html += '<div style="float:left">';
-        html += buildUserLink(u);
+        html += buildUserLink(u, p.ghost);
 
         if (p.virtual > 0) {
             var virtualTitle = p.virtual + ' virtual participation' + (p.virtual > 1 ? 's' : '') + ' of this user';
@@ -456,22 +464,26 @@
         html += '<div class="personal-info"><span>' + escapeHtml(u.name || '') + '</span></div>';
         html += '</div>';
 
-        // Right float (admin ops, org)
+        // Right float (admin ops, org). Ghosts get no admin ops and a plain-text org.
         html += '<div style="float:right">';
-        html += buildAdminOps(p, contest);
+        if (!p.ghost) html += buildAdminOps(p, contest);
         html += '<div class="personal-info" style="text-align: right;">';
         if (u.organization) {
+            var orgName = escapeHtml(u.organization.short_name);
             html += '<span class="organization">' +
-                '<a href="' + escapeHtml(u.organization.url) + '">' +
-                escapeHtml(u.organization.short_name) + '</a></span>';
+                (p.ghost ? orgName
+                         : '<a href="' + escapeHtml(u.organization.url) + '">' + orgName + '</a>') +
+                '</span>';
         }
         html += '</div></div>';
         html += '</div></td>';
 
-        // Build meta for renderer
+        // Build meta for renderer. Ghosts have no valid submission URLs on this
+        // server, so the url helpers render every problem cell as plain text.
         var meta = {
             contest: contest,
             username: u.username,
+            ghost: p.ghost,
         };
 
         // Result cell(s)

--- a/resources/contest-replay.js
+++ b/resources/contest-replay.js
@@ -319,10 +319,39 @@
         var replayUrl = rankingData.contest && rankingData.contest.replay_url;
         if (!replayUrl) return;
 
+        // Virtual participations have no replay subs, so virtual and ghost/replay
+        // are mutually exclusive in the UI.
+        var showVirtual = window.CONTEST_SHOW_VIRTUAL;
+        var virtualTooltip = window.CONTEST_REPLAY_VIRTUAL_TOOLTIP;
+
+        if (showVirtual) {
+            // Floating tooltip that follows the cursor over greyed (replay-blocked) controls.
+            var $tip = null;
+            $(document)
+                .on('mouseenter', '.replay-blocked', function () {
+                    if (!$tip) $tip = $('<div class="replay-tooltip"></div>').appendTo('body');
+                    $tip.text($(this).attr('data-tooltip')).show();
+                })
+                .on('mousemove', '.replay-blocked', function (e) {
+                    if ($tip) $tip.css({ left: (e.clientX + 12) + 'px', top: (e.clientY + 12) + 'px' });
+                })
+                .on('mouseleave', '.replay-blocked', function () {
+                    if ($tip) $tip.hide();
+                });
+        }
+
         // Ghost toggle: swap between the backend ranking and end-of-contest
         // standings (A's live participants + ghosts) computed from the replay file.
         var $ghost = $('#show-ghosts-checkbox');
-        if ($ghost.length) {
+        if ($ghost.length && showVirtual) {
+            // Virtual can't be replayed: grey the ghost toggle and show a tooltip on hover.
+            // Children are greyed (not the wrap) so the tooltip stays crisp; pointer-events:none
+            // lets hover reach the wrap so its :hover ::after tooltip fires.
+            var $wrap = $('#show-ghosts-wrap');
+            $wrap.addClass('replay-blocked').attr('data-tooltip', virtualTooltip);
+            $wrap.children().css({ 'opacity': 0.5, 'pointer-events': 'none' });
+            $ghost.prop('disabled', true);
+        } else if ($ghost.length) {
             $ghost.on('change', function () {
                 if (this.checked) {
                     fetchReplayData(replayUrl, function (data) {
@@ -333,6 +362,8 @@
                     window.renderRankingTable(rankingData);
                 }
             });
+            // Show ghosts by default when available (and virtual isn't active).
+            $ghost.prop('checked', true).trigger('change');
         }
 
         var isVirtual      = !!rankingData.own;
@@ -460,14 +491,24 @@
             });
         } else {
             _endBtn = createBar(rankingData.contest.replay_duration);
-            wireFreezeInput();
             updateBar(rankingData.contest.replay_duration, rankingData.contest.replay_duration);
-            if (frozenOverride !== null) {
-                fetchReplayData(replayUrl, onReplayLoaded);
+            if (showVirtual) {
+                // Grey out and disable the replay bar; virtual can't be replayed.
+                // Children greyed (not the bar) so the tooltip stays crisp; pointer-events:none
+                // lets hover reach the bar so its :hover ::after tooltip fires.
+                var $bar = $slider.parent();
+                $bar.addClass('replay-blocked').attr('data-tooltip', virtualTooltip);
+                $bar.children().css({ 'opacity': 0.5, 'pointer-events': 'none' });
+                $bar.find('input, button').prop('disabled', true);
             } else {
-                $slider.one('mousedown touchstart', function () {
+                wireFreezeInput();
+                if (frozenOverride !== null) {
                     fetchReplayData(replayUrl, onReplayLoaded);
-                });
+                } else {
+                    $slider.one('mousedown touchstart', function () {
+                        fetchReplayData(replayUrl, onReplayLoaded);
+                    });
+                }
             }
         }
     };

--- a/resources/contest-replay.js
+++ b/resources/contest-replay.js
@@ -311,6 +311,15 @@
         return (h ? h + ':' : '') + (h && m < 10 ? '0' : '') + m + ':' + (sec < 10 ? '0' : '') + sec;
     }
 
+    // Grey out and disable a control that can't be used while virtual is showing.
+    // Children (not $el itself) are greyed and get pointer-events:none, so mouse
+    // events fall through to $el and fire the delegated .replay-blocked tooltip.
+    function blockForVirtual($el, tooltip) {
+        $el.addClass('replay-blocked').attr('data-tooltip', tooltip);
+        $el.children().css({ 'opacity': 0.5, 'pointer-events': 'none' });
+        $el.find('input, button').prop('disabled', true);
+    }
+
     // ─── Public entry point ───────────────────────────────────────────────────
 
     window.initContestRanking = function (rankingData) {
@@ -344,13 +353,8 @@
         // standings (A's live participants + ghosts) computed from the replay file.
         var $ghost = $('#show-ghosts-checkbox');
         if ($ghost.length && showVirtual) {
-            // Virtual can't be replayed: grey the ghost toggle and show a tooltip on hover.
-            // Children are greyed (not the wrap) so the tooltip stays crisp; pointer-events:none
-            // lets hover reach the wrap so its :hover ::after tooltip fires.
-            var $wrap = $('#show-ghosts-wrap');
-            $wrap.addClass('replay-blocked').attr('data-tooltip', virtualTooltip);
-            $wrap.children().css({ 'opacity': 0.5, 'pointer-events': 'none' });
-            $ghost.prop('disabled', true);
+            // Virtual can't be replayed: grey out the ghost toggle with an explanatory tooltip.
+            blockForVirtual($('#show-ghosts-wrap'), virtualTooltip);
         } else if ($ghost.length) {
             $ghost.on('change', function () {
                 if (this.checked) {
@@ -494,12 +498,7 @@
             updateBar(rankingData.contest.replay_duration, rankingData.contest.replay_duration);
             if (showVirtual) {
                 // Grey out and disable the replay bar; virtual can't be replayed.
-                // Children greyed (not the bar) so the tooltip stays crisp; pointer-events:none
-                // lets hover reach the bar so its :hover ::after tooltip fires.
-                var $bar = $slider.parent();
-                $bar.addClass('replay-blocked').attr('data-tooltip', virtualTooltip);
-                $bar.children().css({ 'opacity': 0.5, 'pointer-events': 'none' });
-                $bar.find('input, button').prop('disabled', true);
+                blockForVirtual($slider.parent(), virtualTooltip);
             } else {
                 wireFreezeInput();
                 if (frozenOverride !== null) {

--- a/resources/contest-replay.js
+++ b/resources/contest-replay.js
@@ -319,6 +319,22 @@
         var replayUrl = rankingData.contest && rankingData.contest.replay_url;
         if (!replayUrl) return;
 
+        // Ghost toggle: swap between the backend ranking and end-of-contest
+        // standings (A's live participants + ghosts) computed from the replay file.
+        var $ghost = $('#show-ghosts-checkbox');
+        if ($ghost.length) {
+            $ghost.on('change', function () {
+                if (this.checked) {
+                    fetchReplayData(replayUrl, function (data) {
+                        if (!data) return;
+                        window.renderRankingTable(computeVirtualRanking(data, rankingData, data.duration));
+                    });
+                } else {
+                    window.renderRankingTable(rankingData);
+                }
+            });
+        }
+
         var isVirtual      = !!rankingData.own;
         var virtualSubsData = null;
         var timerId        = null;

--- a/resources/contest-replay.js
+++ b/resources/contest-replay.js
@@ -269,7 +269,7 @@
                 id: p.id, score: scored.score, cumtime: scored.cumtime,
                 tiebreaker: scored.tiebreaker, format_data: scored.format_data,
                 is_disqualified: p.is_disqualified, virtual: p.virtual,
-                rating: p.rating, user: p.user,
+                rating: p.rating, user: p.user, ghost: p.ghost,
             };
         });
 

--- a/resources/contest.scss
+++ b/resources/contest.scss
@@ -241,6 +241,15 @@ form.contest-join-pseudotab {
         background-color: $color_contest_ranking_disqualified !important;
     }
 
+    tr.ghost {
+        opacity: 0.5;
+    }
+
+    .ghost-user::before {
+        content: "👻";
+        margin-right: 0.25em;
+    }
+
     .point-denominator {
         border-top: 1px solid $color_primary50;
         font-size: 0.7em;

--- a/templates/contest/contest-tabs.html
+++ b/templates/contest/contest-tabs.html
@@ -9,7 +9,7 @@
     {% if contest.start_time <= now or perms.judge.see_private_contest %}
         {% if contest.can_see_own_scoreboard(request.user) %}
             {{ make_tab('ranking', 'fa-bar-chart', url('contest_ranking', contest.key), _('Rankings')) }}
-            {% if contest.csv_ranking and contest.csv_ranking != 'ghost' %}
+            {% if contest.csv_ranking and contest.csv_ranking != contest.HAS_GHOST_PARTICIPATION %}
                 {{ make_tab('official_ranking', 'fa-bar-chart', url('contest_official_ranking', contest.key), _('Official Rankings')) }}
             {% endif %}
         {% else %}

--- a/templates/contest/contest-tabs.html
+++ b/templates/contest/contest-tabs.html
@@ -9,7 +9,7 @@
     {% if contest.start_time <= now or perms.judge.see_private_contest %}
         {% if contest.can_see_own_scoreboard(request.user) %}
             {{ make_tab('ranking', 'fa-bar-chart', url('contest_ranking', contest.key), _('Rankings')) }}
-            {% if contest.csv_ranking %}
+            {% if contest.csv_ranking and contest.csv_ranking != 'ghost' %}
                 {{ make_tab('official_ranking', 'fa-bar-chart', url('contest_official_ranking', contest.key), _('Official Rankings')) }}
             {% endif %}
         {% else %}

--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -470,6 +470,10 @@ $('#show-personal-info-checkbox').click(function () {
         {% if tab == 'ranking' %}
             <input id="show-virtual-participations-checkbox" type="checkbox" style="vertical-align: bottom">
             <label for="show-virtual-participations-checkbox" style="vertical-align: bottom">{{ _('Show virtual participations') }}</label>
+            {% if has_ghosts %}
+            <input id="show-ghosts-checkbox" type="checkbox" style="vertical-align: bottom">
+            <label for="show-ghosts-checkbox" style="vertical-align: bottom">{{ _('Show ghost participations') }}</label>
+            {% endif %}
             {% if not is_ICPC_format %}
             <a href="#" onclick="download_table_as_csv()" style="float: right;">{{ _('Download as CSV') }}</a>
             {% endif %}

--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -39,6 +39,22 @@
         .filter-checklist-button {
             float: right;
         }
+
+        .replay-blocked {
+            cursor: not-allowed;
+        }
+
+        .replay-tooltip {
+            position: fixed;
+            z-index: 1000;
+            white-space: nowrap;
+            background: #333;
+            color: #fff;
+            padding: 4px 8px;
+            border-radius: 4px;
+            font-size: 12px;
+            pointer-events: none;
+        }
     </style>
 {% endblock %}
 
@@ -50,6 +66,8 @@
     <script type="text/javascript">
         window.RANKING_DATA = {{ ranking_json|safe }};
         window.CONTEST_CAN_SEE_SUBMISSIONS = {{ 'true' if can_see_full_submission_list else 'false' }};
+        window.CONTEST_SHOW_VIRTUAL = {{ 'true' if show_virtual else 'false' }};
+        window.CONTEST_REPLAY_VIRTUAL_TOOLTIP = {{ _("Virtual participations aren't supported in replay, turn it off first.")|htmltojs }};
     </script>
     {% if not contest.ended %}
         <script type="text/javascript">
@@ -471,8 +489,10 @@ $('#show-personal-info-checkbox').click(function () {
             <input id="show-virtual-participations-checkbox" type="checkbox" style="vertical-align: bottom">
             <label for="show-virtual-participations-checkbox" style="vertical-align: bottom">{{ _('Show virtual participations') }}</label>
             {% if has_ghosts %}
-            <input id="show-ghosts-checkbox" type="checkbox" style="vertical-align: bottom">
-            <label for="show-ghosts-checkbox" style="vertical-align: bottom">{{ _('Show ghost participations') }}</label>
+            <span id="show-ghosts-wrap">
+                <input id="show-ghosts-checkbox" type="checkbox" style="vertical-align: bottom">
+                <label for="show-ghosts-checkbox" style="vertical-align: bottom">{{ _('Show ghost participations') }}</label>
+            </span>
             {% endif %}
             {% if not is_ICPC_format %}
             <a href="#" onclick="download_table_as_csv()" style="float: right;">{{ _('Download as CSV') }}</a>


### PR DESCRIPTION
- **Support ghost participation**
- **Toggle show ghost**
- **disable ghost if virtual is showing**

## How it works

Use the command below to merge a replay data of the ghost contest:

```  
./manage.py merge_replay_data <A_contest_key> path/to/ghost_replay.json
```

This will generate a new replay data that's compatible with our render ranking logic,
so no new backend request/logic drives the view.

<img width="1364" height="515" alt="image" src="https://github.com/user-attachments/assets/1748f2c8-387c-4c03-8297-f1d771a417aa" />

