### PR TITLE
Hide report-issue link from anonymous users

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -302,18 +302,18 @@
                     </ul>
                 </li>
             </ul>
-            <a href=
-                {% if request.resolver_match.view_name == "problem_detail" and problem %}
-                    "{{ url('new_problem_ticket', problem.code) }}"
-                {% else %}
-                    "/tickets/new?issue_url={{ request.build_absolute_uri()|urlencode }}"
-                {% endif %}
-            style="margin-right: 5px;">
-                <span title="{{ _('Report issue') }}">
-                    <i class="fa fa-exclamation-triangle" style="color: yellow;"></i>
-                </span>
-            </a>
             {% if request.user.is_authenticated %}
+                <a href=
+                    {% if request.resolver_match.view_name == "problem_detail" and problem %}
+                        "{{ url('new_problem_ticket', problem.code) }}"
+                    {% else %}
+                        "/tickets/new?issue_url={{ request.build_absolute_uri()|urlencode }}"
+                    {% endif %}
+                style="margin-right: 5px;">
+                    <span title="{{ _('Report issue') }}">
+                        <i class="fa fa-exclamation-triangle" style="color: yellow;"></i>
+                    </span>
+                </a>
                 <ul id="notification-nav">
                     <li>
                         <a href="{{ url('notification_list') }}" class="notification-bell" title="{{ _('Notifications') }}">


### PR DESCRIPTION
This help fix a crawl trap when crawler get looped in `/accounts/login` and `/tickets/new`
