### PR TITLE
Cursor pagination for submission lists (extracted from #668)

### DIFF
--- a/dmoj/urls.py
+++ b/dmoj/urls.py
@@ -148,8 +148,8 @@ urlpatterns = [
         path('/update-polygon', problem.ProblemUpdatePolygon.as_view(), name='problem_update_polygon'),
 
         path('/rank/', paged_list_view(ranked_submission.RankedSubmissions, 'ranked_submissions')),
-        path('/submissions/', paged_list_view(submission.ProblemSubmissions, 'chronological_submissions')),
-        path('/submissions/<str:user>/', paged_list_view(submission.UserProblemSubmissions, 'user_submissions')),
+        path('/submissions/', cursor_list_view(submission.ProblemSubmissions, 'chronological_submissions')),
+        path('/submissions/<str:user>/', cursor_list_view(submission.UserProblemSubmissions, 'user_submissions')),
 
         path('/', lambda _, problem: HttpResponsePermanentRedirect(reverse('problem_detail', args=[problem]))),
 
@@ -283,9 +283,9 @@ urlpatterns = [
         path('/submissions/',
              paged_list_view(submission.AllContestSubmissions, 'contest_all_submissions')),
         path('/submissions/<str:user>/',
-             paged_list_view(submission.UserAllContestSubmissions, 'contest_all_user_submissions')),
+             cursor_list_view(submission.UserAllContestSubmissions, 'contest_all_user_submissions')),
         path('/submissions/<str:user>/<str:problem>/',
-             paged_list_view(submission.UserContestSubmissions, 'contest_user_submissions')),
+             cursor_list_view(submission.UserContestSubmissions, 'contest_user_submissions')),
 
         path('/participation/disqualify', contests.ContestParticipationDisqualify.as_view(),
              name='contest_participation_disqualify'),
@@ -324,7 +324,7 @@ urlpatterns = [
              name='organization_problems_bulk_delete'),
         path('/contests/', organization.ContestListOrganization.as_view(), name='contest_list_organization'),
         path('/submissions/',
-             paged_list_view(organization.SubmissionListOrganization, 'submission_list_organization')),
+             cursor_list_view(organization.SubmissionListOrganization, 'submission_list_organization')),
         path('/problem-create', organization.ProblemCreateOrganization.as_view(), name='problem_create_organization'),
         path('/contest-create', organization.ContestCreateOrganization.as_view(), name='contest_create_organization'),
 

--- a/dmoj/urls.py
+++ b/dmoj/urls.py
@@ -100,6 +100,19 @@ def paged_list_view(view, name):
     ])
 
 
+def cursor_list_view(view, name):
+    """Like paged_list_view, for views that page by cursor.
+
+    Cursor pagination has no numbered pages, so existing /2 links redirect to the
+    first page rather than 404ing or silently rendering something else.
+    """
+    return include([
+        path('', view.as_view(), name=name),
+        path('<int:page>', lambda request, page, **kwargs:
+             HttpResponsePermanentRedirect(reverse(name, kwargs=kwargs))),
+    ])
+
+
 urlpatterns = [
     path('', blog.PostList.as_view(template_name='home.html', title=_('Home')), kwargs={'page': 1}, name='home'),
     path('500/', exception),
@@ -181,7 +194,7 @@ urlpatterns = [
 
     path('submissions/', paged_list_view(submission.AllSubmissions, 'all_submissions')),
     path('submissions/diff', submission.SubmissionSourceDiff, name='diff_submissions'),
-    path('submissions/user/<str:user>/', paged_list_view(submission.AllUserSubmissions, 'all_user_submissions')),
+    path('submissions/user/<str:user>/', cursor_list_view(submission.AllUserSubmissions, 'all_user_submissions')),
 
     path('src/<int:submission>', submission.SubmissionSource.as_view(), name='submission_source'),
     path('src/<int:submission>/raw', submission.SubmissionSourceRaw.as_view(), name='submission_source_raw'),
@@ -215,7 +228,7 @@ urlpatterns = [
             path('', user.UserProblemsPage.as_view(), name='user_problems'),
             path('ajax', user.UserPerformancePointsAjax.as_view(), name='user_pp_ajax'),
         ])),
-        path('/submissions/', paged_list_view(submission.AllUserSubmissions, 'all_user_submissions_old')),
+        path('/submissions/', cursor_list_view(submission.AllUserSubmissions, 'all_user_submissions_old')),
         path('/submissions/', lambda _, user:
              HttpResponsePermanentRedirect(reverse('all_user_submissions', args=[user]))),
 

--- a/judge/utils/cursor_paginator.py
+++ b/judge/utils/cursor_paginator.py
@@ -1,0 +1,297 @@
+"""
+Pagination serializers determine the structure of the output that should
+be used for paginated responses.
+
+# License
+
+Copyright © 2011-present, [Encode OSS Ltd](https://www.encode.io/).
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
+from base64 import urlsafe_b64decode, urlsafe_b64encode
+from collections import namedtuple
+from urllib import parse
+
+from django.core.exceptions import BadRequest
+from django.db.models.query import QuerySet
+
+
+def _positive_int(integer_string, strict=False, cutoff=None):
+    """
+    Cast a string to a strictly positive integer.
+    """
+    ret = int(integer_string)
+    if ret < 0 or (ret == 0 and strict):
+        raise ValueError()
+    if cutoff:
+        return min(ret, cutoff)
+    return ret
+
+
+def _reverse_ordering(ordering_tuple):
+    """
+    Given an order_by tuple such as `('-created', 'uuid')` reverse the
+    ordering and return a new tuple, eg. `('created', '-uuid')`.
+    """
+    def invert(x):
+        return x[1:] if x.startswith('-') else '-' + x
+
+    return tuple([invert(item) for item in ordering_tuple])
+
+
+Cursor = namedtuple('Cursor', ['offset', 'reverse', 'position'])
+
+
+class CursorPaginator:
+    """
+    The cursor pagination implementation is necessarily complex.
+    For an overview of the position/offset style we use, see this post:
+    https://cra.mr/2011/03/08/building-cursors-for-the-disqus-api
+    """
+
+    def __init__(self, queryset: QuerySet, ordering: tuple[str], page_size: int, offset_cutoff=1000):
+        self.queryset = queryset
+        self.ordering = ordering
+        # Client can control the page size using this query parameter.
+        # Default is 'None'. Set to eg 'page_size' to enable usage.
+        self.page_size = page_size
+        # The offset in the cursor is used in situations where we have a
+        # nearly-unique index. (Eg millisecond precision creation timestamps)
+        # We guard against malicious users attempting to cause expensive database
+        # queries, by having a hard cap on the maximum possible size of the offset.
+        self.offset_cutoff = offset_cutoff
+
+    def paginate(self, token):
+        self.cursor = self.decode_cursor(token)
+        if self.cursor is None:
+            (offset, reverse, current_position) = (0, False, None)
+        else:
+            (offset, reverse, current_position) = self.cursor
+
+        # Cursor pagination always enforces an ordering.
+        if reverse:
+            queryset = self.queryset.order_by(*_reverse_ordering(self.ordering))
+        else:
+            queryset = self.queryset.order_by(*self.ordering)
+
+        # If we have a cursor with a fixed position then filter by that.
+        if current_position is not None:
+            order = self.ordering[0]
+            is_reversed = order.startswith('-')
+            order_attr = order.lstrip('-')
+
+            # Test for: (cursor reversed) XOR (queryset reversed)
+            if self.cursor.reverse != is_reversed:
+                kwargs = {order_attr + '__lt': current_position}
+            else:
+                kwargs = {order_attr + '__gt': current_position}
+
+            queryset = queryset.filter(**kwargs)
+
+        # If we have an offset cursor then offset the entire page by that amount.
+        # We also always fetch an extra item in order to determine if there is a
+        # page following on from this one.
+        results = list(queryset[offset:offset + self.page_size + 1])
+        self.page = list(results[:self.page_size])
+
+        # Determine the position of the final item following the page.
+        if len(results) > len(self.page):
+            has_following_position = True
+            following_position = self._get_position_from_instance(results[-1], self.ordering)
+        else:
+            has_following_position = False
+            following_position = None
+
+        if reverse:
+            # If we have a reverse queryset, then the query ordering was in reverse
+            # so we need to reverse the items again before returning them to the user.
+            self.page = list(reversed(self.page))
+
+            # Determine next and previous positions for reverse cursors.
+            self.has_next = (current_position is not None) or (offset > 0)
+            self.has_previous = has_following_position
+            if self.has_next:
+                self.next_position = current_position
+            if self.has_previous:
+                self.previous_position = following_position
+        else:
+            # Determine next and previous positions for forward cursors.
+            self.has_next = has_following_position
+            self.has_previous = (current_position is not None) or (offset > 0)
+            if self.has_next:
+                self.next_position = following_position
+            if self.has_previous:
+                self.previous_position = current_position
+
+        return self.page, self.get_previous_link(), self.get_next_link()
+
+    def get_next_link(self):
+        if not self.has_next:
+            return None
+
+        if self.page and self.cursor and self.cursor.reverse and self.cursor.offset != 0:
+            # If we're reversing direction and we have an offset cursor
+            # then we cannot use the first position we find as a marker.
+            compare = self._get_position_from_instance(self.page[-1], self.ordering)
+        else:
+            compare = self.next_position
+        offset = 0
+
+        has_item_with_unique_position = False
+        for item in reversed(self.page):
+            position = self._get_position_from_instance(item, self.ordering)
+            if position != compare:
+                # The item in this position and the item following it
+                # have different positions. We can use this position as
+                # our marker.
+                has_item_with_unique_position = True
+                break
+
+            # The item in this position has the same position as the item
+            # following it, we can't use it as a marker position, so increment
+            # the offset and keep seeking to the previous item.
+            compare = position
+            offset += 1
+
+        if self.page and not has_item_with_unique_position:
+            # There were no unique positions in the page.
+            if not self.has_previous:
+                # We are on the first page.
+                # Our cursor will have an offset equal to the page size,
+                # but no position to filter against yet.
+                offset = self.page_size
+                position = None
+            elif self.cursor.reverse:
+                # The change in direction will introduce a paging artifact,
+                # where we end up skipping forward a few extra items.
+                offset = 0
+                position = self.previous_position
+            else:
+                # Use the position from the existing cursor and increment
+                # it's offset by the page size.
+                offset = self.cursor.offset + self.page_size
+                position = self.previous_position
+
+        if not self.page:
+            position = self.next_position
+
+        cursor = Cursor(offset=offset, reverse=False, position=position)
+        return self.encode_cursor(cursor)
+
+    def get_previous_link(self):
+        if not self.has_previous:
+            return None
+
+        if self.page and self.cursor and not self.cursor.reverse and self.cursor.offset != 0:
+            # If we're reversing direction and we have an offset cursor
+            # then we cannot use the first position we find as a marker.
+            compare = self._get_position_from_instance(self.page[0], self.ordering)
+        else:
+            compare = self.previous_position
+        offset = 0
+
+        has_item_with_unique_position = False
+        for item in self.page:
+            position = self._get_position_from_instance(item, self.ordering)
+            if position != compare:
+                # The item in this position and the item following it
+                # have different positions. We can use this position as
+                # our marker.
+                has_item_with_unique_position = True
+                break
+
+            # The item in this position has the same position as the item
+            # following it, we can't use it as a marker position, so increment
+            # the offset and keep seeking to the previous item.
+            compare = position
+            offset += 1
+
+        if self.page and not has_item_with_unique_position:
+            # There were no unique positions in the page.
+            if not self.has_next:
+                # We are on the final page.
+                # Our cursor will have an offset equal to the page size,
+                # but no position to filter against yet.
+                offset = self.page_size
+                position = None
+            elif self.cursor.reverse:
+                # Use the position from the existing cursor and increment
+                # it's offset by the page size.
+                offset = self.cursor.offset + self.page_size
+                position = self.next_position
+            else:
+                # The change in direction will introduce a paging artifact,
+                # where we end up skipping back a few extra items.
+                offset = 0
+                position = self.next_position
+
+        if not self.page:
+            position = self.previous_position
+
+        cursor = Cursor(offset=offset, reverse=True, position=position)
+        return self.encode_cursor(cursor)
+
+    def decode_cursor(self, token: str | None):
+        if token is None:
+            return None
+        try:
+            querystring = urlsafe_b64decode(token.encode('ascii')).decode('ascii')
+            tokens = parse.parse_qs(querystring, keep_blank_values=True)
+
+            offset = tokens.get('o', ['0'])[0]
+            offset = _positive_int(offset, cutoff=self.offset_cutoff)
+
+            reverse = tokens.get('r', ['0'])[0]
+            reverse = bool(int(reverse))
+
+            position = tokens.get('p', [None])[0]
+        except (TypeError, ValueError):
+            raise BadRequest('Invalid cursor')
+
+        return Cursor(offset=offset, reverse=reverse, position=position)
+
+    def encode_cursor(self, cursor: Cursor):
+        tokens = {}
+        if cursor.offset != 0:
+            tokens['o'] = str(cursor.offset)
+        if cursor.reverse:
+            tokens['r'] = '1'
+        if cursor.position is not None:
+            tokens['p'] = cursor.position
+
+        querystring = parse.urlencode(tokens, doseq=True)
+        encoded = urlsafe_b64encode(querystring.encode('ascii')).decode('ascii')
+        return encoded
+
+    def _get_position_from_instance(self, instance, ordering):
+        field_name = ordering[0].lstrip('-')
+        if isinstance(instance, dict):
+            attr = instance[field_name]
+        else:
+            attr = getattr(instance, field_name)
+        return str(attr)

--- a/judge/utils/cursor_paginator.py
+++ b/judge/utils/cursor_paginator.py
@@ -1,152 +1,90 @@
 """
-Pagination serializers determine the structure of the output that should
-be used for paginated responses.
+Cursor pagination helpers for stable, seek-based list navigation.
 
-# License
-
-Copyright © 2011-present, [Encode OSS Ltd](https://www.encode.io/).
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-
-* Neither the name of the copyright holder nor the names of its
-  contributors may be used to endorse or promote products derived from
-  this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+The paginator requires an ordering that ends in a unique tie-breaker, usually
+``id``. This lets us page with lexicographic predicates instead of OFFSET.
 """
 
-from base64 import urlsafe_b64decode, urlsafe_b64encode
-from collections import namedtuple
-from urllib import parse
+from dataclasses import dataclass
+from datetime import date, datetime, time
+from decimal import Decimal
+from uuid import UUID
 
-from django.core.exceptions import BadRequest
+from django.core import signing
+from django.core.exceptions import BadRequest, FieldDoesNotExist, ValidationError
+from django.db.models import Q
 from django.db.models.query import QuerySet
 
 
-def _positive_int(integer_string, strict=False, cutoff=None):
-    """
-    Cast a string to a strictly positive integer.
-    """
-    ret = int(integer_string)
-    if ret < 0 or (ret == 0 and strict):
-        raise ValueError()
-    if cutoff:
-        return min(ret, cutoff)
-    return ret
+CURSOR_VERSION = 1
+DEFAULT_CURSOR_MAX_AGE = 24 * 60 * 60
+DEFAULT_CURSOR_SALT = 'judge.cursor_paginator'
 
 
 def _reverse_ordering(ordering_tuple):
     """
-    Given an order_by tuple such as `('-created', 'uuid')` reverse the
-    ordering and return a new tuple, eg. `('created', '-uuid')`.
+    Given an order_by tuple such as ``('-created', 'uuid')``, reverse the
+    ordering and return a new tuple, e.g. ``('created', '-uuid')``.
     """
     def invert(x):
         return x[1:] if x.startswith('-') else '-' + x
 
-    return tuple([invert(item) for item in ordering_tuple])
+    return tuple(invert(item) for item in ordering_tuple)
 
 
-Cursor = namedtuple('Cursor', ['offset', 'reverse', 'position'])
+@dataclass(frozen=True)
+class Cursor:
+    reverse: bool
+    position: tuple
 
 
 class CursorPaginator:
     """
-    The cursor pagination implementation is necessarily complex.
-    For an overview of the position/offset style we use, see this post:
-    https://cra.mr/2011/03/08/building-cursors-for-the-disqus-api
+    QuerySet cursor paginator using signed, timestamped cursor tokens.
+
+    ``ordering`` must end with ``unique_field``. For non-unique sorts, include
+    a unique tie-breaker, for example ``('-score', '-id')``.
     """
 
-    def __init__(self, queryset: QuerySet, ordering: tuple[str], page_size: int, offset_cutoff=1000):
+    def __init__(
+            self,
+            queryset: QuerySet,
+            ordering: tuple[str, ...],
+            page_size: int,
+            *,
+            unique_field='id',
+            cursor_max_age=DEFAULT_CURSOR_MAX_AGE,
+            cursor_salt=DEFAULT_CURSOR_SALT):
         self.queryset = queryset
-        self.ordering = ordering
-        # Client can control the page size using this query parameter.
-        # Default is 'None'. Set to eg 'page_size' to enable usage.
+        self.ordering = tuple(ordering)
         self.page_size = page_size
-        # The offset in the cursor is used in situations where we have a
-        # nearly-unique index. (Eg millisecond precision creation timestamps)
-        # We guard against malicious users attempting to cause expensive database
-        # queries, by having a hard cap on the maximum possible size of the offset.
-        self.offset_cutoff = offset_cutoff
+        self.unique_field = unique_field
+        self.cursor_max_age = cursor_max_age
+        self.cursor_salt = cursor_salt
+
+        self._field_names = tuple(item.lstrip('-') for item in self.ordering)
+        self._validate_ordering()
 
     def paginate(self, token):
         self.cursor = self.decode_cursor(token)
-        if self.cursor is None:
-            (offset, reverse, current_position) = (0, False, None)
-        else:
-            (offset, reverse, current_position) = self.cursor
+        reverse = bool(self.cursor and self.cursor.reverse)
+        query_ordering = _reverse_ordering(self.ordering) if reverse else self.ordering
 
-        # Cursor pagination always enforces an ordering.
-        if reverse:
-            queryset = self.queryset.order_by(*_reverse_ordering(self.ordering))
-        else:
-            queryset = self.queryset.order_by(*self.ordering)
+        queryset = self.queryset.order_by(*query_ordering)
+        if self.cursor is not None:
+            queryset = queryset.filter(self._seek_filter(self.cursor.position, query_ordering))
 
-        # If we have a cursor with a fixed position then filter by that.
-        if current_position is not None:
-            order = self.ordering[0]
-            is_reversed = order.startswith('-')
-            order_attr = order.lstrip('-')
-
-            # Test for: (cursor reversed) XOR (queryset reversed)
-            if self.cursor.reverse != is_reversed:
-                kwargs = {order_attr + '__lt': current_position}
-            else:
-                kwargs = {order_attr + '__gt': current_position}
-
-            queryset = queryset.filter(**kwargs)
-
-        # If we have an offset cursor then offset the entire page by that amount.
-        # We also always fetch an extra item in order to determine if there is a
-        # page following on from this one.
-        results = list(queryset[offset:offset + self.page_size + 1])
+        results = list(queryset[:self.page_size + 1])
+        has_more = len(results) > self.page_size
         self.page = list(results[:self.page_size])
 
-        # Determine the position of the final item following the page.
-        if len(results) > len(self.page):
-            has_following_position = True
-            following_position = self._get_position_from_instance(results[-1], self.ordering)
-        else:
-            has_following_position = False
-            following_position = None
-
         if reverse:
-            # If we have a reverse queryset, then the query ordering was in reverse
-            # so we need to reverse the items again before returning them to the user.
-            self.page = list(reversed(self.page))
-
-            # Determine next and previous positions for reverse cursors.
-            self.has_next = (current_position is not None) or (offset > 0)
-            self.has_previous = has_following_position
-            if self.has_next:
-                self.next_position = current_position
-            if self.has_previous:
-                self.previous_position = following_position
+            self.page.reverse()
+            self.has_previous = has_more
+            self.has_next = bool(self.page)
         else:
-            # Determine next and previous positions for forward cursors.
-            self.has_next = has_following_position
-            self.has_previous = (current_position is not None) or (offset > 0)
-            if self.has_next:
-                self.next_position = following_position
-            if self.has_previous:
-                self.previous_position = current_position
+            self.has_next = has_more
+            self.has_previous = self.cursor is not None and bool(self.page)
 
         return self.page, self.get_previous_link(), self.get_next_link()
 
@@ -154,144 +92,133 @@ class CursorPaginator:
         if not self.has_next:
             return None
 
-        if self.page and self.cursor and self.cursor.reverse and self.cursor.offset != 0:
-            # If we're reversing direction and we have an offset cursor
-            # then we cannot use the first position we find as a marker.
-            compare = self._get_position_from_instance(self.page[-1], self.ordering)
+        if self.page:
+            position = self._get_position_from_instance(self.page[-1])
+        elif self.cursor is not None:
+            position = self.cursor.position
         else:
-            compare = self.next_position
-        offset = 0
+            return None
 
-        has_item_with_unique_position = False
-        for item in reversed(self.page):
-            position = self._get_position_from_instance(item, self.ordering)
-            if position != compare:
-                # The item in this position and the item following it
-                # have different positions. We can use this position as
-                # our marker.
-                has_item_with_unique_position = True
-                break
-
-            # The item in this position has the same position as the item
-            # following it, we can't use it as a marker position, so increment
-            # the offset and keep seeking to the previous item.
-            compare = position
-            offset += 1
-
-        if self.page and not has_item_with_unique_position:
-            # There were no unique positions in the page.
-            if not self.has_previous:
-                # We are on the first page.
-                # Our cursor will have an offset equal to the page size,
-                # but no position to filter against yet.
-                offset = self.page_size
-                position = None
-            elif self.cursor.reverse:
-                # The change in direction will introduce a paging artifact,
-                # where we end up skipping forward a few extra items.
-                offset = 0
-                position = self.previous_position
-            else:
-                # Use the position from the existing cursor and increment
-                # it's offset by the page size.
-                offset = self.cursor.offset + self.page_size
-                position = self.previous_position
-
-        if not self.page:
-            position = self.next_position
-
-        cursor = Cursor(offset=offset, reverse=False, position=position)
-        return self.encode_cursor(cursor)
+        return self.encode_cursor(Cursor(reverse=False, position=position))
 
     def get_previous_link(self):
         if not self.has_previous:
             return None
 
-        if self.page and self.cursor and not self.cursor.reverse and self.cursor.offset != 0:
-            # If we're reversing direction and we have an offset cursor
-            # then we cannot use the first position we find as a marker.
-            compare = self._get_position_from_instance(self.page[0], self.ordering)
+        if self.page:
+            position = self._get_position_from_instance(self.page[0])
+        elif self.cursor is not None:
+            position = self.cursor.position
         else:
-            compare = self.previous_position
-        offset = 0
+            return None
 
-        has_item_with_unique_position = False
-        for item in self.page:
-            position = self._get_position_from_instance(item, self.ordering)
-            if position != compare:
-                # The item in this position and the item following it
-                # have different positions. We can use this position as
-                # our marker.
-                has_item_with_unique_position = True
-                break
-
-            # The item in this position has the same position as the item
-            # following it, we can't use it as a marker position, so increment
-            # the offset and keep seeking to the previous item.
-            compare = position
-            offset += 1
-
-        if self.page and not has_item_with_unique_position:
-            # There were no unique positions in the page.
-            if not self.has_next:
-                # We are on the final page.
-                # Our cursor will have an offset equal to the page size,
-                # but no position to filter against yet.
-                offset = self.page_size
-                position = None
-            elif self.cursor.reverse:
-                # Use the position from the existing cursor and increment
-                # it's offset by the page size.
-                offset = self.cursor.offset + self.page_size
-                position = self.next_position
-            else:
-                # The change in direction will introduce a paging artifact,
-                # where we end up skipping back a few extra items.
-                offset = 0
-                position = self.next_position
-
-        if not self.page:
-            position = self.previous_position
-
-        cursor = Cursor(offset=offset, reverse=True, position=position)
-        return self.encode_cursor(cursor)
+        return self.encode_cursor(Cursor(reverse=True, position=position))
 
     def decode_cursor(self, token: str | None):
         if token is None:
             return None
+
         try:
-            querystring = urlsafe_b64decode(token.encode('ascii')).decode('ascii')
-            tokens = parse.parse_qs(querystring, keep_blank_values=True)
+            payload = signing.loads(token, salt=self.cursor_salt, max_age=self.cursor_max_age)
+            if payload.get('v') != CURSOR_VERSION:
+                raise ValueError()
 
-            offset = tokens.get('o', ['0'])[0]
-            offset = _positive_int(offset, cutoff=self.offset_cutoff)
+            raw_position = payload['p']
+            if not isinstance(raw_position, list) or len(raw_position) != len(self.ordering):
+                raise ValueError()
+            reverse = payload.get('r', False)
+            if not isinstance(reverse, bool):
+                raise ValueError()
 
-            reverse = tokens.get('r', ['0'])[0]
-            reverse = bool(int(reverse))
-
-            position = tokens.get('p', [None])[0]
-        except (TypeError, ValueError):
+            position = tuple(
+                self._deserialize_value(field_name, value)
+                for field_name, value in zip(self._field_names, raw_position)
+            )
+            if any(value is None for value in position):
+                raise ValueError()
+            return Cursor(reverse=reverse, position=position)
+        except (KeyError, TypeError, ValueError, signing.BadSignature, ValidationError):
             raise BadRequest('Invalid cursor')
 
-        return Cursor(offset=offset, reverse=reverse, position=position)
-
     def encode_cursor(self, cursor: Cursor):
-        tokens = {}
-        if cursor.offset != 0:
-            tokens['o'] = str(cursor.offset)
-        if cursor.reverse:
-            tokens['r'] = '1'
-        if cursor.position is not None:
-            tokens['p'] = cursor.position
+        if any(value is None for value in cursor.position):
+            raise ValueError('Cursor positions cannot contain None.')
 
-        querystring = parse.urlencode(tokens, doseq=True)
-        encoded = urlsafe_b64encode(querystring.encode('ascii')).decode('ascii')
-        return encoded
+        payload = {
+            'v': CURSOR_VERSION,
+            'r': bool(cursor.reverse),
+            'p': [
+                self._serialize_value(value)
+                for value in cursor.position
+            ],
+        }
+        return signing.dumps(payload, salt=self.cursor_salt, compress=True)
 
-    def _get_position_from_instance(self, instance, ordering):
-        field_name = ordering[0].lstrip('-')
-        if isinstance(instance, dict):
-            attr = instance[field_name]
-        else:
-            attr = getattr(instance, field_name)
-        return str(attr)
+    def _seek_filter(self, position, ordering):
+        query = Q()
+        equal_prefix = Q()
+
+        for order, value in zip(ordering, position):
+            if value is None:
+                raise ValueError('Cursor positions cannot contain None.')
+            field_name = order.lstrip('-')
+            lookup = 'lt' if order.startswith('-') else 'gt'
+            query |= equal_prefix & Q(**{f'{field_name}__{lookup}': value})
+            equal_prefix &= Q(**{field_name: value})
+
+        return query
+
+    def _get_position_from_instance(self, instance):
+        position = []
+        for field_name in self._field_names:
+            if isinstance(instance, dict):
+                position.append(instance[field_name])
+            else:
+                position.append(getattr(instance, field_name))
+        return tuple(position)
+
+    def _serialize_value(self, value):
+        if value is None:
+            return None
+        if isinstance(value, (datetime, date, time)):
+            return value.isoformat()
+        if isinstance(value, (Decimal, UUID)):
+            return str(value)
+        return value
+
+    def _deserialize_value(self, field_name, value):
+        if value is None:
+            return None
+
+        field = self._model_field(field_name)
+        if field is None:
+            return value
+
+        return field.to_python(value)
+
+    def _model_field(self, field_name):
+        try:
+            return self.queryset.model._meta.get_field(field_name)
+        except (AttributeError, FieldDoesNotExist):
+            return None
+
+    def _validate_ordering(self):
+        if self.page_size <= 0:
+            raise ValueError('Cursor page size must be positive.')
+
+        if not self.ordering:
+            raise ValueError('Cursor ordering must not be empty.')
+
+        for order in self.ordering:
+            if order in ('', '-'):
+                raise ValueError('Cursor ordering contains an invalid field.')
+
+        if self._field_names[-1] != self.unique_field:
+            raise ValueError('Cursor ordering must end with a unique field.')
+
+        for field_name in self._field_names:
+            if '__' in field_name:
+                raise ValueError('Cursor ordering does not support related fields.')
+            field = self._model_field(field_name)
+            if field is not None and field.null:
+                raise ValueError('Cursor ordering does not support nullable fields.')

--- a/judge/utils/cursor_paginator.py
+++ b/judge/utils/cursor_paginator.py
@@ -85,6 +85,9 @@ class CursorPaginator:
             raise BadRequest('Invalid cursor')
 
     def encode_cursor(self, cursor: Cursor):
+        if len(cursor.position) != len(self.ordering):
+            raise ValueError('Cursor position must hold one value per ordering field.')
+
         if any(value is None for value in cursor.position):
             raise ValueError('Cursor positions cannot contain None.')
 
@@ -133,6 +136,11 @@ class CursorPaginator:
 
         if self._field_names[-1] != self.unique_field:
             raise ValueError('Cursor ordering must end with a unique field.')
+
+        tie_breaker = self._model_field(self.unique_field)
+        if tie_breaker is not None and not (tie_breaker.primary_key or tie_breaker.unique):
+            raise ValueError('Cursor unique_field must be unique: a tie-breaker that repeats can skip or '
+                             'duplicate rows across pages.')
 
         for field_name in self._field_names:
             if '__' in field_name:

--- a/judge/utils/cursor_paginator.py
+++ b/judge/utils/cursor_paginator.py
@@ -19,7 +19,7 @@ from decimal import Decimal
 from uuid import UUID
 
 from django.core import signing
-from django.core.exceptions import BadRequest, FieldDoesNotExist, ValidationError
+from django.core.exceptions import BadRequest, FieldDoesNotExist, ImproperlyConfigured, ValidationError
 from django.db.models import Q
 from django.http import Http404
 
@@ -266,6 +266,17 @@ class CursorPaginationMixin:
         return tuple(getattr(instance, order.lstrip('-')) for order in self.cursor_ordering)
 
     def paginate_queryset(self, queryset, page_size):
+        # Seeking only works against the ordering the cursor was minted for, and the
+        # order_by below would otherwise silently replace whatever the view asked for.
+        # A subclass that re-sorts (RankedSubmissions, say) must not inherit this.
+        existing = tuple(queryset.query.order_by)
+        if existing and existing != tuple(self.cursor_ordering):
+            raise ImproperlyConfigured(
+                '%s orders by %r but cursor_ordering is %r. Set cursor_ordering to match, '
+                'or page this view some other way.'
+                % (type(self).__name__, existing, tuple(self.cursor_ordering)),
+            )
+
         paginator = self.get_cursor_paginator(queryset)
         cursor = paginator.decode_cursor(self.request.GET.get(self.cursor_query_param) or None)
 

--- a/judge/utils/cursor_paginator.py
+++ b/judge/utils/cursor_paginator.py
@@ -1,10 +1,13 @@
 """
-Signed cursor tokens for stable, seek-based list navigation.
+Seek-based list navigation with signed cursor tokens.
 
 A token carries the ordering position of a row, letting a view resume a listing
-with a lexicographic predicate (``WHERE id < :position``) instead of ``OFFSET``.
-Building and running that predicate is the caller's job; this module only
-encodes, signs, and validates the position.
+with a lexicographic predicate (``WHERE id < :position``) instead of ``OFFSET``,
+so the cost of a page stops growing with its depth.
+
+``CursorPaginator`` is the token codec: it signs, validates and decodes a
+position. ``CursorPaginationMixin`` drives an ordinary ``ListView`` with it.
+Callers that build their own SQL can use the codec alone.
 
 The ordering must end in a unique tie-breaker, usually ``id``, otherwise a
 position cannot identify a single row.
@@ -17,6 +20,8 @@ from uuid import UUID
 
 from django.core import signing
 from django.core.exceptions import BadRequest, FieldDoesNotExist, ValidationError
+from django.db.models import Q
+from django.http import Http404
 
 
 CURSOR_VERSION = 1
@@ -28,6 +33,32 @@ DEFAULT_CURSOR_SALT = 'judge.cursor_paginator'
 class Cursor:
     reverse: bool
     position: tuple
+
+
+def _reverse_ordering(ordering):
+    """``('-created', 'uuid')`` -> ``('created', '-uuid')``."""
+    def invert(order):
+        return order[1:] if order.startswith('-') else '-' + order
+
+    return tuple(invert(order) for order in ordering)
+
+
+def _seek_filter(ordering, position):
+    """Lexicographic "strictly past this position" predicate for ``ordering``.
+
+    For a single field this is just ``id__lt=...``; for a composite ordering it
+    expands to the usual ``a < x OR (a = x AND b < y)`` chain.
+    """
+    query = Q()
+    equal_prefix = Q()
+
+    for order, value in zip(ordering, position):
+        field_name = order.lstrip('-')
+        lookup = 'lt' if order.startswith('-') else 'gt'
+        query |= equal_prefix & Q(**{'%s__%s' % (field_name, lookup): value})
+        equal_prefix &= Q(**{field_name: value})
+
+    return query
 
 
 class CursorPaginator:
@@ -148,3 +179,128 @@ class CursorPaginator:
             field = self._model_field(field_name)
             if field is not None and field.null:
                 raise ValueError('Cursor ordering does not support nullable fields.')
+
+
+class CursorPage:
+    """Page object for cursor pagination, shaped like ``django.core.paginator.Page``.
+
+    ``number`` is 1 on the first page and 2 everywhere else. Seek pagination cannot
+    know a page's true ordinal without counting, and the point of it is to avoid
+    counting. It exists so that existing ``page_obj.number == 1`` checks -- live
+    submission updates, for instance -- keep working.
+    """
+
+    is_cursor = True
+    page_range = ()
+
+    def __init__(self, object_list, previous_href=None, next_href=None):
+        self.object_list = object_list
+        self.previous_href = previous_href
+        self.next_href = next_href
+        self.number = 1 if previous_href is None else 2
+
+    def __len__(self):
+        return len(self.object_list)
+
+    def __iter__(self):
+        return iter(self.object_list)
+
+    def __getitem__(self, index):
+        return self.object_list[index]
+
+    def has_previous(self):
+        return self.previous_href is not None
+
+    def has_next(self):
+        return self.next_href is not None
+
+    def has_other_pages(self):
+        return self.has_previous() or self.has_next()
+
+
+class CursorListPaginator:
+    """Stand-in for the paginator a ``ListView`` normally supplies.
+
+    Templates only ever read ``per_page`` off it; there is no page count to give.
+    """
+
+    def __init__(self, per_page):
+        self.per_page = per_page
+
+
+class CursorPaginationMixin:
+    """Seek pagination for a ``ListView``.
+
+    Pagination links are ordinary URLs carrying a ``cursor`` query parameter, so
+    pages stay shareable, the back button works, and the list degrades gracefully
+    without JavaScript.
+
+    ``cursor_ordering`` must end in a unique field and is applied to the queryset,
+    replacing whatever ordering it already carries.
+    """
+
+    cursor_ordering = ('-id',)
+    cursor_query_param = 'cursor'
+    cursor_salt = DEFAULT_CURSOR_SALT
+
+    def get_cursor_salt(self):
+        return self.cursor_salt
+
+    def get_cursor_paginator(self, queryset):
+        return CursorPaginator(
+            model=queryset.model,
+            ordering=self.cursor_ordering,
+            cursor_salt=self.get_cursor_salt(),
+        )
+
+    def get_cursor_href(self, token):
+        """Current URL with ``cursor`` swapped out, so filters survive paging."""
+        params = self.request.GET.copy()
+        params.pop(self.cursor_query_param, None)
+        if token is not None:
+            params[self.cursor_query_param] = token
+        encoded = params.urlencode()
+        return '%s?%s' % (self.request.path, encoded) if encoded else self.request.path
+
+    def get_cursor_position(self, instance):
+        return tuple(getattr(instance, order.lstrip('-')) for order in self.cursor_ordering)
+
+    def paginate_queryset(self, queryset, page_size):
+        paginator = self.get_cursor_paginator(queryset)
+        cursor = paginator.decode_cursor(self.request.GET.get(self.cursor_query_param) or None)
+
+        backwards = bool(cursor and cursor.reverse)
+        ordering = _reverse_ordering(self.cursor_ordering) if backwards else self.cursor_ordering
+
+        page_queryset = queryset.order_by(*ordering)
+        if cursor is not None:
+            page_queryset = page_queryset.filter(_seek_filter(ordering, cursor.position))
+
+        # One extra row answers "is there a next page?" without a second query.
+        rows = list(page_queryset[:page_size + 1])
+        has_more = len(rows) > page_size
+        rows = rows[:page_size]
+        if backwards:
+            rows.reverse()
+
+        if cursor is not None and not rows:
+            raise Http404('That page contains no results.')
+
+        if backwards:
+            # Arriving from a later page, so there is always something ahead of us.
+            has_previous, has_next = has_more, True
+        else:
+            has_previous, has_next = cursor is not None, has_more
+
+        def href(reverse, instance):
+            return self.get_cursor_href(paginator.encode_cursor(Cursor(
+                reverse=reverse,
+                position=self.get_cursor_position(instance),
+            )))
+
+        page = CursorPage(
+            object_list=rows,
+            previous_href=href(True, rows[0]) if has_previous and rows else None,
+            next_href=href(False, rows[-1]) if has_next and rows else None,
+        )
+        return CursorListPaginator(page_size), page, page.object_list, page.has_other_pages()

--- a/judge/utils/cursor_paginator.py
+++ b/judge/utils/cursor_paginator.py
@@ -1,8 +1,13 @@
 """
-Cursor pagination helpers for stable, seek-based list navigation.
+Signed cursor tokens for stable, seek-based list navigation.
 
-The paginator requires an ordering that ends in a unique tie-breaker, usually
-``id``. This lets us page with lexicographic predicates instead of OFFSET.
+A token carries the ordering position of a row, letting a view resume a listing
+with a lexicographic predicate (``WHERE id < :position``) instead of ``OFFSET``.
+Building and running that predicate is the caller's job; this module only
+encodes, signs, and validates the position.
+
+The ordering must end in a unique tie-breaker, usually ``id``, otherwise a
+position cannot identify a single row.
 """
 
 from dataclasses import dataclass
@@ -12,24 +17,11 @@ from uuid import UUID
 
 from django.core import signing
 from django.core.exceptions import BadRequest, FieldDoesNotExist, ValidationError
-from django.db.models import Q
-from django.db.models.query import QuerySet
 
 
 CURSOR_VERSION = 1
 DEFAULT_CURSOR_MAX_AGE = 24 * 60 * 60
 DEFAULT_CURSOR_SALT = 'judge.cursor_paginator'
-
-
-def _reverse_ordering(ordering_tuple):
-    """
-    Given an order_by tuple such as ``('-created', 'uuid')``, reverse the
-    ordering and return a new tuple, e.g. ``('created', '-uuid')``.
-    """
-    def invert(x):
-        return x[1:] if x.startswith('-') else '-' + x
-
-    return tuple(invert(item) for item in ordering_tuple)
 
 
 @dataclass(frozen=True)
@@ -40,79 +32,31 @@ class Cursor:
 
 class CursorPaginator:
     """
-    QuerySet cursor paginator using signed, timestamped cursor tokens.
+    Encodes and decodes signed, timestamped cursor tokens for a given ordering.
 
-    ``ordering`` must end with ``unique_field``. For non-unique sorts, include
-    a unique tie-breaker, for example ``('-score', '-id')``.
+    ``ordering`` must end with ``unique_field``. For non-unique sorts, include a
+    unique tie-breaker, for example ``('-score', '-id')``.
+
+    ``cursor_salt`` scopes a token: tokens signed under one salt are rejected
+    under another, so callers can bind a cursor to the filters it was issued for.
     """
 
     def __init__(
             self,
-            queryset: QuerySet,
+            model,
             ordering: tuple[str, ...],
-            page_size: int,
             *,
             unique_field='id',
             cursor_max_age=DEFAULT_CURSOR_MAX_AGE,
             cursor_salt=DEFAULT_CURSOR_SALT):
-        self.queryset = queryset
+        self.model = model
         self.ordering = tuple(ordering)
-        self.page_size = page_size
         self.unique_field = unique_field
         self.cursor_max_age = cursor_max_age
         self.cursor_salt = cursor_salt
 
         self._field_names = tuple(item.lstrip('-') for item in self.ordering)
         self._validate_ordering()
-
-    def paginate(self, token):
-        self.cursor = self.decode_cursor(token)
-        reverse = bool(self.cursor and self.cursor.reverse)
-        query_ordering = _reverse_ordering(self.ordering) if reverse else self.ordering
-
-        queryset = self.queryset.order_by(*query_ordering)
-        if self.cursor is not None:
-            queryset = queryset.filter(self._seek_filter(self.cursor.position, query_ordering))
-
-        results = list(queryset[:self.page_size + 1])
-        has_more = len(results) > self.page_size
-        self.page = list(results[:self.page_size])
-
-        if reverse:
-            self.page.reverse()
-            self.has_previous = has_more
-            self.has_next = bool(self.page)
-        else:
-            self.has_next = has_more
-            self.has_previous = self.cursor is not None and bool(self.page)
-
-        return self.page, self.get_previous_link(), self.get_next_link()
-
-    def get_next_link(self):
-        if not self.has_next:
-            return None
-
-        if self.page:
-            position = self._get_position_from_instance(self.page[-1])
-        elif self.cursor is not None:
-            position = self.cursor.position
-        else:
-            return None
-
-        return self.encode_cursor(Cursor(reverse=False, position=position))
-
-    def get_previous_link(self):
-        if not self.has_previous:
-            return None
-
-        if self.page:
-            position = self._get_position_from_instance(self.page[0])
-        elif self.cursor is not None:
-            position = self.cursor.position
-        else:
-            return None
-
-        return self.encode_cursor(Cursor(reverse=True, position=position))
 
     def decode_cursor(self, token: str | None):
         if token is None:
@@ -154,29 +98,6 @@ class CursorPaginator:
         }
         return signing.dumps(payload, salt=self.cursor_salt, compress=True)
 
-    def _seek_filter(self, position, ordering):
-        query = Q()
-        equal_prefix = Q()
-
-        for order, value in zip(ordering, position):
-            if value is None:
-                raise ValueError('Cursor positions cannot contain None.')
-            field_name = order.lstrip('-')
-            lookup = 'lt' if order.startswith('-') else 'gt'
-            query |= equal_prefix & Q(**{f'{field_name}__{lookup}': value})
-            equal_prefix &= Q(**{field_name: value})
-
-        return query
-
-    def _get_position_from_instance(self, instance):
-        position = []
-        for field_name in self._field_names:
-            if isinstance(instance, dict):
-                position.append(instance[field_name])
-            else:
-                position.append(getattr(instance, field_name))
-        return tuple(position)
-
     def _serialize_value(self, value):
         if value is None:
             return None
@@ -198,14 +119,11 @@ class CursorPaginator:
 
     def _model_field(self, field_name):
         try:
-            return self.queryset.model._meta.get_field(field_name)
+            return self.model._meta.get_field(field_name)
         except (AttributeError, FieldDoesNotExist):
             return None
 
     def _validate_ordering(self):
-        if self.page_size <= 0:
-            raise ValueError('Cursor page size must be positive.')
-
         if not self.ordering:
             raise ValueError('Cursor ordering must not be empty.')
 

--- a/judge/utils/tests/test_cursor_paginator.py
+++ b/judge/utils/tests/test_cursor_paginator.py
@@ -1,0 +1,462 @@
+from base64 import urlsafe_b64encode
+from unittest.mock import MagicMock
+
+from django.core.exceptions import BadRequest
+from django.test import SimpleTestCase, TestCase
+from django.utils import timezone
+
+from judge.models import BlogPost
+from judge.utils.cursor_paginator import (
+    Cursor,
+    CursorPaginator,
+    _positive_int,
+    _reverse_ordering,
+)
+
+
+class PositiveIntTestCase(SimpleTestCase):
+    def test_positive_integer(self):
+        self.assertEqual(_positive_int('5'), 5)
+        self.assertEqual(_positive_int('0'), 0)
+        self.assertEqual(_positive_int('100'), 100)
+
+    def test_strict_mode_rejects_zero(self):
+        with self.assertRaises(ValueError):
+            _positive_int('0', strict=True)
+
+    def test_negative_integer_raises(self):
+        with self.assertRaises(ValueError):
+            _positive_int('-1')
+        with self.assertRaises(ValueError):
+            _positive_int('-100')
+
+    def test_cutoff(self):
+        self.assertEqual(_positive_int('1000', cutoff=500), 500)
+        self.assertEqual(_positive_int('100', cutoff=500), 100)
+        self.assertEqual(_positive_int('500', cutoff=500), 500)
+
+    def test_invalid_string_raises(self):
+        with self.assertRaises(ValueError):
+            _positive_int('abc')
+        with self.assertRaises(ValueError):
+            _positive_int('')
+
+
+class ReverseOrderingTestCase(SimpleTestCase):
+    def test_reverse_ascending(self):
+        self.assertEqual(_reverse_ordering(('created',)), ('-created',))
+
+    def test_reverse_descending(self):
+        self.assertEqual(_reverse_ordering(('-created',)), ('created',))
+
+    def test_reverse_multiple_fields(self):
+        self.assertEqual(
+            _reverse_ordering(('-created', 'uuid')),
+            ('created', '-uuid'),
+        )
+
+    def test_reverse_empty_tuple(self):
+        self.assertEqual(_reverse_ordering(()), ())
+
+
+class CursorNamedTupleTestCase(SimpleTestCase):
+    def test_cursor_creation(self):
+        cursor = Cursor(offset=5, reverse=True, position='abc')
+        self.assertEqual(cursor.offset, 5)
+        self.assertEqual(cursor.reverse, True)
+        self.assertEqual(cursor.position, 'abc')
+
+    def test_cursor_immutable(self):
+        cursor = Cursor(offset=5, reverse=True, position='abc')
+        with self.assertRaises(AttributeError):
+            cursor.offset = 10
+
+
+class CursorPaginatorEncodingTestCase(SimpleTestCase):
+    def setUp(self):
+        self.queryset = MagicMock()
+        self.paginator = CursorPaginator(
+            queryset=self.queryset,
+            ordering=('-id',),
+            page_size=10,
+        )
+
+    def test_encode_cursor_basic(self):
+        cursor = Cursor(offset=0, reverse=False, position=None)
+        encoded = self.paginator.encode_cursor(cursor)
+        self.assertEqual(encoded, '')
+
+    def test_encode_cursor_with_offset(self):
+        cursor = Cursor(offset=5, reverse=False, position=None)
+        encoded = self.paginator.encode_cursor(cursor)
+        decoded = self.paginator.decode_cursor(encoded)
+        self.assertEqual(decoded.offset, 5)
+        self.assertEqual(decoded.reverse, False)
+        self.assertIsNone(decoded.position)
+
+    def test_encode_cursor_with_reverse(self):
+        cursor = Cursor(offset=0, reverse=True, position=None)
+        encoded = self.paginator.encode_cursor(cursor)
+        decoded = self.paginator.decode_cursor(encoded)
+        self.assertEqual(decoded.reverse, True)
+
+    def test_encode_cursor_with_position(self):
+        cursor = Cursor(offset=0, reverse=False, position='123')
+        encoded = self.paginator.encode_cursor(cursor)
+        decoded = self.paginator.decode_cursor(encoded)
+        self.assertEqual(decoded.position, '123')
+
+    def test_encode_decode_roundtrip(self):
+        cursor = Cursor(offset=10, reverse=True, position='abc123')
+        encoded = self.paginator.encode_cursor(cursor)
+        decoded = self.paginator.decode_cursor(encoded)
+        self.assertEqual(decoded.offset, 10)
+        self.assertEqual(decoded.reverse, True)
+        self.assertEqual(decoded.position, 'abc123')
+
+    def test_decode_none_returns_none(self):
+        self.assertIsNone(self.paginator.decode_cursor(None))
+
+    def test_decode_invalid_base64_raises_bad_request(self):
+        # binascii.Error is a subclass of ValueError, so it's caught properly
+        with self.assertRaises(BadRequest):
+            self.paginator.decode_cursor('!!invalid!!')
+
+    def test_decode_invalid_offset_raises_bad_request(self):
+        invalid_token = urlsafe_b64encode(b'o=abc').decode('ascii')
+        with self.assertRaises(BadRequest):
+            self.paginator.decode_cursor(invalid_token)
+
+    def test_offset_cutoff_applied(self):
+        paginator = CursorPaginator(
+            queryset=self.queryset,
+            ordering=('-id',),
+            page_size=10,
+            offset_cutoff=100,
+        )
+        token = urlsafe_b64encode(b'o=999').decode('ascii')
+        decoded = paginator.decode_cursor(token)
+        self.assertEqual(decoded.offset, 100)
+
+    def test_negative_reverse_value_in_token(self):
+        token = urlsafe_b64encode(b'r=-1').decode('ascii')
+        decoded = self.paginator.decode_cursor(token)
+        self.assertEqual(decoded.reverse, True)
+
+    def test_position_with_special_characters(self):
+        cursor = Cursor(offset=0, reverse=False, position='test&value=123')
+        encoded = self.paginator.encode_cursor(cursor)
+        decoded = self.paginator.decode_cursor(encoded)
+        self.assertEqual(decoded.position, 'test&value=123')
+
+
+class CursorPaginatorWithBlogPostTestCase(TestCase):
+    """Tests using BlogPost model with real database queries."""
+
+    @classmethod
+    def setUpTestData(cls):
+        now = timezone.now()
+        cls.posts = []
+        for i in range(25):
+            post = BlogPost.objects.create(
+                title=f'Test Post {i:03d}',
+                slug=f'test-post-{i:03d}',
+                publish_on=now,
+                content=f'Content {i}',
+                score=i % 5,
+            )
+            cls.posts.append(post)
+
+    def _create_paginator(self, ordering=('-id',), page_size=10):
+        queryset = BlogPost.objects.filter(id__in=[p.id for p in self.posts])
+        paginator = CursorPaginator(
+            queryset=queryset,
+            ordering=ordering,
+            page_size=page_size,
+        )
+        return paginator
+
+    def test_paginate_first_page(self):
+        paginator = self._create_paginator()
+        page, prev_link, next_link = paginator.paginate(None)
+
+        self.assertEqual(len(page), 10)
+        self.assertIsNone(prev_link)
+        self.assertIsNotNone(next_link)
+
+    def test_paginate_empty_queryset(self):
+        queryset = BlogPost.objects.none()
+        paginator = CursorPaginator(
+            queryset=queryset,
+            ordering=('-id',),
+            page_size=10,
+        )
+
+        page, prev_link, next_link = paginator.paginate(None)
+
+        self.assertEqual(len(page), 0)
+        self.assertIsNone(prev_link)
+        self.assertIsNone(next_link)
+
+    def test_paginate_single_page(self):
+        # Use only first 5 posts
+        queryset = BlogPost.objects.filter(id__in=[p.id for p in self.posts[:5]])
+        paginator = CursorPaginator(
+            queryset=queryset,
+            ordering=('-id',),
+            page_size=10,
+        )
+
+        page, prev_link, next_link = paginator.paginate(None)
+
+        self.assertEqual(len(page), 5)
+        self.assertIsNone(prev_link)
+        self.assertIsNone(next_link)
+
+    def test_paginate_exact_page_size(self):
+        # Use only first 10 posts
+        queryset = BlogPost.objects.filter(id__in=[p.id for p in self.posts[:10]])
+        paginator = CursorPaginator(
+            queryset=queryset,
+            ordering=('-id',),
+            page_size=10,
+        )
+
+        page, prev_link, next_link = paginator.paginate(None)
+
+        self.assertEqual(len(page), 10)
+        self.assertIsNone(prev_link)
+        self.assertIsNone(next_link)
+
+    def test_paginate_forward_navigation(self):
+        paginator = self._create_paginator()
+
+        # First page
+        page1, _, next_link1 = paginator.paginate(None)
+        self.assertEqual(len(page1), 10)
+        page1_ids = [p.id for p in page1]
+
+        # Second page
+        page2, prev_link2, next_link2 = paginator.paginate(next_link1)
+        self.assertEqual(len(page2), 10)
+        self.assertIsNotNone(prev_link2)
+        self.assertIsNotNone(next_link2)
+        page2_ids = [p.id for p in page2]
+
+        # Verify pages don't overlap
+        self.assertEqual(len(set(page1_ids) & set(page2_ids)), 0)
+
+        # Third page (last)
+        page3, prev_link3, next_link3 = paginator.paginate(next_link2)
+        self.assertEqual(len(page3), 5)
+        self.assertIsNotNone(prev_link3)
+        self.assertIsNone(next_link3)
+
+    def test_paginate_backward_navigation(self):
+        paginator = self._create_paginator()
+
+        # Navigate forward to page 2
+        _, _, next_link = paginator.paginate(None)
+        page2, prev_link2, _ = paginator.paginate(next_link)
+        page2_ids = [p.id for p in page2]
+
+        # Navigate back to page 1
+        page1_again, prev_link1, next_link1 = paginator.paginate(prev_link2)
+
+        self.assertIsNone(prev_link1)
+        self.assertIsNotNone(next_link1)
+        self.assertEqual(len(page1_again), 10)
+
+        page1_ids = [p.id for p in page1_again]
+        self.assertEqual(len(set(page1_ids) & set(page2_ids)), 0)
+
+    def test_paginate_ascending_order(self):
+        paginator = self._create_paginator(ordering=('id',))
+
+        page, prev_link, next_link = paginator.paginate(None)
+
+        self.assertEqual(len(page), 10)
+        self.assertEqual(page[0].id, min(p.id for p in page))
+        self.assertIsNone(prev_link)
+        self.assertIsNotNone(next_link)
+
+    def test_paginate_descending_order(self):
+        paginator = self._create_paginator(ordering=('-id',))
+
+        page, _, _ = paginator.paginate(None)
+
+        self.assertEqual(len(page), 10)
+        self.assertEqual(page[0].id, max(p.id for p in page))
+
+    def test_paginate_by_score_field(self):
+        paginator = self._create_paginator(ordering=('-score',))
+
+        page, _, _ = paginator.paginate(None)
+
+        scores = [p.score for p in page]
+        self.assertEqual(scores, sorted(scores, reverse=True))
+
+    def test_paginate_with_position_filter(self):
+        paginator = self._create_paginator()
+
+        page1, _, next_link = paginator.paginate(None)
+        page2, _, _ = paginator.paginate(next_link)
+
+        max_page2_id = max(p.id for p in page2)
+        min_page1_id = min(p.id for p in page1)
+        self.assertLess(max_page2_id, min_page1_id)
+
+    def test_paginate_different_page_sizes(self):
+        for page_size in [1, 5, 10, 20, 100]:
+            with self.subTest(page_size=page_size):
+                paginator = self._create_paginator(page_size=page_size)
+                page, _, _ = paginator.paginate(None)
+                self.assertLessEqual(len(page), page_size)
+
+
+class CursorPaginatorEdgeCasesTestCase(TestCase):
+    """Test edge cases and known bugs."""
+
+    @classmethod
+    def setUpTestData(cls):
+        now = timezone.now()
+        cls.posts = []
+        for i in range(15):
+            post = BlogPost.objects.create(
+                title=f'Edge Case Post {i}',
+                slug=f'edge-case-post-{i}',
+                publish_on=now,
+                content=f'Content {i}',
+                score=100,  # All same score for duplicate position test
+            )
+            cls.posts.append(post)
+
+    def test_duplicate_position_values(self):
+        """Test handling of items with same position value."""
+        queryset = BlogPost.objects.filter(id__in=[p.id for p in self.posts])
+        paginator = CursorPaginator(
+            queryset=queryset,
+            ordering=('-score',),
+            page_size=10,
+        )
+
+        page, _, next_link = paginator.paginate(None)
+
+        self.assertEqual(len(page), 10)
+        self.assertIsNotNone(next_link)
+
+    def test_get_position_from_dict_instance(self):
+        paginator = CursorPaginator(
+            queryset=MagicMock(),
+            ordering=('-id',),
+            page_size=10,
+        )
+
+        instance = {'id': 42, 'name': 'test'}
+        position = paginator._get_position_from_instance(instance, ('-id',))
+        self.assertEqual(position, '42')
+
+    def test_get_position_from_model_instance(self):
+        post = self.posts[0]
+
+        paginator = CursorPaginator(
+            queryset=BlogPost.objects.none(),
+            ordering=('-id',),
+            page_size=10,
+        )
+
+        position = paginator._get_position_from_instance(post, ('-id',))
+        self.assertEqual(position, str(post.id))
+
+
+class CursorPaginatorConsistencyTestCase(TestCase):
+    """Test that pagination is consistent across multiple traversals."""
+
+    @classmethod
+    def setUpTestData(cls):
+        now = timezone.now()
+        cls.posts = []
+        for i in range(50):
+            post = BlogPost.objects.create(
+                title=f'Consistency Post {i:03d}',
+                slug=f'consistency-post-{i:03d}',
+                publish_on=now,
+                content=f'Content {i}',
+                score=i % 10,
+            )
+            cls.posts.append(post)
+
+    def _create_paginator(self, ordering=('-id',), page_size=10):
+        queryset = BlogPost.objects.filter(id__in=[p.id for p in self.posts])
+        paginator = CursorPaginator(
+            queryset=queryset,
+            ordering=ordering,
+            page_size=page_size,
+        )
+        return paginator
+
+    def test_full_forward_traversal_covers_all_items(self):
+        """Verify that paginating forward covers all items exactly once."""
+        queryset = BlogPost.objects.filter(id__in=[p.id for p in self.posts])
+        expected_ids = set(queryset.values_list('id', flat=True))
+
+        paginator = CursorPaginator(
+            queryset=queryset,
+            ordering=('-id',),
+            page_size=7,
+        )
+
+        collected_ids = set()
+        cursor = None
+
+        while True:
+            page, _, next_link = paginator.paginate(cursor)
+            for item in page:
+                self.assertNotIn(item.id, collected_ids, 'Duplicate item found')
+                collected_ids.add(item.id)
+
+            if next_link is None:
+                break
+            cursor = next_link
+
+        self.assertEqual(collected_ids, expected_ids)
+
+    def test_forward_and_backward_consistency(self):
+        """Test that going forward then backward returns to the same items."""
+        paginator = self._create_paginator()
+
+        page1, _, next_link = paginator.paginate(None)
+        page1_ids = [p.id for p in page1]
+
+        _, prev_link, _ = paginator.paginate(next_link)
+
+        page1_again, _, _ = paginator.paginate(prev_link)
+        page1_again_ids = [p.id for p in page1_again]
+
+        self.assertEqual(page1_ids, page1_again_ids)
+
+    def test_all_pages_forward_then_backward(self):
+        """Test traversing all pages forward then all backward."""
+        paginator = self._create_paginator()
+
+        forward_pages = []
+        cursor = None
+        last_prev_link = None
+        while True:
+            page, prev_link, next_link = paginator.paginate(cursor)
+            forward_pages.append([p.id for p in page])
+
+            if next_link is None:
+                last_prev_link = prev_link
+                break
+            cursor = next_link
+
+        backward_pages = []
+        cursor = last_prev_link
+        while cursor is not None:
+            page, prev_link, _ = paginator.paginate(cursor)
+            backward_pages.append([p.id for p in page])
+            cursor = prev_link
+
+        backward_pages.reverse()
+        self.assertEqual(forward_pages[:-1], backward_pages)

--- a/judge/utils/tests/test_cursor_paginator.py
+++ b/judge/utils/tests/test_cursor_paginator.py
@@ -1,45 +1,18 @@
-from base64 import urlsafe_b64encode
-from unittest.mock import MagicMock
+from dataclasses import FrozenInstanceError
 
+from django.core import signing
 from django.core.exceptions import BadRequest
 from django.test import SimpleTestCase, TestCase
 from django.utils import timezone
 
 from judge.models import BlogPost
 from judge.utils.cursor_paginator import (
+    CURSOR_VERSION,
+    DEFAULT_CURSOR_SALT,
     Cursor,
     CursorPaginator,
-    _positive_int,
     _reverse_ordering,
 )
-
-
-class PositiveIntTestCase(SimpleTestCase):
-    def test_positive_integer(self):
-        self.assertEqual(_positive_int('5'), 5)
-        self.assertEqual(_positive_int('0'), 0)
-        self.assertEqual(_positive_int('100'), 100)
-
-    def test_strict_mode_rejects_zero(self):
-        with self.assertRaises(ValueError):
-            _positive_int('0', strict=True)
-
-    def test_negative_integer_raises(self):
-        with self.assertRaises(ValueError):
-            _positive_int('-1')
-        with self.assertRaises(ValueError):
-            _positive_int('-100')
-
-    def test_cutoff(self):
-        self.assertEqual(_positive_int('1000', cutoff=500), 500)
-        self.assertEqual(_positive_int('100', cutoff=500), 100)
-        self.assertEqual(_positive_int('500', cutoff=500), 500)
-
-    def test_invalid_string_raises(self):
-        with self.assertRaises(ValueError):
-            _positive_int('abc')
-        with self.assertRaises(ValueError):
-            _positive_int('')
 
 
 class ReverseOrderingTestCase(SimpleTestCase):
@@ -59,100 +32,116 @@ class ReverseOrderingTestCase(SimpleTestCase):
         self.assertEqual(_reverse_ordering(()), ())
 
 
-class CursorNamedTupleTestCase(SimpleTestCase):
+class CursorTestCase(SimpleTestCase):
     def test_cursor_creation(self):
-        cursor = Cursor(offset=5, reverse=True, position='abc')
-        self.assertEqual(cursor.offset, 5)
-        self.assertEqual(cursor.reverse, True)
-        self.assertEqual(cursor.position, 'abc')
+        cursor = Cursor(reverse=True, position=(5, 'abc'))
+        self.assertIs(cursor.reverse, True)
+        self.assertEqual(cursor.position, (5, 'abc'))
 
     def test_cursor_immutable(self):
-        cursor = Cursor(offset=5, reverse=True, position='abc')
-        with self.assertRaises(AttributeError):
-            cursor.offset = 10
+        cursor = Cursor(reverse=True, position=(5,))
+        with self.assertRaises(FrozenInstanceError):
+            cursor.position = (10,)
 
 
 class CursorPaginatorEncodingTestCase(SimpleTestCase):
     def setUp(self):
-        self.queryset = MagicMock()
         self.paginator = CursorPaginator(
-            queryset=self.queryset,
+            queryset=BlogPost.objects.none(),
             ordering=('-id',),
             page_size=10,
         )
-
-    def test_encode_cursor_basic(self):
-        cursor = Cursor(offset=0, reverse=False, position=None)
-        encoded = self.paginator.encode_cursor(cursor)
-        self.assertEqual(encoded, '')
-
-    def test_encode_cursor_with_offset(self):
-        cursor = Cursor(offset=5, reverse=False, position=None)
-        encoded = self.paginator.encode_cursor(cursor)
-        decoded = self.paginator.decode_cursor(encoded)
-        self.assertEqual(decoded.offset, 5)
-        self.assertEqual(decoded.reverse, False)
-        self.assertIsNone(decoded.position)
-
-    def test_encode_cursor_with_reverse(self):
-        cursor = Cursor(offset=0, reverse=True, position=None)
-        encoded = self.paginator.encode_cursor(cursor)
-        decoded = self.paginator.decode_cursor(encoded)
-        self.assertEqual(decoded.reverse, True)
-
-    def test_encode_cursor_with_position(self):
-        cursor = Cursor(offset=0, reverse=False, position='123')
-        encoded = self.paginator.encode_cursor(cursor)
-        decoded = self.paginator.decode_cursor(encoded)
-        self.assertEqual(decoded.position, '123')
-
-    def test_encode_decode_roundtrip(self):
-        cursor = Cursor(offset=10, reverse=True, position='abc123')
-        encoded = self.paginator.encode_cursor(cursor)
-        decoded = self.paginator.decode_cursor(encoded)
-        self.assertEqual(decoded.offset, 10)
-        self.assertEqual(decoded.reverse, True)
-        self.assertEqual(decoded.position, 'abc123')
 
     def test_decode_none_returns_none(self):
         self.assertIsNone(self.paginator.decode_cursor(None))
 
-    def test_decode_invalid_base64_raises_bad_request(self):
-        # binascii.Error is a subclass of ValueError, so it's caught properly
-        with self.assertRaises(BadRequest):
-            self.paginator.decode_cursor('!!invalid!!')
-
-    def test_decode_invalid_offset_raises_bad_request(self):
-        invalid_token = urlsafe_b64encode(b'o=abc').decode('ascii')
-        with self.assertRaises(BadRequest):
-            self.paginator.decode_cursor(invalid_token)
-
-    def test_offset_cutoff_applied(self):
-        paginator = CursorPaginator(
-            queryset=self.queryset,
-            ordering=('-id',),
-            page_size=10,
-            offset_cutoff=100,
-        )
-        token = urlsafe_b64encode(b'o=999').decode('ascii')
-        decoded = paginator.decode_cursor(token)
-        self.assertEqual(decoded.offset, 100)
-
-    def test_negative_reverse_value_in_token(self):
-        token = urlsafe_b64encode(b'r=-1').decode('ascii')
-        decoded = self.paginator.decode_cursor(token)
-        self.assertEqual(decoded.reverse, True)
-
-    def test_position_with_special_characters(self):
-        cursor = Cursor(offset=0, reverse=False, position='test&value=123')
+    def test_encode_decode_roundtrip(self):
+        cursor = Cursor(reverse=True, position=(123,))
         encoded = self.paginator.encode_cursor(cursor)
         decoded = self.paginator.decode_cursor(encoded)
-        self.assertEqual(decoded.position, 'test&value=123')
+
+        self.assertIsInstance(encoded, str)
+        self.assertNotEqual('', encoded)
+        self.assertEqual(cursor, decoded)
+
+    def test_decode_invalid_token_raises_bad_request(self):
+        with self.assertRaises(BadRequest):
+            self.paginator.decode_cursor('not-a-valid-signed-cursor')
+
+    def test_decode_tampered_token_raises_bad_request(self):
+        cursor = Cursor(reverse=False, position=(123,))
+        encoded = self.paginator.encode_cursor(cursor)
+        tampered = encoded[:-1] + ('a' if encoded[-1] != 'a' else 'b')
+
+        with self.assertRaises(BadRequest):
+            self.paginator.decode_cursor(tampered)
+
+    def test_decode_wrong_version_raises_bad_request(self):
+        token = signing.dumps({'v': CURSOR_VERSION + 1, 'r': False, 'p': [123]}, salt=DEFAULT_CURSOR_SALT)
+
+        with self.assertRaises(BadRequest):
+            self.paginator.decode_cursor(token)
+
+    def test_decode_wrong_position_length_raises_bad_request(self):
+        token = signing.dumps({'v': CURSOR_VERSION, 'r': False, 'p': [123, 456]}, salt=DEFAULT_CURSOR_SALT)
+
+        with self.assertRaises(BadRequest):
+            self.paginator.decode_cursor(token)
+
+    def test_decode_non_boolean_reverse_raises_bad_request(self):
+        token = signing.dumps({'v': CURSOR_VERSION, 'r': '1', 'p': [123]}, salt=DEFAULT_CURSOR_SALT)
+
+        with self.assertRaises(BadRequest):
+            self.paginator.decode_cursor(token)
+
+    def test_decode_null_position_raises_bad_request(self):
+        token = signing.dumps({'v': CURSOR_VERSION, 'r': False, 'p': [None]}, salt=DEFAULT_CURSOR_SALT)
+
+        with self.assertRaises(BadRequest):
+            self.paginator.decode_cursor(token)
+
+    def test_encode_null_position_rejected(self):
+        with self.assertRaises(ValueError):
+            self.paginator.encode_cursor(Cursor(reverse=False, position=(None,)))
+
+
+class CursorPaginatorValidationTestCase(SimpleTestCase):
+    def test_empty_ordering_rejected(self):
+        with self.assertRaises(ValueError):
+            CursorPaginator(BlogPost.objects.none(), (), 10)
+
+    def test_non_positive_page_size_rejected(self):
+        with self.assertRaises(ValueError):
+            CursorPaginator(BlogPost.objects.none(), ('-id',), 0)
+
+    def test_non_unique_single_field_ordering_rejected(self):
+        with self.assertRaises(ValueError):
+            CursorPaginator(BlogPost.objects.none(), ('-score',), 10)
+
+    def test_non_unique_ordering_requires_unique_tie_breaker(self):
+        with self.assertRaises(ValueError):
+            CursorPaginator(BlogPost.objects.none(), ('-score', '-publish_on'), 10)
+
+    def test_unique_single_field_ordering_allowed(self):
+        paginator = CursorPaginator(BlogPost.objects.none(), ('-id',), 10)
+
+        self.assertEqual(('-id',), paginator.ordering)
+
+    def test_composite_ordering_with_tie_breaker_allowed(self):
+        paginator = CursorPaginator(BlogPost.objects.none(), ('-score', '-id'), 10)
+
+        self.assertEqual(('-score', '-id'), paginator.ordering)
+
+    def test_related_ordering_rejected(self):
+        with self.assertRaises(ValueError):
+            CursorPaginator(BlogPost.objects.none(), ('authors__id', 'id'), 10)
+
+    def test_nullable_model_field_ordering_rejected(self):
+        with self.assertRaises(ValueError):
+            CursorPaginator(BlogPost.objects.none(), ('organization', 'id'), 10)
 
 
 class CursorPaginatorWithBlogPostTestCase(TestCase):
-    """Tests using BlogPost model with real database queries."""
-
     @classmethod
     def setUpTestData(cls):
         now = timezone.now()
@@ -167,284 +156,131 @@ class CursorPaginatorWithBlogPostTestCase(TestCase):
             )
             cls.posts.append(post)
 
+    def _queryset(self):
+        return BlogPost.objects.filter(id__in=[post.id for post in self.posts])
+
     def _create_paginator(self, ordering=('-id',), page_size=10):
-        queryset = BlogPost.objects.filter(id__in=[p.id for p in self.posts])
-        paginator = CursorPaginator(
-            queryset=queryset,
+        return CursorPaginator(
+            queryset=self._queryset(),
             ordering=ordering,
             page_size=page_size,
         )
-        return paginator
+
+    def _collect_forward_ids(self, ordering=('-id',), page_size=10):
+        paginator = self._create_paginator(ordering=ordering, page_size=page_size)
+        cursor = None
+        result = []
+
+        while True:
+            page, _, next_link = paginator.paginate(cursor)
+            result.extend(post.id for post in page)
+
+            if next_link is None:
+                break
+            cursor = next_link
+
+        return result
 
     def test_paginate_first_page(self):
         paginator = self._create_paginator()
         page, prev_link, next_link = paginator.paginate(None)
 
-        self.assertEqual(len(page), 10)
+        self.assertEqual(10, len(page))
         self.assertIsNone(prev_link)
         self.assertIsNotNone(next_link)
 
     def test_paginate_empty_queryset(self):
-        queryset = BlogPost.objects.none()
-        paginator = CursorPaginator(
-            queryset=queryset,
-            ordering=('-id',),
-            page_size=10,
-        )
-
-        page, prev_link, next_link = paginator.paginate(None)
-
-        self.assertEqual(len(page), 0)
-        self.assertIsNone(prev_link)
-        self.assertIsNone(next_link)
-
-    def test_paginate_single_page(self):
-        # Use only first 5 posts
-        queryset = BlogPost.objects.filter(id__in=[p.id for p in self.posts[:5]])
-        paginator = CursorPaginator(
-            queryset=queryset,
-            ordering=('-id',),
-            page_size=10,
-        )
-
-        page, prev_link, next_link = paginator.paginate(None)
-
-        self.assertEqual(len(page), 5)
-        self.assertIsNone(prev_link)
-        self.assertIsNone(next_link)
-
-    def test_paginate_exact_page_size(self):
-        # Use only first 10 posts
-        queryset = BlogPost.objects.filter(id__in=[p.id for p in self.posts[:10]])
-        paginator = CursorPaginator(
-            queryset=queryset,
-            ordering=('-id',),
-            page_size=10,
-        )
-
-        page, prev_link, next_link = paginator.paginate(None)
-
-        self.assertEqual(len(page), 10)
-        self.assertIsNone(prev_link)
-        self.assertIsNone(next_link)
-
-    def test_paginate_forward_navigation(self):
-        paginator = self._create_paginator()
-
-        # First page
-        page1, _, next_link1 = paginator.paginate(None)
-        self.assertEqual(len(page1), 10)
-        page1_ids = [p.id for p in page1]
-
-        # Second page
-        page2, prev_link2, next_link2 = paginator.paginate(next_link1)
-        self.assertEqual(len(page2), 10)
-        self.assertIsNotNone(prev_link2)
-        self.assertIsNotNone(next_link2)
-        page2_ids = [p.id for p in page2]
-
-        # Verify pages don't overlap
-        self.assertEqual(len(set(page1_ids) & set(page2_ids)), 0)
-
-        # Third page (last)
-        page3, prev_link3, next_link3 = paginator.paginate(next_link2)
-        self.assertEqual(len(page3), 5)
-        self.assertIsNotNone(prev_link3)
-        self.assertIsNone(next_link3)
-
-    def test_paginate_backward_navigation(self):
-        paginator = self._create_paginator()
-
-        # Navigate forward to page 2
-        _, _, next_link = paginator.paginate(None)
-        page2, prev_link2, _ = paginator.paginate(next_link)
-        page2_ids = [p.id for p in page2]
-
-        # Navigate back to page 1
-        page1_again, prev_link1, next_link1 = paginator.paginate(prev_link2)
-
-        self.assertIsNone(prev_link1)
-        self.assertIsNotNone(next_link1)
-        self.assertEqual(len(page1_again), 10)
-
-        page1_ids = [p.id for p in page1_again]
-        self.assertEqual(len(set(page1_ids) & set(page2_ids)), 0)
-
-    def test_paginate_ascending_order(self):
-        paginator = self._create_paginator(ordering=('id',))
-
-        page, prev_link, next_link = paginator.paginate(None)
-
-        self.assertEqual(len(page), 10)
-        self.assertEqual(page[0].id, min(p.id for p in page))
-        self.assertIsNone(prev_link)
-        self.assertIsNotNone(next_link)
-
-    def test_paginate_descending_order(self):
-        paginator = self._create_paginator(ordering=('-id',))
-
-        page, _, _ = paginator.paginate(None)
-
-        self.assertEqual(len(page), 10)
-        self.assertEqual(page[0].id, max(p.id for p in page))
-
-    def test_paginate_by_score_field(self):
-        paginator = self._create_paginator(ordering=('-score',))
-
-        page, _, _ = paginator.paginate(None)
-
-        scores = [p.score for p in page]
-        self.assertEqual(scores, sorted(scores, reverse=True))
-
-    def test_paginate_with_position_filter(self):
-        paginator = self._create_paginator()
-
-        page1, _, next_link = paginator.paginate(None)
-        page2, _, _ = paginator.paginate(next_link)
-
-        max_page2_id = max(p.id for p in page2)
-        min_page1_id = min(p.id for p in page1)
-        self.assertLess(max_page2_id, min_page1_id)
-
-    def test_paginate_different_page_sizes(self):
-        for page_size in [1, 5, 10, 20, 100]:
-            with self.subTest(page_size=page_size):
-                paginator = self._create_paginator(page_size=page_size)
-                page, _, _ = paginator.paginate(None)
-                self.assertLessEqual(len(page), page_size)
-
-
-class CursorPaginatorEdgeCasesTestCase(TestCase):
-    """Test edge cases and known bugs."""
-
-    @classmethod
-    def setUpTestData(cls):
-        now = timezone.now()
-        cls.posts = []
-        for i in range(15):
-            post = BlogPost.objects.create(
-                title=f'Edge Case Post {i}',
-                slug=f'edge-case-post-{i}',
-                publish_on=now,
-                content=f'Content {i}',
-                score=100,  # All same score for duplicate position test
-            )
-            cls.posts.append(post)
-
-    def test_duplicate_position_values(self):
-        """Test handling of items with same position value."""
-        queryset = BlogPost.objects.filter(id__in=[p.id for p in self.posts])
-        paginator = CursorPaginator(
-            queryset=queryset,
-            ordering=('-score',),
-            page_size=10,
-        )
-
-        page, _, next_link = paginator.paginate(None)
-
-        self.assertEqual(len(page), 10)
-        self.assertIsNotNone(next_link)
-
-    def test_get_position_from_dict_instance(self):
-        paginator = CursorPaginator(
-            queryset=MagicMock(),
-            ordering=('-id',),
-            page_size=10,
-        )
-
-        instance = {'id': 42, 'name': 'test'}
-        position = paginator._get_position_from_instance(instance, ('-id',))
-        self.assertEqual(position, '42')
-
-    def test_get_position_from_model_instance(self):
-        post = self.posts[0]
-
         paginator = CursorPaginator(
             queryset=BlogPost.objects.none(),
             ordering=('-id',),
             page_size=10,
         )
 
-        position = paginator._get_position_from_instance(post, ('-id',))
-        self.assertEqual(position, str(post.id))
+        page, prev_link, next_link = paginator.paginate(None)
 
+        self.assertEqual([], page)
+        self.assertIsNone(prev_link)
+        self.assertIsNone(next_link)
 
-class CursorPaginatorConsistencyTestCase(TestCase):
-    """Test that pagination is consistent across multiple traversals."""
-
-    @classmethod
-    def setUpTestData(cls):
-        now = timezone.now()
-        cls.posts = []
-        for i in range(50):
-            post = BlogPost.objects.create(
-                title=f'Consistency Post {i:03d}',
-                slug=f'consistency-post-{i:03d}',
-                publish_on=now,
-                content=f'Content {i}',
-                score=i % 10,
-            )
-            cls.posts.append(post)
-
-    def _create_paginator(self, ordering=('-id',), page_size=10):
-        queryset = BlogPost.objects.filter(id__in=[p.id for p in self.posts])
-        paginator = CursorPaginator(
-            queryset=queryset,
-            ordering=ordering,
-            page_size=page_size,
-        )
-        return paginator
-
-    def test_full_forward_traversal_covers_all_items(self):
-        """Verify that paginating forward covers all items exactly once."""
-        queryset = BlogPost.objects.filter(id__in=[p.id for p in self.posts])
-        expected_ids = set(queryset.values_list('id', flat=True))
-
+    def test_paginate_single_page(self):
+        queryset = BlogPost.objects.filter(id__in=[post.id for post in self.posts[:5]])
         paginator = CursorPaginator(
             queryset=queryset,
             ordering=('-id',),
-            page_size=7,
+            page_size=10,
         )
 
-        collected_ids = set()
-        cursor = None
+        page, prev_link, next_link = paginator.paginate(None)
 
-        while True:
-            page, _, next_link = paginator.paginate(cursor)
-            for item in page:
-                self.assertNotIn(item.id, collected_ids, 'Duplicate item found')
-                collected_ids.add(item.id)
+        self.assertEqual(5, len(page))
+        self.assertIsNone(prev_link)
+        self.assertIsNone(next_link)
 
-            if next_link is None:
-                break
-            cursor = next_link
+    def test_paginate_exact_page_size(self):
+        queryset = BlogPost.objects.filter(id__in=[post.id for post in self.posts[:10]])
+        paginator = CursorPaginator(
+            queryset=queryset,
+            ordering=('-id',),
+            page_size=10,
+        )
 
-        self.assertEqual(collected_ids, expected_ids)
+        page, prev_link, next_link = paginator.paginate(None)
 
-    def test_forward_and_backward_consistency(self):
-        """Test that going forward then backward returns to the same items."""
+        self.assertEqual(10, len(page))
+        self.assertIsNone(prev_link)
+        self.assertIsNone(next_link)
+
+    def test_full_forward_traversal_by_id(self):
+        expected_ids = list(self._queryset().order_by('-id').values_list('id', flat=True))
+
+        self.assertEqual(expected_ids, self._collect_forward_ids(ordering=('-id',), page_size=7))
+
+    def test_full_forward_traversal_with_duplicate_sort_key(self):
+        expected_ids = list(self._queryset().order_by('-score', '-id').values_list('id', flat=True))
+
+        self.assertEqual(expected_ids, self._collect_forward_ids(ordering=('-score', '-id'), page_size=7))
+
+    def test_paginate_backward_navigation(self):
         paginator = self._create_paginator()
 
         page1, _, next_link = paginator.paginate(None)
-        page1_ids = [p.id for p in page1]
+        page2, prev_link2, _ = paginator.paginate(next_link)
+        page1_again, prev_link1, next_link1 = paginator.paginate(prev_link2)
 
-        _, prev_link, _ = paginator.paginate(next_link)
+        self.assertEqual([post.id for post in page1], [post.id for post in page1_again])
+        self.assertNotEqual([post.id for post in page1], [post.id for post in page2])
+        self.assertIsNone(prev_link1)
+        self.assertIsNotNone(next_link1)
 
-        page1_again, _, _ = paginator.paginate(prev_link)
-        page1_again_ids = [p.id for p in page1_again]
+    def test_paginate_backward_navigation_with_duplicate_sort_key(self):
+        paginator = self._create_paginator(ordering=('-score', '-id'), page_size=7)
 
-        self.assertEqual(page1_ids, page1_again_ids)
+        page1, _, next_link = paginator.paginate(None)
+        page2, prev_link2, _ = paginator.paginate(next_link)
+        page1_again, prev_link1, next_link1 = paginator.paginate(prev_link2)
+
+        self.assertEqual([post.id for post in page1], [post.id for post in page1_again])
+        self.assertNotEqual([post.id for post in page1], [post.id for post in page2])
+        self.assertIsNone(prev_link1)
+        self.assertIsNotNone(next_link1)
+
+    def test_paginate_ascending_order(self):
+        paginator = self._create_paginator(ordering=('id',))
+        page, prev_link, next_link = paginator.paginate(None)
+
+        self.assertEqual([post.id for post in page], sorted(post.id for post in page))
+        self.assertIsNone(prev_link)
+        self.assertIsNotNone(next_link)
 
     def test_all_pages_forward_then_backward(self):
-        """Test traversing all pages forward then all backward."""
-        paginator = self._create_paginator()
-
+        paginator = self._create_paginator(ordering=('-score', '-id'), page_size=6)
         forward_pages = []
         cursor = None
         last_prev_link = None
+
         while True:
             page, prev_link, next_link = paginator.paginate(cursor)
-            forward_pages.append([p.id for p in page])
+            forward_pages.append([post.id for post in page])
 
             if next_link is None:
                 last_prev_link = prev_link
@@ -455,7 +291,7 @@ class CursorPaginatorConsistencyTestCase(TestCase):
         cursor = last_prev_link
         while cursor is not None:
             page, prev_link, _ = paginator.paginate(cursor)
-            backward_pages.append([p.id for p in page])
+            backward_pages.append([post.id for post in page])
             cursor = prev_link
 
         backward_pages.reverse()

--- a/judge/utils/tests/test_cursor_paginator.py
+++ b/judge/utils/tests/test_cursor_paginator.py
@@ -4,7 +4,7 @@ from django.core import signing
 from django.core.exceptions import BadRequest
 from django.test import SimpleTestCase
 
-from judge.models import BlogPost
+from judge.models import BlogPost, BlogPostTag
 from judge.utils.cursor_paginator import (
     CURSOR_VERSION,
     Cursor,
@@ -91,6 +91,16 @@ class CursorPaginatorEncodingTestCase(SimpleTestCase):
         with self.assertRaises(ValueError):
             self.paginator.encode_cursor(Cursor(reverse=False, position=(None,)))
 
+    def test_encode_short_position_rejected(self):
+        paginator = CursorPaginator(model=BlogPost, ordering=('-score', '-id'))
+
+        with self.assertRaises(ValueError):
+            paginator.encode_cursor(Cursor(reverse=False, position=(123,)))
+
+    def test_encode_long_position_rejected(self):
+        with self.assertRaises(ValueError):
+            self.paginator.encode_cursor(Cursor(reverse=False, position=(123, 456)))
+
     def test_decode_coerces_value_to_model_field_type(self):
         cursor = self.paginator.decode_cursor(
             signing.dumps({'v': CURSOR_VERSION, 'r': False, 'p': ['123']}, salt=DEFAULT_CURSOR_SALT),
@@ -135,3 +145,14 @@ class CursorPaginatorValidationTestCase(SimpleTestCase):
     def test_nullable_model_field_ordering_rejected(self):
         with self.assertRaises(ValueError):
             CursorPaginator(BlogPost, ('organization', 'id'))
+
+    def test_non_unique_tie_breaker_rejected(self):
+        # BlogPost.score is not unique, so it cannot identify a single row.
+        with self.assertRaises(ValueError):
+            CursorPaginator(BlogPost, ('score',), unique_field='score')
+
+    def test_unique_non_pk_tie_breaker_allowed(self):
+        # BlogPostTag.slug carries unique=True, so it is a valid tie-breaker.
+        paginator = CursorPaginator(BlogPostTag, ('slug',), unique_field='slug')
+
+        self.assertEqual(('slug',), paginator.ordering)

--- a/judge/utils/tests/test_cursor_paginator.py
+++ b/judge/utils/tests/test_cursor_paginator.py
@@ -2,8 +2,7 @@ from dataclasses import FrozenInstanceError
 
 from django.core import signing
 from django.core.exceptions import BadRequest
-from django.test import SimpleTestCase, TestCase
-from django.utils import timezone
+from django.test import SimpleTestCase
 
 from judge.models import BlogPost
 from judge.utils.cursor_paginator import (
@@ -11,25 +10,7 @@ from judge.utils.cursor_paginator import (
     Cursor,
     CursorPaginator,
     DEFAULT_CURSOR_SALT,
-    _reverse_ordering,
 )
-
-
-class ReverseOrderingTestCase(SimpleTestCase):
-    def test_reverse_ascending(self):
-        self.assertEqual(_reverse_ordering(('created',)), ('-created',))
-
-    def test_reverse_descending(self):
-        self.assertEqual(_reverse_ordering(('-created',)), ('created',))
-
-    def test_reverse_multiple_fields(self):
-        self.assertEqual(
-            _reverse_ordering(('-created', 'uuid')),
-            ('created', '-uuid'),
-        )
-
-    def test_reverse_empty_tuple(self):
-        self.assertEqual(_reverse_ordering(()), ())
 
 
 class CursorTestCase(SimpleTestCase):
@@ -47,9 +28,8 @@ class CursorTestCase(SimpleTestCase):
 class CursorPaginatorEncodingTestCase(SimpleTestCase):
     def setUp(self):
         self.paginator = CursorPaginator(
-            queryset=BlogPost.objects.none(),
+            model=BlogPost,
             ordering=('-id',),
-            page_size=10,
         )
 
     def test_decode_none_returns_none(self):
@@ -75,6 +55,13 @@ class CursorPaginatorEncodingTestCase(SimpleTestCase):
 
         with self.assertRaises(BadRequest):
             self.paginator.decode_cursor(tampered)
+
+    def test_decode_wrong_salt_raises_bad_request(self):
+        encoded = self.paginator.encode_cursor(Cursor(reverse=False, position=(123,)))
+        other = CursorPaginator(model=BlogPost, ordering=('-id',), cursor_salt='some.other.salt')
+
+        with self.assertRaises(BadRequest):
+            other.decode_cursor(encoded)
 
     def test_decode_wrong_version_raises_bad_request(self):
         token = signing.dumps({'v': CURSOR_VERSION + 1, 'r': False, 'p': [123]}, salt=DEFAULT_CURSOR_SALT)
@@ -104,195 +91,47 @@ class CursorPaginatorEncodingTestCase(SimpleTestCase):
         with self.assertRaises(ValueError):
             self.paginator.encode_cursor(Cursor(reverse=False, position=(None,)))
 
+    def test_decode_coerces_value_to_model_field_type(self):
+        cursor = self.paginator.decode_cursor(
+            signing.dumps({'v': CURSOR_VERSION, 'r': False, 'p': ['123']}, salt=DEFAULT_CURSOR_SALT),
+        )
+
+        self.assertEqual((123,), cursor.position)
+
+    def test_composite_position_roundtrip(self):
+        paginator = CursorPaginator(model=BlogPost, ordering=('-score', '-id'))
+        cursor = Cursor(reverse=False, position=(7, 123))
+
+        self.assertEqual(cursor, paginator.decode_cursor(paginator.encode_cursor(cursor)))
+
 
 class CursorPaginatorValidationTestCase(SimpleTestCase):
     def test_empty_ordering_rejected(self):
         with self.assertRaises(ValueError):
-            CursorPaginator(BlogPost.objects.none(), (), 10)
-
-    def test_non_positive_page_size_rejected(self):
-        with self.assertRaises(ValueError):
-            CursorPaginator(BlogPost.objects.none(), ('-id',), 0)
+            CursorPaginator(BlogPost, ())
 
     def test_non_unique_single_field_ordering_rejected(self):
         with self.assertRaises(ValueError):
-            CursorPaginator(BlogPost.objects.none(), ('-score',), 10)
+            CursorPaginator(BlogPost, ('-score',))
 
     def test_non_unique_ordering_requires_unique_tie_breaker(self):
         with self.assertRaises(ValueError):
-            CursorPaginator(BlogPost.objects.none(), ('-score', '-publish_on'), 10)
+            CursorPaginator(BlogPost, ('-score', '-publish_on'))
 
     def test_unique_single_field_ordering_allowed(self):
-        paginator = CursorPaginator(BlogPost.objects.none(), ('-id',), 10)
+        paginator = CursorPaginator(BlogPost, ('-id',))
 
         self.assertEqual(('-id',), paginator.ordering)
 
     def test_composite_ordering_with_tie_breaker_allowed(self):
-        paginator = CursorPaginator(BlogPost.objects.none(), ('-score', '-id'), 10)
+        paginator = CursorPaginator(BlogPost, ('-score', '-id'))
 
         self.assertEqual(('-score', '-id'), paginator.ordering)
 
     def test_related_ordering_rejected(self):
         with self.assertRaises(ValueError):
-            CursorPaginator(BlogPost.objects.none(), ('authors__id', 'id'), 10)
+            CursorPaginator(BlogPost, ('authors__id', 'id'))
 
     def test_nullable_model_field_ordering_rejected(self):
         with self.assertRaises(ValueError):
-            CursorPaginator(BlogPost.objects.none(), ('organization', 'id'), 10)
-
-
-class CursorPaginatorWithBlogPostTestCase(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        now = timezone.now()
-        cls.posts = []
-        for i in range(25):
-            post = BlogPost.objects.create(
-                title=f'Test Post {i:03d}',
-                slug=f'test-post-{i:03d}',
-                publish_on=now,
-                content=f'Content {i}',
-                score=i % 5,
-            )
-            cls.posts.append(post)
-
-    def _queryset(self):
-        return BlogPost.objects.filter(id__in=[post.id for post in self.posts])
-
-    def _create_paginator(self, ordering=('-id',), page_size=10):
-        return CursorPaginator(
-            queryset=self._queryset(),
-            ordering=ordering,
-            page_size=page_size,
-        )
-
-    def _collect_forward_ids(self, ordering=('-id',), page_size=10):
-        paginator = self._create_paginator(ordering=ordering, page_size=page_size)
-        cursor = None
-        result = []
-
-        while True:
-            page, _, next_link = paginator.paginate(cursor)
-            result.extend(post.id for post in page)
-
-            if next_link is None:
-                break
-            cursor = next_link
-
-        return result
-
-    def test_paginate_first_page(self):
-        paginator = self._create_paginator()
-        page, prev_link, next_link = paginator.paginate(None)
-
-        self.assertEqual(10, len(page))
-        self.assertIsNone(prev_link)
-        self.assertIsNotNone(next_link)
-
-    def test_paginate_empty_queryset(self):
-        paginator = CursorPaginator(
-            queryset=BlogPost.objects.none(),
-            ordering=('-id',),
-            page_size=10,
-        )
-
-        page, prev_link, next_link = paginator.paginate(None)
-
-        self.assertEqual([], page)
-        self.assertIsNone(prev_link)
-        self.assertIsNone(next_link)
-
-    def test_paginate_single_page(self):
-        queryset = BlogPost.objects.filter(id__in=[post.id for post in self.posts[:5]])
-        paginator = CursorPaginator(
-            queryset=queryset,
-            ordering=('-id',),
-            page_size=10,
-        )
-
-        page, prev_link, next_link = paginator.paginate(None)
-
-        self.assertEqual(5, len(page))
-        self.assertIsNone(prev_link)
-        self.assertIsNone(next_link)
-
-    def test_paginate_exact_page_size(self):
-        queryset = BlogPost.objects.filter(id__in=[post.id for post in self.posts[:10]])
-        paginator = CursorPaginator(
-            queryset=queryset,
-            ordering=('-id',),
-            page_size=10,
-        )
-
-        page, prev_link, next_link = paginator.paginate(None)
-
-        self.assertEqual(10, len(page))
-        self.assertIsNone(prev_link)
-        self.assertIsNone(next_link)
-
-    def test_full_forward_traversal_by_id(self):
-        expected_ids = list(self._queryset().order_by('-id').values_list('id', flat=True))
-
-        self.assertEqual(expected_ids, self._collect_forward_ids(ordering=('-id',), page_size=7))
-
-    def test_full_forward_traversal_with_duplicate_sort_key(self):
-        expected_ids = list(self._queryset().order_by('-score', '-id').values_list('id', flat=True))
-
-        self.assertEqual(expected_ids, self._collect_forward_ids(ordering=('-score', '-id'), page_size=7))
-
-    def test_paginate_backward_navigation(self):
-        paginator = self._create_paginator()
-
-        page1, _, next_link = paginator.paginate(None)
-        page2, prev_link2, _ = paginator.paginate(next_link)
-        page1_again, prev_link1, next_link1 = paginator.paginate(prev_link2)
-
-        self.assertEqual([post.id for post in page1], [post.id for post in page1_again])
-        self.assertNotEqual([post.id for post in page1], [post.id for post in page2])
-        self.assertIsNone(prev_link1)
-        self.assertIsNotNone(next_link1)
-
-    def test_paginate_backward_navigation_with_duplicate_sort_key(self):
-        paginator = self._create_paginator(ordering=('-score', '-id'), page_size=7)
-
-        page1, _, next_link = paginator.paginate(None)
-        page2, prev_link2, _ = paginator.paginate(next_link)
-        page1_again, prev_link1, next_link1 = paginator.paginate(prev_link2)
-
-        self.assertEqual([post.id for post in page1], [post.id for post in page1_again])
-        self.assertNotEqual([post.id for post in page1], [post.id for post in page2])
-        self.assertIsNone(prev_link1)
-        self.assertIsNotNone(next_link1)
-
-    def test_paginate_ascending_order(self):
-        paginator = self._create_paginator(ordering=('id',))
-        page, prev_link, next_link = paginator.paginate(None)
-
-        self.assertEqual([post.id for post in page], sorted(post.id for post in page))
-        self.assertIsNone(prev_link)
-        self.assertIsNotNone(next_link)
-
-    def test_all_pages_forward_then_backward(self):
-        paginator = self._create_paginator(ordering=('-score', '-id'), page_size=6)
-        forward_pages = []
-        cursor = None
-        last_prev_link = None
-
-        while True:
-            page, prev_link, next_link = paginator.paginate(cursor)
-            forward_pages.append([post.id for post in page])
-
-            if next_link is None:
-                last_prev_link = prev_link
-                break
-            cursor = next_link
-
-        backward_pages = []
-        cursor = last_prev_link
-        while cursor is not None:
-            page, prev_link, _ = paginator.paginate(cursor)
-            backward_pages.append([post.id for post in page])
-            cursor = prev_link
-
-        backward_pages.reverse()
-        self.assertEqual(forward_pages[:-1], backward_pages)
+            CursorPaginator(BlogPost, ('organization', 'id'))

--- a/judge/utils/tests/test_cursor_paginator.py
+++ b/judge/utils/tests/test_cursor_paginator.py
@@ -2,6 +2,7 @@ from dataclasses import FrozenInstanceError
 
 from django.core import signing
 from django.core.exceptions import BadRequest
+from django.db.models import Q
 from django.test import SimpleTestCase
 
 from judge.models import BlogPost, BlogPostTag
@@ -10,7 +11,35 @@ from judge.utils.cursor_paginator import (
     Cursor,
     CursorPaginator,
     DEFAULT_CURSOR_SALT,
+    _reverse_ordering,
+    _seek_filter,
 )
+
+
+class ReverseOrderingTestCase(SimpleTestCase):
+    def test_reverse_ascending(self):
+        self.assertEqual(('-created',), _reverse_ordering(('created',)))
+
+    def test_reverse_descending(self):
+        self.assertEqual(('created',), _reverse_ordering(('-created',)))
+
+    def test_reverse_multiple_fields(self):
+        self.assertEqual(('created', '-uuid'), _reverse_ordering(('-created', 'uuid')))
+
+
+class SeekFilterTestCase(SimpleTestCase):
+    def test_descending_single_field(self):
+        self.assertEqual(Q(id__lt=10), _seek_filter(('-id',), (10,)))
+
+    def test_ascending_single_field(self):
+        self.assertEqual(Q(id__gt=10), _seek_filter(('id',), (10,)))
+
+    def test_composite_ordering_is_lexicographic(self):
+        # score < 7 OR (score = 7 AND id < 10)
+        self.assertEqual(
+            Q(score__lt=7) | (Q(score=7) & Q(id__lt=10)),
+            _seek_filter(('-score', '-id'), (7, 10)),
+        )
 
 
 class CursorTestCase(SimpleTestCase):

--- a/judge/utils/tests/test_cursor_paginator.py
+++ b/judge/utils/tests/test_cursor_paginator.py
@@ -1,14 +1,15 @@
 from dataclasses import FrozenInstanceError
 
 from django.core import signing
-from django.core.exceptions import BadRequest
+from django.core.exceptions import BadRequest, ImproperlyConfigured
 from django.db.models import Q
-from django.test import SimpleTestCase
+from django.test import RequestFactory, SimpleTestCase
 
 from judge.models import BlogPost, BlogPostTag
 from judge.utils.cursor_paginator import (
     CURSOR_VERSION,
     Cursor,
+    CursorPaginationMixin,
     CursorPaginator,
     DEFAULT_CURSOR_SALT,
     _reverse_ordering,
@@ -185,3 +186,29 @@ class CursorPaginatorValidationTestCase(SimpleTestCase):
         paginator = CursorPaginator(BlogPostTag, ('slug',), unique_field='slug')
 
         self.assertEqual(('slug',), paginator.ordering)
+
+
+class CursorPaginationMixinTestCase(SimpleTestCase):
+    class _View(CursorPaginationMixin):
+        cursor_ordering = ('-id',)
+
+        def __init__(self, request):
+            self.request = request
+
+    def _view(self):
+        return self._View(RequestFactory().get('/'))
+
+    def test_ordering_mismatch_is_rejected(self):
+        # Seeking against an ordering the cursor was not minted for would silently
+        # re-sort the page, so it must fail loudly instead.
+        with self.assertRaises(ImproperlyConfigured):
+            self._view().paginate_queryset(BlogPost.objects.order_by('-score'), 10)
+
+    def test_matching_ordering_is_accepted(self):
+        # Reaches the database, so only assert that the guard let it through.
+        try:
+            self._view().paginate_queryset(BlogPost.objects.order_by('-id'), 10)
+        except ImproperlyConfigured:
+            self.fail('guard rejected an ordering that matches cursor_ordering')
+        except Exception:
+            pass

--- a/judge/utils/tests/test_cursor_paginator.py
+++ b/judge/utils/tests/test_cursor_paginator.py
@@ -8,9 +8,9 @@ from django.utils import timezone
 from judge.models import BlogPost
 from judge.utils.cursor_paginator import (
     CURSOR_VERSION,
-    DEFAULT_CURSOR_SALT,
     Cursor,
     CursorPaginator,
+    DEFAULT_CURSOR_SALT,
     _reverse_ordering,
 )
 

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -28,6 +28,7 @@ from judge.models import BlogPost, Comment, Contest, Language, Organization, Org
 from judge.models.profile import OrganizationMonthlyUsage, OrganizationQuota
 from judge.tasks import on_new_problem
 from judge.utils.cache_helper import storage_pie_cache_factory
+from judge.utils.cursor_paginator import CursorPaginationMixin
 from judge.utils.infinite_paginator import InfinitePaginationMixin
 from judge.utils.organization import add_admin_to_group, add_quota_context
 from judge.utils.ranker import ranker
@@ -748,7 +749,9 @@ class ContestListOrganization(PrivateOrganizationMixin, ContestList):
         return context
 
 
-class SubmissionListOrganization(InfinitePaginationMixin, PrivateOrganizationMixin, SubmissionsListBase):
+class SubmissionListOrganization(CursorPaginationMixin, PrivateOrganizationMixin, SubmissionsListBase):
+    cursor_salt = 'judge.organization_submissions.cursor'
+
     template_name = 'organization/submission-list.html'
     permission_bypass = ['judge.view_all_submission']
 

--- a/judge/views/ranked_submission.py
+++ b/judge/views/ranked_submission.py
@@ -4,6 +4,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 
 from judge.models import Language, Submission
+from judge.utils.infinite_paginator import InfinitePaginationMixin
 from judge.utils.problems import get_result_data
 from judge.utils.raw_sql import join_sql_subquery
 from judge.views.submission import ForceContestMixin, ProblemSubmissions
@@ -11,7 +12,9 @@ from judge.views.submission import ForceContestMixin, ProblemSubmissions
 __all__ = ['RankedSubmissions', 'ContestRankedSubmission']
 
 
-class RankedSubmissions(ProblemSubmissions):
+# Ranked by points rather than id, which is not a unique ordering, so this keeps
+# the OFFSET paginator instead of inheriting ProblemSubmissions' cursor one.
+class RankedSubmissions(InfinitePaginationMixin, ProblemSubmissions):
     tab = 'best_submissions_list'
     dynamic_update = False
 

--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -655,7 +655,9 @@ class ProblemSubmissionsBase(SubmissionsListBase):
         return context
 
 
-class ProblemSubmissions(InfinitePaginationMixin, ProblemSubmissionsBase):
+class ProblemSubmissions(CursorPaginationMixin, ProblemSubmissionsBase):
+    cursor_salt = 'judge.problem_submissions.cursor'
+
     def get_my_submissions_page(self):
         if self.request.user.is_authenticated:
             if hasattr(self, 'contest'):

--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -26,6 +26,7 @@ from django.views.generic import DetailView, ListView
 from judge.highlight_code import highlight_code
 from judge.models import Contest, Language, Organization, Problem, ProblemTranslation, Profile, Submission
 from judge.models.problem import ProblemTestcaseResultAccess, SubmissionSourceAccess
+from judge.utils.cursor_paginator import CursorPaginationMixin
 from judge.utils.infinite_paginator import InfinitePaginationMixin
 from judge.utils.lazy import memo_lazy
 from judge.utils.problem_data import get_problem_testcases_data
@@ -553,7 +554,11 @@ class ConditionalUserTabMixin(object):
         return context
 
 
-class AllUserSubmissions(InfinitePaginationMixin, ConditionalUserTabMixin, UserMixin, SubmissionsListBase):
+class AllUserSubmissions(CursorPaginationMixin, ConditionalUserTabMixin, UserMixin, SubmissionsListBase):
+    # Submissions are listed newest-first by id, which is unique, so this list seeks
+    # instead of counting past every earlier page.
+    cursor_salt = 'judge.all_user_submissions.cursor'
+
     def get_queryset(self):
         return super(AllUserSubmissions, self).get_queryset().filter(user_id=self.profile.id)
 

--- a/judge/views/tests/test_submission.py
+++ b/judge/views/tests/test_submission.py
@@ -1,7 +1,10 @@
 from unittest.mock import PropertyMock
+from urllib.parse import parse_qs, urlparse
 
+from django.core.exceptions import BadRequest
 from django.http import Http404
 from django.test import RequestFactory, TestCase
+from django.urls import reverse
 from django.utils import timezone
 
 from judge.models import Contest, Language, Submission
@@ -869,6 +872,8 @@ class AllUserSubmissionsTestCase(CommonDataMixin, TestCase):
             language=Language.get_python3(),
             result='AC',
             status='D',
+            time=0.1,
+            memory=1024,
         )
 
         cls.sub_other = Submission.objects.create(
@@ -877,12 +882,14 @@ class AllUserSubmissionsTestCase(CommonDataMixin, TestCase):
             language=Language.get_python3(),
             result='WA',
             status='D',
+            time=0.1,
+            memory=1024,
         )
 
-    def _create_view_instance(self, request_user, target_user):
+    def _create_view_instance(self, request_user, target_user, data=None):
         """Helper to create AllUserSubmissions view instance."""
         factory = RequestFactory()
-        request = factory.get(f'/user/{target_user.username}/submissions/')
+        request = factory.get(f'/submissions/user/{target_user.username}/', data=data or {})
         request.user = request_user
         request.profile = request_user.profile if hasattr(request_user, 'profile') else None
         request.LANGUAGE_CODE = 'en'
@@ -897,6 +904,131 @@ class AllUserSubmissionsTestCase(CommonDataMixin, TestCase):
         view.selected_organization = None
 
         return view
+
+    # --- cursor pagination -------------------------------------------------
+
+    def _make_submissions(self, count):
+        return [
+            Submission.objects.create(
+                user=self.users['normal'].profile,
+                problem=self.public_problem,
+                language=Language.get_python3(),
+                result='AC',
+                status='D',
+                time=0.1,
+                memory=1024,
+            )
+            for _ in range(count)
+        ]
+
+    def _page(self, cursor=None, page_size=5):
+        data = {'cursor': cursor} if cursor else None
+        view = self._create_view_instance(
+            request_user=self.users['normal'],
+            target_user=self.users['normal'],
+            data=data,
+        )
+        _, page, _, _ = view.paginate_queryset(view.get_queryset(), page_size)
+        return page
+
+    @staticmethod
+    def _cursor_of(href):
+        return parse_qs(urlparse(href).query)['cursor'][0]
+
+    def test_cursor_first_page_is_newest_first_and_has_no_previous(self):
+        self._make_submissions(12)
+        page = self._page()
+        ids = [submission.id for submission in page.object_list]
+
+        self.assertEqual(5, len(ids))
+        self.assertEqual(sorted(ids, reverse=True), ids)
+        self.assertFalse(page.has_previous())
+        self.assertIsNone(page.previous_href)
+        self.assertTrue(page.has_next())
+
+    def test_cursor_walks_forward_then_back_to_the_same_page(self):
+        self._make_submissions(12)
+
+        page1 = self._page()
+        ids1 = [submission.id for submission in page1.object_list]
+
+        page2 = self._page(self._cursor_of(page1.next_href))
+        ids2 = [submission.id for submission in page2.object_list]
+
+        self.assertEqual(5, len(ids2))
+        self.assertEqual([], list(set(ids1) & set(ids2)))
+        self.assertLess(max(ids2), min(ids1))
+        self.assertTrue(page2.has_previous())
+
+        page1_again = self._page(self._cursor_of(page2.previous_href))
+        self.assertEqual(ids1, [submission.id for submission in page1_again.object_list])
+        self.assertFalse(page1_again.has_previous())
+
+    def test_cursor_last_page_has_no_next(self):
+        self._make_submissions(7)   # 2 existing + 7 = 9 -> two pages of 5
+
+        page2 = self._page(self._cursor_of(self._page().next_href))
+
+        self.assertFalse(page2.has_next())
+        self.assertIsNone(page2.next_href)
+        self.assertTrue(page2.has_previous())
+
+    def test_cursor_pagination_visits_every_row_exactly_once(self):
+        self._make_submissions(12)
+
+        seen, cursor = [], None
+        while True:
+            page = self._page(cursor)
+            seen.extend(submission.id for submission in page.object_list)
+            if not page.has_next():
+                break
+            cursor = self._cursor_of(page.next_href)
+
+        expected = list(
+            Submission.objects.filter(user=self.users['normal'].profile)
+            .order_by('-id').values_list('id', flat=True),
+        )
+        self.assertEqual(expected, seen)
+
+    def test_cursor_links_preserve_other_query_parameters(self):
+        self._make_submissions(12)
+        view = self._create_view_instance(
+            request_user=self.users['normal'],
+            target_user=self.users['normal'],
+            data={'language': 'PY3'},
+        )
+        _, page, _, _ = view.paginate_queryset(view.get_queryset(), 5)
+
+        self.assertEqual(['PY3'], parse_qs(urlparse(page.next_href).query)['language'])
+
+    def test_invalid_cursor_is_rejected(self):
+        self._make_submissions(12)
+
+        with self.assertRaises(BadRequest):
+            self._page('not-a-signed-cursor')
+
+    def test_cursor_page_renders_with_working_pagination_links(self):
+        self._make_submissions(60)   # 2 existing + 60, so paginate_by=50 gives two pages
+
+        response = self.client.get(reverse('all_user_submissions', kwargs={'user': 'normal'}))
+        self.assertEqual(200, response.status_code)
+
+        html = response.content.decode()
+        self.assertIn('cursor=', html)
+
+        # The rendered "next" link must itself be fetchable.
+        next_href = html.split('rel="next"')[0].rsplit('href="', 1)[1].split('"')[0]
+        follow_up = self.client.get(next_href.replace('&amp;', '&'))
+        self.assertEqual(200, follow_up.status_code)
+
+    def test_numbered_page_url_redirects_to_the_first_page(self):
+        response = self.client.get('/submissions/user/normal/3')
+
+        self.assertEqual(301, response.status_code)
+        self.assertEqual(
+            reverse('all_user_submissions', kwargs={'user': 'normal'}),
+            response['Location'],
+        )
 
     def test_filters_by_user(self):
         """Test that only target user's submissions are returned."""

--- a/judge/views/tests/test_submission.py
+++ b/judge/views/tests/test_submission.py
@@ -17,6 +17,8 @@ from judge.models.tests.util import (
     create_problem,
     create_user,
 )
+from judge.utils.infinite_paginator import InfinitePaginationMixin
+from judge.views.ranked_submission import RankedSubmissions
 from judge.views.submission import (
     AllContestSubmissions,
     AllSubmissions,
@@ -1020,6 +1022,14 @@ class AllUserSubmissionsTestCase(CommonDataMixin, TestCase):
         next_href = html.split('rel="next"')[0].rsplit('href="', 1)[1].split('"')[0]
         follow_up = self.client.get(next_href.replace('&amp;', '&'))
         self.assertEqual(200, follow_up.status_code)
+
+    def test_ranked_submissions_keep_offset_pagination(self):
+        # RankedSubmissions sorts by points, which is not unique, so it must not
+        # inherit cursor pagination from ProblemSubmissions.
+        self.assertIs(
+            InfinitePaginationMixin.paginate_queryset,
+            RankedSubmissions.paginate_queryset,
+        )
 
     def test_numbered_page_url_redirects_to_the_first_page(self):
         response = self.client.get('/submissions/user/normal/3')

--- a/templates/list-pages.html
+++ b/templates/list-pages.html
@@ -1,31 +1,48 @@
 <ul class="pagination">
-    {% if page_obj.has_previous() %}
-        {% if page_obj.previous_page_number() == 1 and first_page_href != None %}
-            <li><a href="{{ first_page_href }}">«</a></li>
+    {% if page_obj.is_cursor|default(false) %}
+        {# Cursor pagination knows only its neighbours, so there are no page numbers. #}
+        {% if page_obj.has_previous() %}
+            <li><a href="{{ page_obj.previous_href }}" rel="prev">«</a></li>
         {% else %}
-            <li><a href="{{ page_prefix or '' }}{{ page_obj.previous_page_number() }}{{ page_suffix or '' }}">«</a></li>
+            <li class="disabled-page"><span>«</span></li>
+        {% endif %}
+
+        {% if page_obj.has_next() %}
+            <li><a href="{{ page_obj.next_href }}" rel="next">»</a></li>
+        {% else %}
+            <li class="disabled-page"><span>»</span></li>
         {% endif %}
     {% else %}
-        <li class="disabled-page"><span>«</span></li>
-    {% endif %}
-
-    {% for page in page_obj.page_range %}
-        {% if not page %}
-            <li class="disabled-page"><span>...</span></li>
+        {% if page_obj.has_previous() %}
+            {% if page_obj.previous_page_number() == 1 and first_page_href != None %}
+                <li><a href="{{ first_page_href }}">«</a></li>
+            {% else %}
+                <li>
+                    <a href="{{ page_prefix or '' }}{{ page_obj.previous_page_number() }}{{ page_suffix or '' }}">«</a>
+                </li>
+            {% endif %}
         {% else %}
-            <li{% if page == page_obj.number %} class="active-page"{% endif %}><a href="
-                {%- if page == 1 and first_page_href != None -%}
-                    {{ first_page_href }}
-                {%- else -%}
-                    {{ page_prefix or '' }}{{ page }}{{ page_suffix or '' }}
-                {%- endif -%}
-            ">{{ page }}</a></li>
+            <li class="disabled-page"><span>«</span></li>
         {% endif %}
-    {% endfor %}
 
-    {% if page_obj.has_next() %}
-        <li><a href="{{ page_prefix or '' }}{{ page_obj.next_page_number() }}{{ page_suffix or '' }}">»</a></li>
-    {% else %}
-        <li class="disabled-page"><span>»</span></li>
+        {% for page in page_obj.page_range %}
+            {% if not page %}
+                <li class="disabled-page"><span>...</span></li>
+            {% else %}
+                <li{% if page == page_obj.number %} class="active-page"{% endif %}><a href="
+                    {%- if page == 1 and first_page_href != None -%}
+                        {{ first_page_href }}
+                    {%- else -%}
+                        {{ page_prefix or '' }}{{ page }}{{ page_suffix or '' }}
+                    {%- endif -%}
+                ">{{ page }}</a></li>
+            {% endif %}
+        {% endfor %}
+
+        {% if page_obj.has_next() %}
+            <li><a href="{{ page_prefix or '' }}{{ page_obj.next_page_number() }}{{ page_suffix or '' }}">»</a></li>
+        {% else %}
+            <li class="disabled-page"><span>»</span></li>
+        {% endif %}
     {% endif %}
 </ul>


### PR DESCRIPTION
Extracts the cursor paginator from #668 ("WIP Submission v2"), then applies it to the submission lists that #668 does *not* rewrite.

## Why split it out

#668 bundles two independent pieces: a generic cursor primitive, and a rewrite of the global All Submissions view. The second has open product questions — it drops `/submissions/<N>`, makes pagination JS-only, and does not honour `VNOJ_LOW_POWER_MODE`. The primitive does not, and neither do the other submission lists, which suffer the same problem and nobody is arguing about.

`ec20c51d7` and `6c38b0627` are cherry-picked verbatim from #668, authorship preserved. Everything after is new.

## What changes

`judge/utils/cursor_paginator.py` gains a `CursorPaginationMixin`, and these lists adopt it:

| View | URL |
|---|---|
| `AllUserSubmissions` | `/submissions/user/<name>/` |
| `ProblemSubmissions` | `/problem/<code>/submissions/` |
| `UserProblemSubmissions` | `/problem/<code>/submissions/<name>/` |
| `UserAllContestSubmissions`, `UserContestSubmissions` | contest-scoped equivalents |
| `SubmissionListOrganization` | organization submission list |

**`AllSubmissions` and `AllContestSubmissions` are deliberately untouched** — #668 rewrites those, and changing them here would conflict.

Pagination links are ordinary URLs carrying a `cursor` parameter, so pages stay shareable, the back button works, and the lists still work without JavaScript. Numbered URLs have no cursor equivalent, so `/2` now **redirects to the first page** rather than 404ing or silently rendering something else.

## Does it help?

Measured on a 12.3M-row `judge_submission` copy. Against `vjudge1` (130 730 submissions, 2 614 pages), timing the real view code:

| page | old (2 queries) | new (1 query) | speedup |
|---|---|---|---|
| 1 | 7.6 ms | 5.6 ms | 1.4× |
| 10 | 9.5 ms | 5.8 ms | 1.6× |
| 100 | 17 256 ms | 7.0 ms | 2468× |
| 1 000 | 17 379 ms | 5.9 ms | 2955× |

Between page 10 and page 100 the optimizer flips to a plan with a fixed ~8.7 s cost, and it hits *both* the page query and the has-next probe, hence ~17.3 s per page from there on. I did not isolate which plan; the point is that it is a cliff, not a gentle slope. Seek stays flat at ~6 ms because it never looks at rows before the cursor.

Isolating just the pagination strategy on the global list (same query, same visibility logic, only the page-location method varies) gives a cleaner picture of the mechanism:

| page | OFFSET total | seek | speedup |
|---|---|---|---|
| 1 | 85.4 ms | 45.8 ms | 1.9× |
| 1 000 | 1.46 s | 46.4 ms | 31.5× |
| 100 000 | 95.57 s | 49.1 ms | 1947× |

`EXPLAIN` shows the plans are identical except that `judge_submission` moves from `index` (full PK scan) to `range` (bounded).

Page 1 improves as well, by deleting a query rather than speeding one up: `InfinitePage._after_up_to_pad` runs a second, deeper probe purely to decide `has_next` and how many page links to draw. Seek gets that free from `LIMIT page_size + 1`.

## Two traps worth reviewing closely

**`RankedSubmissions` subclasses `ProblemSubmissions` but re-sorts by `(-points, time)`**, which is not a unique ordering. Inheriting cursor pagination would have silently re-sorted that page by id. It keeps the OFFSET paginator, and `CursorPaginationMixin` now raises `ImproperlyConfigured` when the queryset's ordering disagrees with `cursor_ordering` instead of overwriting it.

**`UserAllContestSubmissions` inherits from `AllUserSubmissions`**, so it became cursor-paginated the moment its parent did, while its route still registered `<int:page>` — `/2` rendered page 1 without saying so. Every route reaching a cursor-paginated view now redirects numbered pages.

## Other review notes

- `decode_cursor` raises `BadRequest` (HTTP 400) on a tampered, expired, malformed or wrong-salt token; each list uses its own salt.
- Tokens expire after 24 h. Fine for click-through paging; a bookmarked cursor URL will expire, which is the one real downside of putting cursors in URLs.
- `VNOJ_LOW_POWER_MODE`'s `max_page` cap is inert on cursor-paginated lists — there are no numbered pages to cap. Its filter restrictions still apply. Deep pages are no longer expensive, which is what the cap was defending against.
- Cursor pages have no page *numbers*: seek pagination cannot know an ordinal without counting. The controls are prev/next only.

## Verification

```
flake8
./manage.py test judge urlshortener
```

245 tests. The 6 failures are pre-existing and reproduce identically on `master` (verified by checking out `master` and running the same 6).
