### PR TITLE
Add archived organization problem feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,5 @@ celerybeat-schedule.*
 resources/blog-modern.css
 resources/blog-post.css
 resources/theme-toggle.css
+.DS_Store
 .review/

--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -274,6 +274,9 @@ DMOJ_PROBLEM_HOT_PROBLEM_COUNT = 7
 
 # Grace period before a soft-deleted problem is permanently removed
 VNOJ_PROBLEM_DELETION_GRACE_PERIOD = datetime.timedelta(days=7)
+# How long archived data is kept in cold storage before the archiving job drops it for good.
+# Only used to tell users when their archived problems are due to expire; the job owns the real schedule.
+VNOJ_PROBLEM_ARCHIVE_RETENTION = datetime.timedelta(days=180)
 # Maximum time the garbage collection task is allowed to run per invocation
 VNOJ_PROBLEM_GARBAGE_COLLECTOR_TIME_LIMIT = datetime.timedelta(hours=1)
 VNOJ_PROBLEM_GARBAGE_COLLECTOR_CRONTAB_KWARGS = {'minute': 0, 'hour': 0}

--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -232,8 +232,7 @@ OJ_REQUESTS_TIMEOUT = 5  # in seconds
 
 OJAPI_CACHE_TIMEOUT = 3600  # Cache timeout for OJAPI data
 
-# External service holding the archived data of problems that were moved to cold storage.
-# GET <URL>?problem=<code> is expected to return a presigned S3 URL for that problem's archive.
+# External service to handle problem archiving
 VNOJ_PROBLEM_ARCHIVE_SERVICE_URL = None
 VNOJ_PROBLEM_ARCHIVE_SERVICE_TOKEN = None
 

--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -232,6 +232,11 @@ OJ_REQUESTS_TIMEOUT = 5  # in seconds
 
 OJAPI_CACHE_TIMEOUT = 3600  # Cache timeout for OJAPI data
 
+# External service holding the archived data of problems that were moved to cold storage.
+# GET <URL>?problem=<code> is expected to return a presigned S3 URL for that problem's archive.
+VNOJ_PROBLEM_ARCHIVE_SERVICE_URL = None
+VNOJ_PROBLEM_ARCHIVE_SERVICE_TOKEN = None
+
 # Urls of discord webhook.
 # https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks
 DISCORD_WEBHOOK = {

--- a/dmoj/urls.py
+++ b/dmoj/urls.py
@@ -147,6 +147,8 @@ urlpatterns = [
 
         path('/download/package', problem_download.DownloadProblemFullPackage.as_view(),
              name='problem_download_full_package'),
+        path('/download/archive', problem_download.DownloadArchivedProblemData.as_view(),
+             name='problem_download_archived_data'),
 
         path('/tickets/', ticket.ProblemTicketListView.as_view(), name='problem_ticket_list'),
         path('/tickets/new', ticket.NewProblemTicketView.as_view(), name='new_problem_ticket'),
@@ -312,6 +314,8 @@ urlpatterns = [
         path('/tags/<int:pk>/delete', organization.OrganizationTagDelete.as_view(), name='organization_tag_delete'),
         path('/kick', organization.KickUserWidgetView.as_view(), name='organization_user_kick'),
         path('/usage', organization.OrganizationStorageDashboard.as_view(), name='organization_monthly_usage'),
+        path('/usage/archived', organization.OrganizationArchivedProblems.as_view(),
+             name='organization_archived_problems'),
         path('/problems/', organization.ProblemListOrganization.as_view(), name='problem_list_organization'),
         path('/problems/random/', organization.RandomProblemOrganization.as_view(),
              name='problem_random_organization'),

--- a/dmoj/urls.py
+++ b/dmoj/urls.py
@@ -316,6 +316,8 @@ urlpatterns = [
         path('/usage', organization.OrganizationStorageDashboard.as_view(), name='organization_monthly_usage'),
         path('/usage/archived', organization.OrganizationArchivedProblems.as_view(),
              name='organization_archived_problems'),
+        path('/usage/archived/<str:problem>/restore', organization.RestoreArchivedProblem.as_view(),
+             name='organization_archived_problem_restore'),
         path('/problems/', organization.ProblemListOrganization.as_view(), name='problem_list_organization'),
         path('/problems/random/', organization.RandomProblemOrganization.as_view(),
              name='problem_random_organization'),

--- a/judge/jinja2/datetime.py
+++ b/judge/jinja2/datetime.py
@@ -5,9 +5,7 @@ from django.template.defaultfilters import date, time
 from django.templatetags.tz import localtime
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
-from django.utils.timezone import now
 from django.utils.translation import gettext as _
-from django.utils.translation import ngettext_lazy
 
 from . import registry
 
@@ -32,28 +30,3 @@ def relative_time(time, **kwargs):
     return mark_safe(f'<span data-iso="{time.astimezone(timezone.utc).isoformat()}" class="time-with-rel"'
                      f' title="{escape(abs_time)}" data-format="{escape(kwargs.get("rel", _("{time}")))}">'
                      f'{escape(kwargs.get("abs", _("on {time}")).replace("{time}", abs_time))}</span>')
-
-
-# Coarsest-first, so `time_ago` reports a single unit: "3 months ago", never "3 months, 1 week ago".
-TIME_AGO_UNITS = (
-    (365 * 24 * 60 * 60, ngettext_lazy('%(count)d year ago', '%(count)d years ago', 'count')),
-    (30 * 24 * 60 * 60, ngettext_lazy('%(count)d month ago', '%(count)d months ago', 'count')),
-    (24 * 60 * 60, ngettext_lazy('%(count)d day ago', '%(count)d days ago', 'count')),
-    (60 * 60, ngettext_lazy('%(count)d hour ago', '%(count)d hours ago', 'count')),
-    (60, ngettext_lazy('%(count)d minute ago', '%(count)d minutes ago', 'count')),
-)
-
-
-@registry.filter
-def time_ago(value):
-    """How long ago `value` was, rounded down to one unit: "5 hours ago", "2 months ago"."""
-    if value is None:
-        return ''
-
-    seconds = (now() - value).total_seconds()
-    for unit_seconds, message in TIME_AGO_UNITS:
-        count = int(seconds // unit_seconds)
-        if count > 0:
-            return message % {'count': count}
-    # Anything under a minute, and anything in the future (clock skew), reads as just now.
-    return _('just now')

--- a/judge/jinja2/datetime.py
+++ b/judge/jinja2/datetime.py
@@ -5,7 +5,9 @@ from django.template.defaultfilters import date, time
 from django.templatetags.tz import localtime
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
+from django.utils.timezone import now
 from django.utils.translation import gettext as _
+from django.utils.translation import ngettext_lazy
 
 from . import registry
 
@@ -30,3 +32,28 @@ def relative_time(time, **kwargs):
     return mark_safe(f'<span data-iso="{time.astimezone(timezone.utc).isoformat()}" class="time-with-rel"'
                      f' title="{escape(abs_time)}" data-format="{escape(kwargs.get("rel", _("{time}")))}">'
                      f'{escape(kwargs.get("abs", _("on {time}")).replace("{time}", abs_time))}</span>')
+
+
+# Coarsest-first, so `time_ago` reports a single unit: "3 months ago", never "3 months, 1 week ago".
+TIME_AGO_UNITS = (
+    (365 * 24 * 60 * 60, ngettext_lazy('%(count)d year ago', '%(count)d years ago', 'count')),
+    (30 * 24 * 60 * 60, ngettext_lazy('%(count)d month ago', '%(count)d months ago', 'count')),
+    (24 * 60 * 60, ngettext_lazy('%(count)d day ago', '%(count)d days ago', 'count')),
+    (60 * 60, ngettext_lazy('%(count)d hour ago', '%(count)d hours ago', 'count')),
+    (60, ngettext_lazy('%(count)d minute ago', '%(count)d minutes ago', 'count')),
+)
+
+
+@registry.filter
+def time_ago(value):
+    """How long ago `value` was, rounded down to one unit: "5 hours ago", "2 months ago"."""
+    if value is None:
+        return ''
+
+    seconds = (now() - value).total_seconds()
+    for unit_seconds, message in TIME_AGO_UNITS:
+        count = int(seconds // unit_seconds)
+        if count > 0:
+            return message % {'count': count}
+    # Anything under a minute, and anything in the future (clock skew), reads as just now.
+    return _('just now')

--- a/judge/migrations/0234_problem_archived_at.py
+++ b/judge/migrations/0234_problem_archived_at.py
@@ -14,6 +14,11 @@ class Migration(migrations.Migration):
             field=models.DateTimeField(blank=True, null=True, verbose_name='archived at',
                                        help_text="When set, this problem's data has been moved to cold storage."),
         ),
+        migrations.AddField(
+            model_name='problemdata',
+            name='archived_size',
+            field=models.BigIntegerField(default=0, help_text='Size of the test data zip file in bytes when archived.', verbose_name='archived test data storage size'),
+        ),
         migrations.AddIndex(
             model_name='problem',
             index=models.Index(fields=['organization', '-archived_at'], name='judge_probl_organiz_0d1c92_idx'),

--- a/judge/migrations/0234_problem_archived_at.py
+++ b/judge/migrations/0234_problem_archived_at.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('judge', '0233_organization_notice'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='problem',
+            name='archived_at',
+            field=models.DateTimeField(blank=True, null=True, verbose_name='archived at',
+                                       help_text="When set, this problem's data has been moved to cold storage."),
+        ),
+        migrations.AddIndex(
+            model_name='problem',
+            index=models.Index(fields=['organization', '-archived_at'], name='judge_probl_organiz_0d1c92_idx'),
+        ),
+    ]

--- a/judge/models/problem.py
+++ b/judge/models/problem.py
@@ -244,6 +244,8 @@ class Problem(models.Model):
                                                        help_text=_('What testcase result should be showed to users?'))
 
     deleted_at = models.DateTimeField(verbose_name=_('deleted at'), null=True, db_index=True)
+    archived_at = models.DateTimeField(verbose_name=_('archived at'), null=True, blank=True,
+                                       help_text=_("When set, this problem's data has been moved to cold storage."))
 
     objects = ProblemManager()
     tickets = GenericRelation('Ticket')
@@ -632,6 +634,10 @@ class Problem(models.Model):
     def is_deleted(self):
         return self.deleted_at is not None
 
+    @property
+    def is_archived(self):
+        return self.archived_at is not None
+
     def mark_as_deleted(self, invalidate_storage_cache=True):
         """Soft-delete this problem. Use the garbage collector to permanently remove it after the grace period."""
         self.deleted_at = timezone.now()
@@ -660,6 +666,8 @@ class Problem(models.Model):
         )
         indexes = [
             models.Index(fields=['is_public', 'is_organization_private', '-date']),
+            # The archived problem list is always scoped to one organization.
+            models.Index(fields=['organization', '-archived_at']),
         ]
         verbose_name = _('problem')
         verbose_name_plural = _('problems')

--- a/judge/models/problem_data.py
+++ b/judge/models/problem_data.py
@@ -93,12 +93,19 @@ class ProblemData(models.Model):
                                    help_text=_('grader arguments as a JSON object'))
     zipfile_size = models.BigIntegerField(verbose_name=_('test data storage size'), default=0,
                                           help_text=_('Size of the test data zip file in bytes.'))
+    # the logic to set this field is outside of this codebase,
+    # it will be set by our archive service when the problem is archived
+    archived_size = models.BigIntegerField(verbose_name=_('archived test data storage size'), default=0,
+                                           help_text=_('Size of the test data zip file in bytes when archived.'))
 
     def has_yml(self):
         return problem_data_storage.exists('%s/init.yml' % self.problem.code)
 
     def update_zipfile_size(self):
         """Update the zipfile_size field based on the actual size of all attached files."""
+        if self.archived_size > 0:
+            self.zipfile_size = self.archived_size
+            return
         total_size = 0
         for field in [self.zipfile, self.generator, self.custom_checker, self.custom_grader, self.custom_header]:
             if field:

--- a/judge/models/profile.py
+++ b/judge/models/profile.py
@@ -178,7 +178,7 @@ class Organization(models.Model):
         return result['total'] or 0
 
     def can_create_problem(self):
-        return self.current_problem_count < self.max_problems
+        return self.current_problem_count < self.max_problems and self.current_storage < self.max_storage
 
     def can_upload_data(self):
         return self.current_storage < self.max_storage

--- a/judge/utils/organization.py
+++ b/judge/utils/organization.py
@@ -1,8 +1,8 @@
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.shortcuts import render
-from django.utils.translation import gettext as _
 from django.template.defaultfilters import filesizeformat
+from django.utils.translation import gettext as _
 
 
 def quota_error_response(request, organization):

--- a/judge/utils/organization.py
+++ b/judge/utils/organization.py
@@ -1,5 +1,18 @@
 from django.conf import settings
 from django.contrib.auth.models import Group
+from django.shortcuts import render
+from django.utils.translation import gettext as _
+from django.template.defaultfilters import filesizeformat
+
+
+def quota_error_response(request, organization):
+    return render(request, 'organization/quota-error.html', {
+        'title': _('Problem limit reached'),
+        'message': _('This organization has reached its maximum number of problems (%d) and/or storage (%s). '
+                     'Please delete some problems or free up storage before creating new ones.')
+        % (organization.max_problems, filesizeformat(organization.max_storage)),
+        'quota_warning_suffix': settings.VNOJ_QUOTA_WARNING_SUFFIX,
+    })
 
 
 def add_quota_context(org, context, total_storage=None):

--- a/judge/utils/problem_archive.py
+++ b/judge/utils/problem_archive.py
@@ -8,8 +8,6 @@ from django.core.validators import URLValidator
 logger = logging.getLogger('judge.problem.archive')
 
 
-ARCHIVE_SERVICE_URL = settings.VNOJ_PROBLEM_ARCHIVE_SERVICE_URL
-
 # The archive service is not part of this codebase and its exact response shape is not pinned down yet,
 # so every assumption about it lives in `_extract_url` and nowhere else.
 _URL_KEYS = ('url', 'download_url', 'presigned_url')
@@ -18,7 +16,7 @@ validate_archive_url = URLValidator(schemes=['http', 'https'])
 
 
 class ArchiveServiceError(Exception):
-    """Raised when the archive service could not hand us a usable download URL."""
+    """Raised when the archive service could not be reached or gave an unusable answer."""
 
 
 def _extract_url(data):
@@ -32,39 +30,56 @@ def _extract_url(data):
     raise ArchiveServiceError('archive service response did not contain a download URL')
 
 
-def get_archive_download_url(problem_code: str) -> str:
-    """Ask the archive service for a presigned URL to the archived data of `problem_code`."""
-    if not ARCHIVE_SERVICE_URL:
-        raise ArchiveServiceError('the problem archive service is not configured')
+class ArchiveService:
+    """The single place that talks to the external problem-archive service."""
 
-    headers = {}
-    if settings.VNOJ_PROBLEM_ARCHIVE_SERVICE_TOKEN:
-        headers['Authorization'] = 'Bearer %s' % settings.VNOJ_PROBLEM_ARCHIVE_SERVICE_TOKEN
+    def _request(self, method, path='', **kwargs):
+        base = settings.VNOJ_PROBLEM_ARCHIVE_SERVICE_URL  # read lazily so override_settings works in tests
+        if not base:
+            raise ArchiveServiceError('the problem archive service is not configured')
 
-    try:
-        response = requests.get(
-            ARCHIVE_SERVICE_URL,
-            params={'problem': problem_code},
-            headers=headers,
-            timeout=settings.OJ_REQUESTS_TIMEOUT,
-        )
-        response.raise_for_status()
-    except requests.RequestException:
-        logger.exception('failed to reach the archive service for problem %s', problem_code)
-        raise ArchiveServiceError('could not reach the archive service')
+        headers = {}
+        if settings.VNOJ_PROBLEM_ARCHIVE_SERVICE_TOKEN:
+            headers['Authorization'] = 'Bearer %s' % settings.VNOJ_PROBLEM_ARCHIVE_SERVICE_TOKEN
 
-    try:
-        data = response.json()
-    except ValueError:
-        data = response.text
+        try:
+            response = requests.request(
+                method, base.rstrip('/') + path,
+                headers=headers, timeout=settings.OJ_REQUESTS_TIMEOUT, **kwargs,
+            )
+            response.raise_for_status()
+        except requests.RequestException:
+            logger.exception('archive service request failed: %s %s', method, path)
+            raise ArchiveServiceError('could not reach the archive service')
+        return response
 
-    url = _extract_url(data)
+    def get_download_url(self, problem_code: str) -> str:
+        """Ask the archive service for a presigned URL to the archived data of `problem_code`."""
+        response = self._request('GET', '/download', params={'problem': problem_code})
 
-    # We redirect the browser to whatever comes back, so never trust it unvalidated.
-    try:
-        validate_archive_url(url)
-    except ValidationError:
-        logger.error('archive service returned an invalid URL for problem %s', problem_code)
-        raise ArchiveServiceError('archive service returned an invalid URL')
+        try:
+            data = response.json()
+        except ValueError:
+            data = response.text
 
-    return url
+        url = _extract_url(data)
+
+        # We redirect the browser to whatever comes back, so never trust it unvalidated.
+        try:
+            validate_archive_url(url)
+        except ValidationError:
+            logger.error('archive service returned an invalid URL for problem %s', problem_code)
+            raise ArchiveServiceError('archive service returned an invalid URL')
+
+        return url
+
+    def restore(self, problem_code: str) -> None:
+        """Ask the archive service to move `problem_code`'s data back to local storage."""
+        self._request('POST', '/restore', params={'problem': problem_code})
+
+    def archive(self, problem_code: str, organization_slug: str) -> None:
+        """Ask the archive service to move `problem_code`'s data to cold storage."""
+        self._request('POST', '/archive', params={'problem': problem_code, 'organization': organization_slug})
+
+
+archive_service = ArchiveService()

--- a/judge/utils/problem_archive.py
+++ b/judge/utils/problem_archive.py
@@ -9,7 +9,6 @@ logger = logging.getLogger('judge.problem.archive')
 
 
 ARCHIVE_SERVICE_URL = settings.VNOJ_PROBLEM_ARCHIVE_SERVICE_URL
-ARCHIVE_DOWNLOAD_ENABLED = ARCHIVE_SERVICE_URL is not None
 
 # The archive service is not part of this codebase and its exact response shape is not pinned down yet,
 # so every assumption about it lives in `_extract_url` and nowhere else.
@@ -35,7 +34,7 @@ def _extract_url(data):
 
 def get_archive_download_url(problem_code: str) -> str:
     """Ask the archive service for a presigned URL to the archived data of `problem_code`."""
-    if not ARCHIVE_DOWNLOAD_ENABLED:
+    if not ARCHIVE_SERVICE_URL:
         raise ArchiveServiceError('the problem archive service is not configured')
 
     headers = {}

--- a/judge/utils/problem_archive.py
+++ b/judge/utils/problem_archive.py
@@ -2,32 +2,12 @@ import logging
 
 import requests
 from django.conf import settings
-from django.core.exceptions import ValidationError
-from django.core.validators import URLValidator
 
 logger = logging.getLogger('judge.problem.archive')
 
 
-# The archive service is not part of this codebase and its exact response shape is not pinned down yet,
-# so every assumption about it lives in `_extract_url` and nowhere else.
-_URL_KEYS = ('url', 'download_url', 'presigned_url')
-
-validate_archive_url = URLValidator(schemes=['http', 'https'])
-
-
 class ArchiveServiceError(Exception):
     """Raised when the archive service could not be reached or gave an unusable answer."""
-
-
-def _extract_url(data):
-    if isinstance(data, str):
-        return data.strip()
-    if isinstance(data, dict):
-        for key in _URL_KEYS:
-            value = data.get(key)
-            if isinstance(value, str) and value.strip():
-                return value.strip()
-    raise ArchiveServiceError('archive service response did not contain a download URL')
 
 
 class ArchiveService:
@@ -59,19 +39,10 @@ class ArchiveService:
 
         try:
             data = response.json()
-        except ValueError:
-            data = response.text
-
-        url = _extract_url(data)
-
-        # We redirect the browser to whatever comes back, so never trust it unvalidated.
-        try:
-            validate_archive_url(url)
-        except ValidationError:
-            logger.error('archive service returned an invalid URL for problem %s', problem_code)
+            return data.get('url')
+        except ValueError as e:
+            logger.error('archive service returned an invalid URL for problem %s', problem_code, exc_info=e)
             raise ArchiveServiceError('archive service returned an invalid URL')
-
-        return url
 
     def restore(self, problem_code: str) -> None:
         """Ask the archive service to move `problem_code`'s data back to local storage."""

--- a/judge/utils/problem_archive.py
+++ b/judge/utils/problem_archive.py
@@ -1,0 +1,71 @@
+import logging
+
+import requests
+from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.core.validators import URLValidator
+
+logger = logging.getLogger('judge.problem.archive')
+
+
+ARCHIVE_SERVICE_URL = settings.VNOJ_PROBLEM_ARCHIVE_SERVICE_URL
+ARCHIVE_DOWNLOAD_ENABLED = ARCHIVE_SERVICE_URL is not None
+
+# The archive service is not part of this codebase and its exact response shape is not pinned down yet,
+# so every assumption about it lives in `_extract_url` and nowhere else.
+_URL_KEYS = ('url', 'download_url', 'presigned_url')
+
+validate_archive_url = URLValidator(schemes=['http', 'https'])
+
+
+class ArchiveServiceError(Exception):
+    """Raised when the archive service could not hand us a usable download URL."""
+
+
+def _extract_url(data):
+    if isinstance(data, str):
+        return data.strip()
+    if isinstance(data, dict):
+        for key in _URL_KEYS:
+            value = data.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    raise ArchiveServiceError('archive service response did not contain a download URL')
+
+
+def get_archive_download_url(problem_code: str) -> str:
+    """Ask the archive service for a presigned URL to the archived data of `problem_code`."""
+    if not ARCHIVE_DOWNLOAD_ENABLED:
+        raise ArchiveServiceError('the problem archive service is not configured')
+
+    headers = {}
+    if settings.VNOJ_PROBLEM_ARCHIVE_SERVICE_TOKEN:
+        headers['Authorization'] = 'Bearer %s' % settings.VNOJ_PROBLEM_ARCHIVE_SERVICE_TOKEN
+
+    try:
+        response = requests.get(
+            ARCHIVE_SERVICE_URL,
+            params={'problem': problem_code},
+            headers=headers,
+            timeout=settings.OJ_REQUESTS_TIMEOUT,
+        )
+        response.raise_for_status()
+    except requests.RequestException:
+        logger.exception('failed to reach the archive service for problem %s', problem_code)
+        raise ArchiveServiceError('could not reach the archive service')
+
+    try:
+        data = response.json()
+    except ValueError:
+        data = response.text
+
+    url = _extract_url(data)
+
+    # We redirect the browser to whatever comes back, so never trust it unvalidated.
+    try:
+        validate_archive_url(url)
+    except ValidationError:
+        logger.error('archive service returned an invalid URL for problem %s', problem_code)
+        raise ArchiveServiceError('archive service returned an invalid URL')
+
+    return url

--- a/judge/utils/problem_archive.py
+++ b/judge/utils/problem_archive.py
@@ -40,8 +40,8 @@ class ArchiveService:
         try:
             data = response.json()
             return data.get('url')
-        except ValueError as e:
-            logger.error('archive service returned an invalid URL for problem %s', problem_code, exc_info=e)
+        except ValueError:
+            logger.exception('archive service returned an invalid URL for problem %s', problem_code)
             raise ArchiveServiceError('archive service returned an invalid URL')
 
     def restore(self, problem_code: str) -> None:

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -35,7 +35,6 @@ from judge.tasks import on_new_problem
 from judge.utils.cache_helper import storage_pie_cache_factory
 from judge.utils.infinite_paginator import InfinitePaginationMixin
 from judge.utils.organization import add_admin_to_group, add_quota_context
-from judge.utils.problem_archive import ARCHIVE_DOWNLOAD_ENABLED
 from judge.utils.problems import user_completed_ids
 from judge.utils.ranker import ranker
 from judge.utils.stats import get_lines_chart, get_pie_chart
@@ -1235,10 +1234,10 @@ class OrganizationArchivedProblems(LoginRequiredMixin, TitleMixin, AdminOrganiza
         last_sub_query = Submission.objects.filter(problem=OuterRef('pk')).order_by('-date').values('date')[:1]
         queryset = queryset.annotate(last_submission_date=Subquery(last_sub_query))
 
-        return queryset.order_by('-archived_at', 'id')
+        return queryset.order_by('archived_at', 'id')
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['archive_enabled'] = ARCHIVE_DOWNLOAD_ENABLED
+        context['archive_retention_days'] = settings.VNOJ_PROBLEM_ARCHIVE_RETENTION.days
         context.update(paginate_query_context(self.request))
         return context

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -1226,11 +1226,10 @@ class OrganizationArchivedProblems(LoginRequiredMixin, TitleMixin, AdminOrganiza
         return _('Archived problems - %s') % self.organization.name
 
     def get_queryset(self):
+        # No data_size annotation: the test data of an archived problem is gone from local storage.
         queryset = Problem.available.filter(
             organization=self.organization,
             archived_at__isnull=False,
-        ).annotate(
-            data_size=Coalesce(F('data_files__zipfile_size'), Value(0)),
         ).prefetch_related('authors__user', 'curators__user')
 
         last_sub_query = Submission.objects.filter(problem=OuterRef('pk')).order_by('-date').values('date')[:1]

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -34,7 +34,7 @@ from judge.models.profile import OrganizationMonthlyUsage, OrganizationQuota
 from judge.tasks import on_new_problem
 from judge.utils.cache_helper import storage_pie_cache_factory
 from judge.utils.infinite_paginator import InfinitePaginationMixin
-from judge.utils.organization import add_admin_to_group, add_quota_context
+from judge.utils.organization import add_admin_to_group, add_quota_context, quota_error_response
 from judge.utils.problems import user_completed_ids
 from judge.utils.ranker import ranker
 from judge.utils.stats import get_lines_chart, get_pie_chart
@@ -955,15 +955,6 @@ class SubmissionListOrganization(InfinitePaginationMixin, PrivateOrganizationMix
 class ProblemCreateOrganization(AdminOrganizationMixin, ProblemCreate):
     permission_required = 'judge.create_organization_problem'
 
-    def _quota_error_response(self):
-        return render(self.request, 'organization/quota-error.html', {
-            'title': _('Problem limit reached'),
-            'message': _('This organization has reached its maximum number of problems (%d). '
-                         'Please delete some problems before creating new ones.')
-            % self.organization.max_problems,
-            'quota_warning_suffix': settings.VNOJ_QUOTA_WARNING_SUFFIX,
-        })
-
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         add_quota_context(self.organization, context)
@@ -972,7 +963,7 @@ class ProblemCreateOrganization(AdminOrganizationMixin, ProblemCreate):
 
     def get(self, request, *args, **kwargs):
         if settings.VNOJ_QUOTA_ENFORCEMENT_ENABLED and not self.organization.can_create_problem():
-            return self._quota_error_response()
+            return quota_error_response(request, self.organization)
         return super().get(request, *args, **kwargs)
 
     def get_initial(self):
@@ -988,7 +979,7 @@ class ProblemCreateOrganization(AdminOrganizationMixin, ProblemCreate):
 
     def form_valid(self, form):
         if settings.VNOJ_QUOTA_ENFORCEMENT_ENABLED and not self.organization.can_create_problem():
-            return self._quota_error_response()
+            return quota_error_response(self.request, self.organization)
         with revisions.create_revision(atomic=True):
             self.object = problem = form.save()
             problem.authors.add(self.request.user.profile)
@@ -1272,13 +1263,7 @@ class RestoreArchivedProblem(LoginRequiredMixin, AdminOrganizationMixin, View):
 
         # Same gate as creating a problem in the organization.
         if settings.VNOJ_QUOTA_ENFORCEMENT_ENABLED and not self.organization.can_create_problem():
-            return render(request, 'organization/quota-error.html', {
-                'title': _('Problem limit reached'),
-                'message': _('This organization has reached its maximum number of problems (%d). '
-                             'Please delete some problems before creating new ones.')
-                % self.organization.max_problems,
-                'quota_warning_suffix': settings.VNOJ_QUOTA_WARNING_SUFFIX,
-            })
+            return quota_error_response(request, self.organization)
 
         problem.archived_at = None
         problem.save(update_fields=['archived_at'])

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -25,6 +25,7 @@ from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _, gettext_lazy, ngettext
 from django.views.generic import CreateView, DetailView, FormView, ListView, TemplateView, UpdateView, View
 from django.views.generic.detail import SingleObjectMixin, SingleObjectTemplateResponseMixin
+from judge.models.problem_data import ProblemData
 from reversion import revisions
 
 from judge.forms import OrganizationForm, OrganizationProblemTagForm, QuotaGrantForm
@@ -1275,5 +1276,13 @@ class RestoreArchivedProblem(LoginRequiredMixin, AdminOrganizationMixin, View):
 
         problem.archived_at = None
         problem.save(update_fields=['archived_at'])
+
+        try:
+            problem_data = problem.data_files
+            problem_data.archived_size = 0
+            problem_data.save(update_fields=['archived_size'])
+        except ProblemData.DoesNotExist:
+            pass
+
         messages.success(request, _('%s has been restored from the archive.') % problem.code)
         return HttpResponseRedirect(reverse('organization_archived_problems', args=[self.organization.slug]))

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -21,6 +21,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.dateparse import parse_date
 from django.utils.html import format_html
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _, gettext_lazy, ngettext
 from django.views.generic import CreateView, DetailView, FormView, ListView, TemplateView, UpdateView, View
 from django.views.generic.detail import SingleObjectMixin, SingleObjectTemplateResponseMixin
@@ -34,6 +35,7 @@ from judge.tasks import on_new_problem
 from judge.utils.cache_helper import storage_pie_cache_factory
 from judge.utils.infinite_paginator import InfinitePaginationMixin
 from judge.utils.organization import add_admin_to_group, add_quota_context
+from judge.utils.problem_archive import ARCHIVE_DOWNLOAD_ENABLED
 from judge.utils.problems import user_completed_ids
 from judge.utils.ranker import ranker
 from judge.utils.stats import get_lines_chart, get_pie_chart
@@ -47,7 +49,7 @@ from judge.views.submission import SubmissionsListBase
 __all__ = ['OrganizationList', 'OrganizationHome', 'OrganizationUsers', 'OrganizationMembershipChange',
            'JoinOrganization', 'LeaveOrganization', 'EditOrganization', 'RequestJoinOrganization',
            'OrganizationRequestDetail', 'OrganizationRequestView', 'OrganizationRequestLog',
-           'KickUserWidgetView', 'OrganizationStorageDashboard',
+           'KickUserWidgetView', 'OrganizationStorageDashboard', 'OrganizationArchivedProblems',
            'OrganizationQuotaAdd', 'OrganizationQuotaDelete', 'get_organization_problem_filter',
            'OrganizationUserSolvedProblems']
 
@@ -851,16 +853,25 @@ class OrganizationUserSolvedProblems(AdminOrganizationMixin, TitleMixin, Templat
 
 
 class BulkDeleteOrganizationProblems(LoginRequiredMixin, AdminOrganizationMixin, View):
+    def get_next_url(self):
+        """The table that submitted the form, so we return to it instead of always to the storage tab."""
+        next_url = self.request.POST.get('next')
+        if next_url and url_has_allowed_host_and_scheme(next_url, allowed_hosts={self.request.get_host()},
+                                                        require_https=self.request.is_secure()):
+            return next_url
+        return reverse('organization_monthly_usage', args=[self.organization.slug])
+
     def post(self, request, *args, **kwargs):
         org = self.organization
+        next_url = self.get_next_url()
         problem_ids = request.POST.getlist('problem_ids')
         if not problem_ids:
             messages.warning(request, _('No problems selected for deletion.'))
-            return HttpResponseRedirect(reverse('organization_monthly_usage', args=[org.slug]))
+            return HttpResponseRedirect(next_url)
 
         if len(problem_ids) > MAX_BULK_DELETE_PROBLEMS:
             messages.error(request, _('Cannot delete more than %d problems at once.') % MAX_BULK_DELETE_PROBLEMS)
-            return HttpResponseRedirect(reverse('organization_monthly_usage', args=[org.slug]))
+            return HttpResponseRedirect(next_url)
 
         problems = Problem.available.filter(
             id__in=problem_ids,
@@ -895,7 +906,7 @@ class BulkDeleteOrganizationProblems(LoginRequiredMixin, AdminOrganizationMixin,
         else:
             messages.error(request, _('No valid problems could be deleted.'))
 
-        return HttpResponseRedirect(reverse('organization_monthly_usage', args=[org.slug]))
+        return HttpResponseRedirect(next_url)
 
 
 class ContestListOrganization(PrivateOrganizationMixin, ContestList):
@@ -1201,4 +1212,34 @@ class OrganizationStorageDashboard(LoginRequiredMixin, TitleMixin, AdminOrganiza
 
         context.update(paginate_query_context(self.request))
 
+        return context
+
+
+class OrganizationArchivedProblems(LoginRequiredMixin, TitleMixin, AdminOrganizationMixin,
+                                   InfinitePaginationMixin, ListView):
+    """List of problems whose data has been moved to cold storage by the archiving cron job."""
+    template_name = 'organization/archived.html'
+    context_object_name = 'problems'
+    paginate_by = MAX_BULK_DELETE_PROBLEMS
+
+    def get_title(self):
+        return _('Archived problems - %s') % self.organization.name
+
+    def get_queryset(self):
+        queryset = Problem.available.filter(
+            organization=self.organization,
+            archived_at__isnull=False,
+        ).annotate(
+            data_size=Coalesce(F('data_files__zipfile_size'), Value(0)),
+        ).prefetch_related('authors__user', 'curators__user')
+
+        last_sub_query = Submission.objects.filter(problem=OuterRef('pk')).order_by('-date').values('date')[:1]
+        queryset = queryset.annotate(last_submission_date=Subquery(last_sub_query))
+
+        return queryset.order_by('-archived_at', 'id')
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['archive_enabled'] = ARCHIVE_DOWNLOAD_ENABLED
+        context.update(paginate_query_context(self.request))
         return context

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -35,6 +35,7 @@ from judge.tasks import on_new_problem
 from judge.utils.cache_helper import storage_pie_cache_factory
 from judge.utils.infinite_paginator import InfinitePaginationMixin
 from judge.utils.organization import add_admin_to_group, add_quota_context, quota_error_response
+from judge.utils.problem_archive import ArchiveServiceError, archive_service
 from judge.utils.problems import user_completed_ids
 from judge.utils.ranker import ranker
 from judge.utils.stats import get_lines_chart, get_pie_chart
@@ -1264,6 +1265,13 @@ class RestoreArchivedProblem(LoginRequiredMixin, AdminOrganizationMixin, View):
         # Same gate as creating a problem in the organization.
         if settings.VNOJ_QUOTA_ENFORCEMENT_ENABLED and not self.organization.can_create_problem():
             return quota_error_response(request, self.organization)
+
+        try:
+            archive_service.restore(problem.code)
+        except ArchiveServiceError:
+            messages.error(request, _('Could not restore %s from the archive. Please try again later.')
+                           % problem.code)
+            return HttpResponseRedirect(reverse('organization_archived_problems', args=[self.organization.slug]))
 
         problem.archived_at = None
         problem.save(update_fields=['archived_at'])

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -57,6 +57,15 @@ MAX_BULK_DELETE_PROBLEMS = 200
 SOLVED_PROBLEMS_PAGE_SIZE = 10
 
 
+def archived_problems_queryset(organization):
+    """The problems listed on the Archived problems tab, before annotation and ordering.
+
+    The permalink ranks over this same set to work out which page a problem lands on, so the two
+    must not be allowed to drift apart.
+    """
+    return Problem.available.filter(organization=organization, archived_at__isnull=False)
+
+
 class OrganizationMixin(object):
     model = Organization
 
@@ -1226,18 +1235,26 @@ class OrganizationArchivedProblems(LoginRequiredMixin, TitleMixin, AdminOrganiza
 
     def get_queryset(self):
         # No data_size annotation: the test data of an archived problem is gone from local storage.
-        queryset = Problem.available.filter(
-            organization=self.organization,
-            archived_at__isnull=False,
-        ).prefetch_related('authors__user', 'curators__user')
+        queryset = archived_problems_queryset(self.organization) \
+            .prefetch_related('authors__user', 'curators__user')
+
+        # `?problem=<code>` is a permalink to one row. Narrowing the queryset keeps a permalink at
+        # a single-row lookup, instead of working out which page the row is on and building it.
+        if self.problem_filter:
+            queryset = queryset.filter(code=self.problem_filter)
 
         last_sub_query = Submission.objects.filter(problem=OuterRef('pk')).order_by('-date').values('date')[:1]
         queryset = queryset.annotate(last_submission_date=Subquery(last_sub_query))
 
         return queryset.order_by('archived_at', 'id')
 
+    @cached_property
+    def problem_filter(self):
+        return self.request.GET.get('problem') or ''
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['archive_retention_days'] = settings.VNOJ_PROBLEM_ARCHIVE_RETENTION.days
+        context['problem_filter'] = self.problem_filter
         context.update(paginate_query_context(self.request))
         return context

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -25,12 +25,12 @@ from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _, gettext_lazy, ngettext
 from django.views.generic import CreateView, DetailView, FormView, ListView, TemplateView, UpdateView, View
 from django.views.generic.detail import SingleObjectMixin, SingleObjectTemplateResponseMixin
-from judge.models.problem_data import ProblemData
 from reversion import revisions
 
 from judge.forms import OrganizationForm, OrganizationProblemTagForm, QuotaGrantForm
 from judge.models import BlogPost, Comment, Contest, Language, Organization, \
     OrganizationRequest, Problem, Profile, Submission
+from judge.models.problem_data import ProblemData
 from judge.models.profile import OrganizationMonthlyUsage, OrganizationQuota
 from judge.tasks import on_new_problem
 from judge.utils.cache_helper import storage_pie_cache_factory

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -49,6 +49,7 @@ __all__ = ['OrganizationList', 'OrganizationHome', 'OrganizationUsers', 'Organiz
            'JoinOrganization', 'LeaveOrganization', 'EditOrganization', 'RequestJoinOrganization',
            'OrganizationRequestDetail', 'OrganizationRequestView', 'OrganizationRequestLog',
            'KickUserWidgetView', 'OrganizationStorageDashboard', 'OrganizationArchivedProblems',
+           'RestoreArchivedProblem',
            'OrganizationQuotaAdd', 'OrganizationQuotaDelete', 'get_organization_problem_filter',
            'OrganizationUserSolvedProblems']
 
@@ -1258,3 +1259,28 @@ class OrganizationArchivedProblems(LoginRequiredMixin, TitleMixin, AdminOrganiza
         context['problem_filter'] = self.problem_filter
         context.update(paginate_query_context(self.request))
         return context
+
+
+class RestoreArchivedProblem(LoginRequiredMixin, AdminOrganizationMixin, View):
+    """Take a problem back out of cold storage by clearing its `archived_at` stamp.
+
+    Fetching the data itself back is the archiving job's business; this only marks the intent.
+    """
+
+    def post(self, request, *args, **kwargs):
+        problem = get_object_or_404(archived_problems_queryset(self.organization), code=kwargs['problem'])
+
+        # Same gate as creating a problem in the organization.
+        if settings.VNOJ_QUOTA_ENFORCEMENT_ENABLED and not self.organization.can_create_problem():
+            return render(request, 'organization/quota-error.html', {
+                'title': _('Problem limit reached'),
+                'message': _('This organization has reached its maximum number of problems (%d). '
+                             'Please delete some problems before creating new ones.')
+                % self.organization.max_problems,
+                'quota_warning_suffix': settings.VNOJ_QUOTA_WARNING_SUFFIX,
+            })
+
+        problem.archived_at = None
+        problem.save(update_fields=['archived_at'])
+        messages.success(request, _('%s has been restored from the archive.') % problem.code)
+        return HttpResponseRedirect(reverse('organization_archived_problems', args=[self.organization.slug]))

--- a/judge/views/problem_data.py
+++ b/judge/views/problem_data.py
@@ -5,6 +5,7 @@ from itertools import chain
 from zipfile import BadZipfile, ZipFile
 
 from django.conf import settings
+from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import ValidationError
@@ -14,6 +15,7 @@ from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils.html import escape, format_html
+from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _, gettext_lazy
 from django.views.generic import DetailView
@@ -182,8 +184,47 @@ class ProblemSubmissionDiff(TitleMixin, ProblemMixin, DetailView):
             return generic_message(self.request, _('No such submissions'), _('Could not find any submissions.'))
 
 
+class ProblemArchived(Exception):
+    def __init__(self, problem):
+        self.problem = problem
+
+
 class ProblemDataView(TitleMixin, ProblemManagerMixin):
     template_name = 'problem/data.html'
+
+    def get_object(self, queryset=None):
+        problem = super().get_object(queryset)
+        # There is nothing left on disk to edit once the data has gone to cold storage.
+        if problem.is_archived:
+            raise ProblemArchived(problem)
+        return problem
+
+    def dispatch(self, request, *args, **kwargs):
+        # Mirrors how ProblemMixin handles ProblemDeleted: raise from get_object and handle it here,
+        # so the login and permission checks below still run first.
+        try:
+            return super().dispatch(request, *args, **kwargs)
+        except ProblemArchived as e:
+            return self.archived_response(e.problem)
+
+    def archived_response(self, problem):
+        request = self.request
+        message = _('The test data of %s has been archived, so it can no longer be edited. '
+                    'Download it from the archive if you still need it.') % problem.code
+
+        organization = problem.organization
+        if organization is not None and request.profile is not None and (
+                organization.is_admin(request.profile) or
+                request.user.has_perm('judge.edit_all_organization')):
+            messages.error(request, message)
+            return HttpResponseRedirect('%s?%s' % (
+                reverse('organization_archived_problems', args=[organization.slug]),
+                urlencode({'problem': problem.code})))
+
+        # The archived list is org-admin only and problem editors are not necessarily org admins,
+        # so anyone else would land on a 403. No other page renders `messages` either, so the
+        # explanation has to be a page of its own.
+        return generic_message(request, _('Problem data archived'), message)
 
     def get_title(self):
         return _('Editing data for {0}').format(self.object.name)

--- a/judge/views/problem_data.py
+++ b/judge/views/problem_data.py
@@ -209,8 +209,8 @@ class ProblemDataView(TitleMixin, ProblemManagerMixin):
 
     def archived_response(self, problem):
         request = self.request
-        message = _('The test data of %s has been archived, so it can no longer be edited. '
-                    'Download it from the archive if you still need it.') % problem.code
+        message = _('Problem %s has been archived, so it can no longer be edited. '
+                    'Restore it from the archive if needed.') % problem.code
 
         organization = problem.organization
         if organization is not None and request.profile is not None and (

--- a/judge/views/problem_download.py
+++ b/judge/views/problem_download.py
@@ -3,12 +3,17 @@ import zipfile
 from io import BytesIO
 
 import requests
+from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import Http404, HttpResponse, JsonResponse
+from django.http import Http404, HttpResponse, HttpResponseRedirect, JsonResponse
+from django.urls import reverse
+from django.utils.http import url_has_allowed_host_and_scheme
+from django.utils.translation import gettext as _
 from django.views.generic import View
 from django.views.generic.detail import SingleObjectMixin
 
 from judge.models import Problem, problem_data_storage
+from judge.utils.problem_archive import ArchiveServiceError, get_archive_download_url
 from judge.utils.url import get_absolute_pdf_url
 from judge.views.problem import ProblemMixin
 
@@ -91,3 +96,28 @@ class DownloadProblemFullPackage(LoginRequiredMixin, ProblemDownloadMixin, Singl
                 zip_file.writestr('statement.md', statement)
         except Exception as e:
             zip_file.writestr('statement_md_error.txt', f'Error processing statement: {str(e)}')
+
+
+class DownloadArchivedProblemData(LoginRequiredMixin, ProblemDownloadMixin, SingleObjectMixin, View):
+    """Redirect to a presigned URL for the archived data of a problem that was moved to cold storage."""
+
+    def _back_url(self, problem: Problem):
+        referer = self.request.META.get('HTTP_REFERER')
+        if referer and url_has_allowed_host_and_scheme(referer, allowed_hosts={self.request.get_host()},
+                                                       require_https=self.request.is_secure()):
+            return referer
+        return reverse('problem_detail', args=[problem.code])
+
+    def get(self, request, *args, **kwargs):
+        problem = self.get_object()
+        if not problem.is_archived:
+            raise Http404()
+
+        try:
+            url = get_archive_download_url(problem.code)
+        except ArchiveServiceError:
+            messages.error(request, _('Could not fetch the archived data of %s. Please try again later.')
+                           % problem.code)
+            return HttpResponseRedirect(self._back_url(problem))
+
+        return HttpResponseRedirect(url)

--- a/judge/views/problem_download.py
+++ b/judge/views/problem_download.py
@@ -13,7 +13,7 @@ from django.views.generic import View
 from django.views.generic.detail import SingleObjectMixin
 
 from judge.models import Problem, problem_data_storage
-from judge.utils.problem_archive import ArchiveServiceError, get_archive_download_url
+from judge.utils.problem_archive import ArchiveServiceError, archive_service
 from judge.utils.url import get_absolute_pdf_url
 from judge.views.problem import ProblemMixin
 
@@ -114,7 +114,7 @@ class DownloadArchivedProblemData(LoginRequiredMixin, ProblemDownloadMixin, Sing
             raise Http404()
 
         try:
-            url = get_archive_download_url(problem.code)
+            url = archive_service.get_download_url(problem.code)
         except ArchiveServiceError:
             messages.error(request, _('Could not fetch the archived data of %s. Please try again later.')
                            % problem.code)

--- a/judge/views/widgets.py
+++ b/judge/views/widgets.py
@@ -23,11 +23,16 @@ def rejudge_submission(request):
         return HttpResponseBadRequest()
 
     try:
-        submission = Submission.objects.get(id=request.POST['id'])
+        submission = Submission.objects.select_related('problem').get(id=request.POST['id'])
     except Submission.DoesNotExist:
         return HttpResponseBadRequest()
 
-    if not submission.problem.is_rejudgeable_by(request.user):
+    problem = submission.problem
+
+    if problem.is_archived or problem.is_deleted:
+        return HttpResponseForbidden()
+
+    if not problem.is_rejudgeable_by(request.user):
         return HttpResponseForbidden()
 
     submission.judge(rejudge=True, rejudge_user=request.user)

--- a/locale/vi/LC_MESSAGES/django.po
+++ b/locale/vi/LC_MESSAGES/django.po
@@ -1103,40 +1103,6 @@ msgstr "{time}"
 msgid "on {time}"
 msgstr "vào lúc {time}"
 
-#: judge/jinja2/datetime.py:39
-#, python-format
-msgid "%(count)d year ago"
-msgid_plural "%(count)d years ago"
-msgstr[0] "%(count)d năm trước"
-
-#: judge/jinja2/datetime.py:40
-#, python-format
-msgid "%(count)d month ago"
-msgid_plural "%(count)d months ago"
-msgstr[0] "%(count)d tháng trước"
-
-#: judge/jinja2/datetime.py:41
-#, python-format
-msgid "%(count)d day ago"
-msgid_plural "%(count)d days ago"
-msgstr[0] "%(count)d ngày trước"
-
-#: judge/jinja2/datetime.py:42
-#, python-format
-msgid "%(count)d hour ago"
-msgid_plural "%(count)d hours ago"
-msgstr[0] "%(count)d giờ trước"
-
-#: judge/jinja2/datetime.py:43
-#, python-format
-msgid "%(count)d minute ago"
-msgid_plural "%(count)d minutes ago"
-msgstr[0] "%(count)d phút trước"
-
-#: judge/jinja2/datetime.py:59
-msgid "just now"
-msgstr "vừa xong"
-
 #: judge/jinja2/filesize.py:33
 #, python-format
 msgid "%s B"
@@ -7212,6 +7178,18 @@ msgstr "Tổng kích thước"
 #: templates/organization/usage.html:417
 msgid "Last Submission"
 msgstr "Lần nộp cuối"
+
+#: templates/organization/problem-table.html:27
+msgid "Archived"
+msgstr "Đã lưu trữ"
+
+#: templates/organization/problem-table.html:28
+msgid "Deletes In"
+msgstr "Xoá sau"
+
+#: templates/organization/problem-table-js.html:99
+msgid "any moment now"
+msgstr "bất cứ lúc nào"
 
 #: templates/organization/usage.html:418 templates/submission/status.html:74
 msgid "Download"

--- a/locale/vi/LC_MESSAGES/django.po
+++ b/locale/vi/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dmoj\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-23 15:15+0000\n"
+"POT-Creation-Date: 2026-08-23 16:15+0000\n"
 "PO-Revision-Date: 2020-08-23 18:59\n"
 "Last-Translator: \n"
 "Language-Team: Vietnamese\n"
@@ -795,7 +795,7 @@ msgid "You must solve at least %d problems before you can update your profile."
 msgstr ""
 "Bạn phải giải ít nhất %d bài trước khi có thể thay đổi thông tin người dùng"
 
-#: judge/forms.py:92 judge/views/organization.py:296 judge/views/register.py:61
+#: judge/forms.py:92 judge/views/organization.py:297 judge/views/register.py:61
 #, python-brace-format
 msgid "You may not be part of more than {count} public organization."
 msgid_plural "You may not be part of more than {count} public organizations."
@@ -1345,7 +1345,7 @@ msgid "terms"
 msgstr "điều khoản"
 
 #: judge/models/contest.py:91 judge/models/problem.py:673
-#: judge/models/runtime.py:153 judge/views/organization.py:1162
+#: judge/models/runtime.py:153 judge/views/organization.py:1163
 msgid "problems"
 msgstr "bài"
 
@@ -2609,11 +2609,11 @@ msgstr "tập tin dữ liệu nén dạng zip"
 msgid "generator file"
 msgstr "trình sinh test"
 
-#: judge/models/problem_data.py:62 judge/models/problem_data.py:150
+#: judge/models/problem_data.py:62 judge/models/problem_data.py:157
 msgid "output prefix length"
 msgstr "độ dài tiền tố output"
 
-#: judge/models/problem_data.py:63 judge/models/problem_data.py:151
+#: judge/models/problem_data.py:63 judge/models/problem_data.py:158
 msgid "output limit length"
 msgstr "hạn chế chiều dài đầu ra"
 
@@ -2621,7 +2621,7 @@ msgstr "hạn chế chiều dài đầu ra"
 msgid "init.yml generation feedback"
 msgstr "phản hồi init.yml"
 
-#: judge/models/problem_data.py:65 judge/models/problem_data.py:152
+#: judge/models/problem_data.py:65 judge/models/problem_data.py:159
 msgid "checker"
 msgstr "trình chấm"
 
@@ -2637,11 +2637,11 @@ msgstr "bật unicode"
 msgid "disable bigInteger / bigDecimal"
 msgstr "tắt bigInteger / bigDecimal"
 
-#: judge/models/problem_data.py:69 judge/models/problem_data.py:153
+#: judge/models/problem_data.py:69 judge/models/problem_data.py:160
 msgid "checker arguments"
 msgstr "tham số của trình chấm"
 
-#: judge/models/problem_data.py:70 judge/models/problem_data.py:154
+#: judge/models/problem_data.py:70 judge/models/problem_data.py:161
 msgid "Checker arguments as a JSON object."
 msgstr "tham số của trình chấm là một JSON"
 
@@ -2673,47 +2673,55 @@ msgstr "kích thước dữ liệu test"
 msgid "Size of the test data zip file in bytes."
 msgstr "Kích thước file zip dữ liệu test tính bằng byte."
 
-#: judge/models/problem_data.py:137
+#: judge/models/problem_data.py:98
+msgid "archived test data storage size"
+msgstr "kích thước dữ liệu test đã lưu trữ"
+
+#: judge/models/problem_data.py:99
+msgid "Size of the test data zip file in bytes when archived."
+msgstr "Kích thước file zip dữ liệu test khi được lưu trữ, tính bằng byte."
+
+#: judge/models/problem_data.py:144
 msgid "problem data set"
 msgstr "tập dữ liệu bài"
 
-#: judge/models/problem_data.py:139
+#: judge/models/problem_data.py:146
 msgid "case position"
 msgstr "vị trí phép thử"
 
-#: judge/models/problem_data.py:140
+#: judge/models/problem_data.py:147
 msgid "case type"
 msgstr "kiểu test"
 
-#: judge/models/problem_data.py:141
+#: judge/models/problem_data.py:148
 msgid "Normal case"
 msgstr "Test đơn"
 
-#: judge/models/problem_data.py:142
+#: judge/models/problem_data.py:149
 msgid "Batch start"
 msgstr "Bắt đầu nhóm test"
 
-#: judge/models/problem_data.py:143
+#: judge/models/problem_data.py:150
 msgid "Batch end"
 msgstr "Hết nhóm test"
 
-#: judge/models/problem_data.py:145
+#: judge/models/problem_data.py:152
 msgid "input file name"
 msgstr "tên file input"
 
-#: judge/models/problem_data.py:146
+#: judge/models/problem_data.py:153
 msgid "output file name"
 msgstr "tên file output"
 
-#: judge/models/problem_data.py:147
+#: judge/models/problem_data.py:154
 msgid "generator arguments"
 msgstr "tham số trình sinh"
 
-#: judge/models/problem_data.py:148
+#: judge/models/problem_data.py:155
 msgid "point value"
 msgstr "điểm"
 
-#: judge/models/problem_data.py:149
+#: judge/models/problem_data.py:156
 msgid "case is pretest?"
 msgstr "là pretests?"
 
@@ -3756,8 +3764,8 @@ msgid ""
 "storage (%s). Please delete some problems or free up storage before creating "
 "new ones."
 msgstr ""
-"Tổ chức đã đạt giới hạn số bài tập tối đa (%d) và/hoặc dung lượng lưu trữ (%s). "
-"Vui lòng xóa một số bài hoặc giải phóng dung lượng trước khi tạo thêm."
+"Tổ chức đã đạt giới hạn số bài tập tối đa (%d) và/hoặc dung lượng lưu trữ "
+"(%s). Vui lòng xóa một số bài hoặc giải phóng dung lượng trước khi tạo thêm."
 
 #: judge/utils/pdfoid.py:22
 #, python-brace-format
@@ -3928,8 +3936,8 @@ msgid "Creating new blog post"
 msgstr "Tạo blog mới"
 
 #: judge/views/blog.py:379 judge/views/contests.py:1468
-#: judge/views/organization.py:474 judge/views/organization.py:995
-#: judge/views/organization.py:1019 judge/views/problem.py:956
+#: judge/views/organization.py:475 judge/views/organization.py:996
+#: judge/views/organization.py:1020 judge/views/problem.py:956
 #: judge/views/tag.py:182
 msgid "Created on site"
 msgstr "Tạo trên trang web"
@@ -3953,7 +3961,7 @@ msgid "Updating blog post"
 msgstr "Cập nhật blog"
 
 #: judge/views/blog.py:426 judge/views/comment.py:142
-#: judge/views/contests.py:1538 judge/views/organization.py:524
+#: judge/views/contests.py:1538 judge/views/organization.py:525
 #: judge/views/problem.py:1123
 msgid "Edited from site"
 msgstr "Chỉnh sửa từ trang web"
@@ -4335,264 +4343,264 @@ msgstr "Cài đặt trang web"
 msgid "Notifications"
 msgstr "Thông báo"
 
-#: judge/views/organization.py:94
+#: judge/views/organization.py:95
 msgid "Cannot view other organizations"
 msgstr "Không thể xem tổ chức khác"
 
-#: judge/views/organization.py:95
+#: judge/views/organization.py:96
 msgid "You cannot view other organizations"
 msgstr "Bạn không thể xem tổ chức khác."
 
-#: judge/views/organization.py:101 judge/views/organization.py:104
+#: judge/views/organization.py:102 judge/views/organization.py:105
 msgid "No such organization"
 msgstr "Không có tổ chức như vậy"
 
-#: judge/views/organization.py:102
+#: judge/views/organization.py:103
 #, python-format
 msgid "Could not find an organization with the key \"%s\"."
 msgstr "Không thể tìm thấy một tổ chức với khóa \"%s\"."
 
-#: judge/views/organization.py:105
+#: judge/views/organization.py:106
 msgid "Could not find such organization."
 msgstr "Không thể tìm thấy các tổ chức như vậy."
 
-#: judge/views/organization.py:140
+#: judge/views/organization.py:141
 msgid "Cannot view organization's private data"
 msgstr "Không thể xem các dữ liệu riêng tư của tổ chức"
 
-#: judge/views/organization.py:141
+#: judge/views/organization.py:142
 msgid "You must join the organization to view its private data."
 msgstr "Bạn phải tham gia tổ chức để xem các dữ liệu riêng tư của tổ chức."
 
-#: judge/views/organization.py:156
+#: judge/views/organization.py:157
 msgid "Can't edit organization"
 msgstr "Không thể chỉnh sửa tổ chức"
 
-#: judge/views/organization.py:157
+#: judge/views/organization.py:158
 msgid "You are not allowed to edit this organization."
 msgstr "Bạn không có quyền chỉnh sửa tổ chức này."
 
-#: judge/views/organization.py:174 judge/views/register.py:36
+#: judge/views/organization.py:175 judge/views/register.py:36
 #: templates/blog/top-rating.html:32 templates/user/user-list-tabs.html:6
 msgid "Organizations"
 msgstr "Tổ chức"
 
-#: judge/views/organization.py:245 templates/organization/list.html:32
+#: judge/views/organization.py:246 templates/organization/list.html:32
 msgid "Members"
 msgstr "Các thành viên"
 
-#: judge/views/organization.py:287 judge/views/organization.py:290
-#: judge/views/organization.py:295
+#: judge/views/organization.py:288 judge/views/organization.py:291
+#: judge/views/organization.py:296
 msgid "Joining organization"
 msgstr "Đang tham gia tổ chức"
 
-#: judge/views/organization.py:287
+#: judge/views/organization.py:288
 msgid "You are already in the organization."
 msgstr "Bạn đã trong tổ chức."
 
-#: judge/views/organization.py:290
+#: judge/views/organization.py:291
 msgid "This organization is not open."
 msgstr "Tổ chức này không phải là mở."
 
-#: judge/views/organization.py:308 judge/views/organization.py:310
+#: judge/views/organization.py:309 judge/views/organization.py:311
 msgid "Leaving organization"
 msgstr "Rời khỏi tổ chức"
 
-#: judge/views/organization.py:308
+#: judge/views/organization.py:309
 #, python-format
 msgid "You are not in \"%s\"."
 msgstr "Bạn đang không ở trong \"%s\"."
 
-#: judge/views/organization.py:310
+#: judge/views/organization.py:311
 msgid "You cannot leave an organization you own."
 msgstr "Bạn không thể rời tổ chức của chính mình."
 
-#: judge/views/organization.py:326
+#: judge/views/organization.py:327
 #, python-format
 msgid "Can't request to join %s"
 msgstr "Không thể yêu cầu tham gia %s"
 
-#: judge/views/organization.py:327
+#: judge/views/organization.py:328
 #, python-format
 msgid "You already have a pending request to join %s."
 msgstr "Bạn đã có yêu cầu đang chờ để tham gia %s."
 
-#: judge/views/organization.py:334
+#: judge/views/organization.py:335
 #, python-format
 msgid "Request to join %s"
 msgstr "Yêu cầu tham gia %s"
 
-#: judge/views/organization.py:352
+#: judge/views/organization.py:353
 msgid "Join request detail"
 msgstr "Chi tiết yêu cầu tham gia"
 
-#: judge/views/organization.py:384 judge/views/organization.py:385
+#: judge/views/organization.py:385 judge/views/organization.py:386
 #, python-format
 msgid "Managing join requests for %s"
 msgstr "Quản lý các yêu cầu tham gia %s"
 
-#: judge/views/organization.py:419
+#: judge/views/organization.py:420
 #, python-format
 msgid "Your organization can only receive %d more member."
 msgid_plural "Your organization can only receive %d more members."
 msgstr[0] "Tổ chức của bạn chỉ có thể nhận thêm %d thành viên."
 
-#: judge/views/organization.py:421
+#: judge/views/organization.py:422
 #, python-format
 msgid "You cannot approve %d user."
 msgid_plural "You cannot approve %d users."
 msgstr[0] "Bạn không thể chấp nhận %d thành viên."
 
-#: judge/views/organization.py:434
+#: judge/views/organization.py:435
 #, python-format
 msgid "Approved %d user."
 msgid_plural "Approved %d users."
 msgstr[0] "Đã chấp nhận %d thành viên."
 
-#: judge/views/organization.py:435
+#: judge/views/organization.py:436
 #, python-format
 msgid "Rejected %d user."
 msgid_plural "Rejected %d users."
 msgstr[0] "Đã từ chối %d thành viên."
 
-#: judge/views/organization.py:465 templates/organization/list-tabs.html:12
+#: judge/views/organization.py:466 templates/organization/list-tabs.html:12
 msgid "Create new organization"
 msgstr "Tạo tổ chức mới"
 
-#: judge/views/organization.py:493 judge/views/organization.py:497
+#: judge/views/organization.py:494 judge/views/organization.py:498
 msgid "Can't create organization"
 msgstr "Không thể tạo tổ chức"
 
-#: judge/views/organization.py:498
+#: judge/views/organization.py:499
 msgid "You are not allowed to create new organizations."
 msgstr "Bạn không có quyền tạo tổ chức mới."
 
-#: judge/views/organization.py:507
+#: judge/views/organization.py:508
 #, python-format
 msgid "Editing %s"
 msgstr "Đang chỉnh sửa %s"
 
-#: judge/views/organization.py:568
+#: judge/views/organization.py:569
 #, python-format
 msgid "Tags of %s"
 msgstr "Dạng bài của %s"
 
-#: judge/views/organization.py:595 judge/views/organization.py:615
+#: judge/views/organization.py:596 judge/views/organization.py:616
 msgid "A tag with this name already exists."
 msgstr "Dạng bài cùng tên đã tồn tại."
 
-#: judge/views/organization.py:636 judge/views/organization.py:640
-#: judge/views/organization.py:645
+#: judge/views/organization.py:637 judge/views/organization.py:641
+#: judge/views/organization.py:646
 msgid "Can't kick user"
 msgstr "Không thể loại thành viên"
 
-#: judge/views/organization.py:637
+#: judge/views/organization.py:638
 msgid "The user you are trying to kick does not exist!"
 msgstr "Thành viên bạn muốn loại không tồn tại!"
 
-#: judge/views/organization.py:641
+#: judge/views/organization.py:642
 #, python-format
 msgid "The user you are trying to kick is not in organization: %s"
 msgstr "Thành viên mà bạn muốn loại không thuộc tổ chức: %s."
 
-#: judge/views/organization.py:646
+#: judge/views/organization.py:647
 #, python-format
 msgid "The user you are trying to kick is an admin of organization: %s."
 msgstr "Thành viên mà bạn muốn loại là admin của tổ chức: %s."
 
-#: judge/views/organization.py:825
+#: judge/views/organization.py:826
 msgid "No such member"
 msgstr "Không có thành viên"
 
-#: judge/views/organization.py:826
+#: judge/views/organization.py:827
 #, python-format
 msgid "Could not find a member with the username \"%s\" in this organization."
 msgstr ""
 "Không thể tìm thấy thành viên với tên đăng nhập \"%s\" trong tổ chức này."
 
-#: judge/views/organization.py:843
+#: judge/views/organization.py:844
 msgid "Untagged"
 msgstr "Chưa phân loại"
 
-#: judge/views/organization.py:879
+#: judge/views/organization.py:880
 msgid "No problems selected for deletion."
 msgstr "Chưa chọn bài tập nào để xóa."
 
-#: judge/views/organization.py:883
+#: judge/views/organization.py:884
 #, python-format
 msgid "Cannot delete more than %d problems at once."
 msgstr "Không thể xóa quá %d bài tập cùng lúc."
 
-#: judge/views/organization.py:897
+#: judge/views/organization.py:898
 #, python-format
 msgid "%d problem was skipped because you are not its author."
 msgid_plural "%d problems were skipped because you are not their author."
 msgstr[0] "%d bài tập đã bị bỏ qua vì bạn không phải tác giả."
 
-#: judge/views/organization.py:908
+#: judge/views/organization.py:909
 msgid "Bulk marked as deleted"
 msgstr "Đã đánh dấu xóa hàng loạt"
 
-#: judge/views/organization.py:912
+#: judge/views/organization.py:913
 #, python-format
 msgid "Successfully deleted %d problem."
 msgid_plural "Successfully deleted %d problems."
 msgstr[0] "Đã xóa thành công %d bài tập."
 
-#: judge/views/organization.py:917
+#: judge/views/organization.py:918
 msgid "No valid problems could be deleted."
 msgstr "Không có bài tập hợp lệ nào để xóa."
 
-#: judge/views/organization.py:1060
+#: judge/views/organization.py:1061
 #, python-format
 msgid "Organization cost - %s"
 msgstr "Chi phí của tổ chức - %s"
 
-#: judge/views/organization.py:1143 templates/organization/usage.html:235
+#: judge/views/organization.py:1144 templates/organization/usage.html:235
 #: templates/organization/usage.html:236 templates/organization/usage.html:237
 #: templates/organization/usage.html:238
 #, python-format
 msgid "Last submission %(months)d+ months ago"
 msgstr "Lần nộp cuối %(months)d+ tháng trước"
 
-#: judge/views/organization.py:1144
+#: judge/views/organization.py:1145
 #, python-format
 msgid "Last submission %(from)d-%(to)d months ago"
 msgstr "Lần nộp cuối %(from)d-%(to)d tháng trước"
 
-#: judge/views/organization.py:1145
+#: judge/views/organization.py:1146
 #, python-format
 msgid "Last submission < %(months)d months ago"
 msgstr "Lần nộp cuối < %(months)d+ tháng trước"
 
-#: judge/views/organization.py:1147 templates/contest/moss.html:61
+#: judge/views/organization.py:1148 templates/contest/moss.html:61
 #: templates/organization/usage.html:239
 msgid "No submissions"
 msgstr "Không có bài nộp"
 
-#: judge/views/organization.py:1184
+#: judge/views/organization.py:1185
 msgid "Current month"
 msgstr "Tháng hiện tại"
 
-#: judge/views/organization.py:1188
+#: judge/views/organization.py:1189
 msgid "Credit usage (hour)"
 msgstr "Số giờ chấm bài"
 
-#: judge/views/organization.py:1191
+#: judge/views/organization.py:1192
 msgid "Cost (thousand vnd)"
 msgstr "chi phí (nghìn đồng)"
 
-#: judge/views/organization.py:1227
+#: judge/views/organization.py:1228
 #, python-format
 msgid "Archived problems - %s"
 msgstr "Bài tập đã lưu trữ - %s"
 
-#: judge/views/organization.py:1272
+#: judge/views/organization.py:1273
 #, python-format
 msgid "Could not restore %s from the archive. Please try again later."
 msgstr "Không thể khôi phục %s từ kho lưu trữ. Vui lòng thử lại sau."
 
-#: judge/views/organization.py:1278
+#: judge/views/organization.py:1287
 #, python-format
 msgid "%s has been restored from the archive."
 msgstr "%s đã được khôi phục từ kho lưu trữ."
@@ -4791,7 +4799,9 @@ msgstr "Không tìm thấy bài nộp nào."
 msgid ""
 "Problem %s has been archived, so it can no longer be edited. Restore it from "
 "the archive if needed."
-msgstr "Bài tập %s đã được lưu trữ, không thể chỉnh sửa nữa. Hãy khôi phục từ kho lưu trữ nếu cần."
+msgstr ""
+"Bài tập %s đã được lưu trữ, không thể chỉnh sửa nữa. Hãy khôi phục từ kho "
+"lưu trữ nếu cần."
 
 #: judge/views/problem_data.py:227
 msgid "Problem data archived"
@@ -6813,7 +6823,17 @@ msgstr "Đánh dấu tất cả đã đọc"
 msgid "You have no notifications."
 msgstr "Bạn không có thông báo nào."
 
-#: templates/organization/archived.html:32
+#: templates/organization/archived.html:24
+#, python-format
+msgid ""
+"Archived problems are permanently deleted %(days)d days after they were "
+"archived, along with their data. Download anything you still need before "
+"then."
+msgstr ""
+"Các bài tập đã lưu trữ sẽ bị xóa vĩnh viễn sau %(days)d ngày kể từ khi được lưu trữ, "
+"cùng với dữ liệu của chúng. Hãy tải xuống những gì bạn cần trước thời hạn đó."
+
+#: templates/organization/archived.html:30
 msgid "Show all archived problems"
 msgstr "Hiển thị tất cả bài tập đã lưu trữ"
 

--- a/locale/vi/LC_MESSAGES/django.po
+++ b/locale/vi/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dmoj\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-14 08:48+0000\n"
+"POT-Creation-Date: 2026-08-23 15:15+0000\n"
 "PO-Revision-Date: 2020-08-23 18:59\n"
 "Last-Translator: \n"
 "Language-Team: Vietnamese\n"
@@ -51,11 +51,11 @@ msgstr "Quản trị"
 msgid "Teacher"
 msgstr "Giáo viên"
 
-#: dmoj/settings.py:625
+#: dmoj/settings.py:632
 msgid "English"
 msgstr "Tiếng Anh"
 
-#: dmoj/settings.py:626
+#: dmoj/settings.py:633
 msgid "Vietnamese"
 msgstr "Tiếng Việt"
 
@@ -244,7 +244,7 @@ msgid "%d participation recalculated."
 msgid_plural "%d participations recalculated."
 msgstr[0] "%d lượt tham gia đã được tính lại."
 
-#: judge/admin/contest.py:426 judge/admin/organization.py:111
+#: judge/admin/contest.py:426 judge/admin/organization.py:112
 msgid "username"
 msgstr "tên người dùng"
 
@@ -261,14 +261,14 @@ msgid "Summary"
 msgstr "Tóm tắt"
 
 #: judge/admin/interface.py:102 judge/admin/problem.py:174
-#: judge/models/interface.py:82 judge/models/problem.py:708
+#: judge/models/interface.py:82 judge/models/problem.py:716
 msgid "authors"
 msgstr "tác giả"
 
 #: judge/admin/interface.py:132 judge/admin/profile.py:112
 #: judge/admin/submission.py:223 judge/models/contest.py:636
-#: judge/models/contest.py:805 judge/models/profile.py:560
-#: judge/models/profile.py:591 judge/models/ticket.py:48
+#: judge/models/contest.py:805 judge/models/profile.py:566
+#: judge/models/profile.py:597 judge/models/ticket.py:48
 msgid "user"
 msgstr "thành viên"
 
@@ -276,34 +276,34 @@ msgstr "thành viên"
 msgid "object"
 msgstr "đối tượng"
 
-#: judge/admin/organization.py:26
+#: judge/admin/organization.py:27
 msgid "Additional storage (GB)"
 msgstr "Dung lượng lưu trữ thêm (GB)"
 
-#: judge/admin/organization.py:27
+#: judge/admin/organization.py:28
 msgid ""
 "Decimal values allowed, e.g. 1.5. Leave blank for no additional storage."
 msgstr ""
 "Cho phép số thập phân, ví dụ 1.5. Để trống nếu không có dung lượng thêm."
 
-#: judge/admin/organization.py:55
+#: judge/admin/organization.py:56
 msgid "Quota Grant"
 msgstr "Cấp phát hạn mức"
 
-#: judge/admin/organization.py:56 templates/organization/edit.html:56
+#: judge/admin/organization.py:57 templates/organization/edit.html:56
 msgid "Quota Grants"
 msgstr "Các hạn mức đã cấp"
 
-#: judge/admin/organization.py:74 judge/admin/problem.py:180
+#: judge/admin/organization.py:75 judge/admin/problem.py:180
 #: judge/admin/profile.py:110
 msgid "View on site"
 msgstr "Xem trên trang web"
 
-#: judge/admin/organization.py:96 judge/admin/profile.py:128
+#: judge/admin/organization.py:97 judge/admin/profile.py:128
 msgid "Recalculate scores"
 msgstr "Tính lại điểm"
 
-#: judge/admin/organization.py:102
+#: judge/admin/organization.py:103
 #, python-format
 msgid "%d organization has scores recalculated."
 msgid_plural "%d organizations have scores recalculated."
@@ -469,7 +469,7 @@ msgstr "mã bài"
 msgid "problem name"
 msgstr "tên bài toán"
 
-#: judge/admin/submission.py:227 judge/models/profile.py:224
+#: judge/admin/submission.py:227 judge/models/profile.py:230
 msgid "time"
 msgstr "thời gian"
 
@@ -487,8 +487,8 @@ msgstr "%d KB"
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: judge/admin/submission.py:241 judge/models/problem.py:670
-#: judge/models/problem.py:689 judge/models/runtime.py:120
+#: judge/admin/submission.py:241 judge/models/problem.py:678
+#: judge/models/problem.py:697 judge/models/runtime.py:120
 msgid "language"
 msgstr "ngôn ngữ"
 
@@ -795,7 +795,7 @@ msgid "You must solve at least %d problems before you can update your profile."
 msgstr ""
 "Bạn phải giải ít nhất %d bài trước khi có thể thay đổi thông tin người dùng"
 
-#: judge/forms.py:92 judge/views/organization.py:284 judge/views/register.py:61
+#: judge/forms.py:92 judge/views/organization.py:296 judge/views/register.py:61
 #, python-brace-format
 msgid "You may not be part of more than {count} public organization."
 msgid_plural "You may not be part of more than {count} public organizations."
@@ -1246,7 +1246,7 @@ msgid "comments"
 msgstr "nhận xét"
 
 #: judge/models/comment.py:92 judge/models/comment.py:153
-#: judge/models/problem.py:719
+#: judge/models/problem.py:727
 #, python-format
 msgid "Editorial for %s"
 msgstr "Hướng giải cho %s"
@@ -1344,8 +1344,8 @@ msgstr "mô tả"
 msgid "terms"
 msgstr "điều khoản"
 
-#: judge/models/contest.py:91 judge/models/problem.py:665
-#: judge/models/runtime.py:153 judge/views/organization.py:1150
+#: judge/models/contest.py:91 judge/models/problem.py:673
+#: judge/models/runtime.py:153 judge/views/organization.py:1162
 msgid "problems"
 msgstr "bài"
 
@@ -1366,7 +1366,7 @@ msgid "registration end time"
 msgstr "thời gian kết thúc đăng ký"
 
 #: judge/models/contest.py:98 judge/models/problem.py:199
-#: judge/models/problem.py:690
+#: judge/models/problem.py:698
 msgid "time limit"
 msgstr "giới hạn thời gian"
 
@@ -1526,15 +1526,15 @@ msgid ""
 "not."
 msgstr "Hiện tóm tắt các cài đặt của kỳ thi ở trang kỳ thi."
 
-#: judge/models/contest.py:157 judge/models/problem.py:256
+#: judge/models/contest.py:157 judge/models/problem.py:258
 msgid "private to organizations"
 msgstr "dành riêng cho tổ chức"
 
 #: judge/models/contest.py:158 judge/models/interface.py:93
-#: judge/models/problem.py:65 judge/models/problem.py:253
-#: judge/models/profile.py:188 judge/models/profile.py:195
-#: judge/models/profile.py:222 judge/models/profile.py:262
-#: judge/models/profile.py:592
+#: judge/models/problem.py:65 judge/models/problem.py:255
+#: judge/models/profile.py:194 judge/models/profile.py:201
+#: judge/models/profile.py:228 judge/models/profile.py:268
+#: judge/models/profile.py:598
 msgid "organization"
 msgstr "tổ chức"
 
@@ -1547,7 +1547,7 @@ msgstr "Nếu là private, thì chỉ các tổ chức này mới có thể xem 
 msgid "OpenGraph image"
 msgstr "Ảnh OpenGraph"
 
-#: judge/models/contest.py:162 judge/models/profile.py:66
+#: judge/models/contest.py:162 judge/models/profile.py:68
 msgid "logo override image"
 msgstr "Logo"
 
@@ -1575,7 +1575,7 @@ msgstr ""
 "Các thông tin này sẽ hiển thị khi chia sẻ kỳ thi lên mạng xã hội (ví dụ "
 "discord, facebook)."
 
-#: judge/models/contest.py:171 judge/models/profile.py:65
+#: judge/models/contest.py:171 judge/models/profile.py:67
 msgid "access code"
 msgstr "mã truy cập"
 
@@ -1664,7 +1664,7 @@ msgstr "bảng xếp hạng chính thức"
 msgid "Official ranking exported from CMS in CSV format."
 msgstr "Bảng xếp hạng chính thức xuất từ CMS dưới dạng CSV."
 
-#: judge/models/contest.py:196 judge/models/profile.py:305
+#: judge/models/contest.py:196 judge/models/profile.py:311
 msgid "last data download time"
 msgstr "thời gian tải gần nhất"
 
@@ -1835,8 +1835,8 @@ msgid "contest participations"
 msgstr "tham gia kỳ thi"
 
 #: judge/models/contest.py:766 judge/models/contest.py:790
-#: judge/models/contest.py:831 judge/models/problem.py:664
-#: judge/models/problem.py:669 judge/models/problem.py:688
+#: judge/models/contest.py:831 judge/models/problem.py:672
+#: judge/models/problem.py:677 judge/models/problem.py:696
 #: judge/models/problem_data.py:56
 msgid "problem"
 msgstr "vấn đề"
@@ -1995,7 +1995,7 @@ msgstr "các nhãn blog"
 msgid "post title"
 msgstr "tiêu đề bài viết"
 
-#: judge/models/interface.py:84 judge/models/problem.py:706
+#: judge/models/interface.py:84 judge/models/problem.py:714
 msgid "public visibility"
 msgstr "hiển thị công khai"
 
@@ -2308,7 +2308,7 @@ msgstr ""
 "Giới hạn thời gian (tính bằng giây) cho bài tập này. Phần lẻ giây (chẳng hạn "
 "1.5) cũng được hỗ trợ."
 
-#: judge/models/problem.py:204 judge/models/problem.py:693
+#: judge/models/problem.py:204 judge/models/problem.py:701
 msgid "memory limit"
 msgstr "giới hạn bộ nhớ"
 
@@ -2401,123 +2401,131 @@ msgstr "Kết quả test case nào nên hiển thị cho người dùng?"
 msgid "deleted at"
 msgstr "thời điểm xoá"
 
-#: judge/models/problem.py:255
+#: judge/models/problem.py:247
+msgid "archived at"
+msgstr "lưu trữ lúc"
+
+#: judge/models/problem.py:248
+msgid "When set, this problem's data has been moved to cold storage."
+msgstr "Khi được đặt, dữ liệu của bài tập này đã được đưa vào kho lưu trữ."
+
+#: judge/models/problem.py:257
 msgid "If private, only this organization may see the problem."
 msgstr "Nếu riêng tư, chỉ những tổ chức này có thể xem bài tập."
 
-#: judge/models/problem.py:259
+#: judge/models/problem.py:261
 msgid "Allow user to view checker feedback."
 msgstr "Cho phép người dùng xem phản hồi của checker."
 
-#: judge/models/problem.py:647
+#: judge/models/problem.py:653
 msgid "See hidden problems"
 msgstr "Xem bài ẩn"
 
-#: judge/models/problem.py:648
+#: judge/models/problem.py:654
 msgid "Edit own problems"
 msgstr "Sửa bài của mình"
 
-#: judge/models/problem.py:649
+#: judge/models/problem.py:655
 msgid "Create organization problem"
 msgstr "Tạo bài trong tổ chức"
 
-#: judge/models/problem.py:650
+#: judge/models/problem.py:656
 msgid "Edit all problems"
 msgstr "Sửa tất cả bài"
 
-#: judge/models/problem.py:651
+#: judge/models/problem.py:657
 msgid "Edit all public problems"
 msgstr "Sửa tất cả bài công khai"
 
-#: judge/models/problem.py:652
+#: judge/models/problem.py:658
 msgid "Edit problems with full markup"
 msgstr "Sửa bài với quyền Markdown đầy đủ"
 
-#: judge/models/problem.py:653 templates/problem/problem.html:254
+#: judge/models/problem.py:659 templates/problem/problem.html:254
 msgid "Clone problem"
 msgstr "Nhân bản bài"
 
-#: judge/models/problem.py:654
+#: judge/models/problem.py:660
 msgid "Upload file-type statement"
 msgstr "Tải lên đề bài dạng file"
 
-#: judge/models/problem.py:655
+#: judge/models/problem.py:661
 msgid "Change is_public field"
 msgstr "Thay đổi trường is_public"
 
-#: judge/models/problem.py:656
+#: judge/models/problem.py:662
 msgid "Change is_manually_managed field"
 msgstr "Thay đổi trường is_manually_managed"
 
-#: judge/models/problem.py:657
+#: judge/models/problem.py:663
 msgid "See organization-private problems"
 msgstr "Xem bài riêng tư của tổ chức"
 
-#: judge/models/problem.py:658
+#: judge/models/problem.py:664
 msgid "Import Codeforces Polygon package"
 msgstr "Nhập gói Codeforces Polygon"
 
-#: judge/models/problem.py:659
+#: judge/models/problem.py:665
 msgid "Edit type and group for all problems"
 msgstr "Sửa loại và nhóm cho tất cả bài"
 
-#: judge/models/problem.py:671
+#: judge/models/problem.py:679
 msgid "translated name"
 msgstr "tên bộ dịch"
 
-#: judge/models/problem.py:672
+#: judge/models/problem.py:680
 msgid "translated description"
 msgstr "mô tả bộ dịch"
 
-#: judge/models/problem.py:677
+#: judge/models/problem.py:685
 msgid "problem translation"
 msgstr "dịch đầu bài"
 
-#: judge/models/problem.py:678
+#: judge/models/problem.py:686
 msgid "problem translations"
 msgstr "dịch đầu bài"
 
-#: judge/models/problem.py:682
+#: judge/models/problem.py:690
 msgid "clarified problem"
 msgstr "bài tập được làm rõ"
 
-#: judge/models/problem.py:683
+#: judge/models/problem.py:691
 msgid "clarification body"
 msgstr "nội dung làm rõ"
 
-#: judge/models/problem.py:684
+#: judge/models/problem.py:692
 msgid "clarification timestamp"
 msgstr "thời gian làm rõ"
 
-#: judge/models/problem.py:699
+#: judge/models/problem.py:707
 msgid "language-specific resource limit"
 msgstr "giới hạn theo ngôn ngữ"
 
-#: judge/models/problem.py:700
+#: judge/models/problem.py:708
 msgid "language-specific resource limits"
 msgstr "giới hạn theo ngôn ngữ"
 
-#: judge/models/problem.py:704
+#: judge/models/problem.py:712
 msgid "associated problem"
 msgstr "bài liên quan"
 
-#: judge/models/problem.py:707
+#: judge/models/problem.py:715
 msgid "publish date"
 msgstr "ngày công bố"
 
-#: judge/models/problem.py:709
+#: judge/models/problem.py:717
 msgid "editorial content"
 msgstr "nội dung lời giải"
 
-#: judge/models/problem.py:732
+#: judge/models/problem.py:740
 msgid "See hidden solutions"
 msgstr "Xem lời giải ẩn"
 
-#: judge/models/problem.py:734
+#: judge/models/problem.py:742
 msgid "solution"
 msgstr "lời giải"
 
-#: judge/models/problem.py:735
+#: judge/models/problem.py:743
 msgid "solutions"
 msgstr "lời giải"
 
@@ -2734,407 +2742,415 @@ msgid "organization description"
 msgstr "mô tả tổ chức"
 
 #: judge/models/profile.py:54
+msgid "organization notice"
+msgstr "thông báo tổ chức"
+
+#: judge/models/profile.py:55
+msgid "Warning banner shown to the administrators of this organization."
+msgstr "Banner cảnh báo hiển thị cho quản trị viên của tổ chức này."
+
+#: judge/models/profile.py:56
 msgid "administrators"
 msgstr "quản trị viên"
 
-#: judge/models/profile.py:55
+#: judge/models/profile.py:57
 msgid "Those who can edit this organization."
 msgstr "Những người có thể chỉnh sửa tổ chức"
 
-#: judge/models/profile.py:56
+#: judge/models/profile.py:58
 msgid "creation date"
 msgstr "ngày tạo"
 
-#: judge/models/profile.py:57
+#: judge/models/profile.py:59
 msgid "is open organization?"
 msgstr "tổ chức công khai"
 
-#: judge/models/profile.py:58
+#: judge/models/profile.py:60
 msgid "Allow joining organization."
 msgstr "Nếu chọn, mọi người đều có thể tham gia tổ chức."
 
-#: judge/models/profile.py:59
+#: judge/models/profile.py:61
 msgid "is unlisted organization?"
 msgstr "tổ chức ẩn"
 
-#: judge/models/profile.py:60
+#: judge/models/profile.py:62
 msgid "Organization will not be listed"
 msgstr "Tổ chức sẽ không được liệt kê trong danh sách tổ chức"
 
-#: judge/models/profile.py:61
+#: judge/models/profile.py:63
 msgid "maximum size"
 msgstr "số thành viên tối đa"
 
-#: judge/models/profile.py:62
+#: judge/models/profile.py:64
 msgid ""
 "Maximum amount of users in this organization, only applicable to private "
 "organizations."
 msgstr ""
 "Số người dùng tối đa trong tổ chức này, chỉ áp dụng đối với tổ chức riêng tư"
 
-#: judge/models/profile.py:64
+#: judge/models/profile.py:66
 msgid "Student access code."
 msgstr "Mã truy cập sinh viên"
 
-#: judge/models/profile.py:68
+#: judge/models/profile.py:70
 msgid ""
 "This image will replace the default site logo for users viewing the "
 "organization."
 msgstr ""
 "Ảnh này sẽ thay thế logo mặc định của trang khi thành viên xem tổ chức."
 
-#: judge/models/profile.py:73
+#: judge/models/profile.py:75
 msgid "Remaining purchased credits"
 msgstr "Tín dụng đã mua còn lại"
 
-#: judge/models/profile.py:76
+#: judge/models/profile.py:78
 msgid "Remaining free credits for the current month"
 msgstr "Tín dụng miễn phí còn lại trong tháng này"
 
-#: judge/models/profile.py:81
+#: judge/models/profile.py:83
 msgid "Amount of free credits allocated each month"
 msgstr "Số credit miễn phí được cấp mỗi tháng"
 
-#: judge/models/profile.py:183
+#: judge/models/profile.py:189
 msgid "Administer organizations"
 msgstr "Quản lý tổ chức"
 
-#: judge/models/profile.py:184
+#: judge/models/profile.py:190
 msgid "Edit all organizations"
 msgstr "Chỉnh sửa toàn bộ tổ chức"
 
-#: judge/models/profile.py:185
+#: judge/models/profile.py:191
 msgid "Change is_open field"
 msgstr "Chỉnh sửa is_open field"
 
-#: judge/models/profile.py:186
+#: judge/models/profile.py:192
 msgid "Create organization without limit"
 msgstr "Không giới hạn tạo tổ chức"
 
-#: judge/models/profile.py:189
+#: judge/models/profile.py:195
 msgid "organizations"
 msgstr "tổ chức"
 
-#: judge/models/profile.py:199
+#: judge/models/profile.py:205
 msgid "start date"
 msgstr "ngày bắt đầu"
 
-#: judge/models/profile.py:200
+#: judge/models/profile.py:206
 msgid "end date"
 msgstr "ngày kết thúc"
 
-#: judge/models/profile.py:202
+#: judge/models/profile.py:208
 msgid "additional problems"
 msgstr "bài tập bổ sung"
 
-#: judge/models/profile.py:204
+#: judge/models/profile.py:210
 msgid "Number of additional problems allowed above the default limit."
 msgstr "Số bài tập được thêm so với giới hạn mặc định."
 
-#: judge/models/profile.py:207
+#: judge/models/profile.py:213
 msgid "additional storage (bytes)"
 msgstr "dung lượng lưu trữ thêm (bytes)"
 
-#: judge/models/profile.py:209
+#: judge/models/profile.py:215
 msgid "Additional storage allowed above the default limit, in bytes."
 msgstr "Dung lượng lưu trữ thêm so với giới hạn mặc định, tính bằng bytes."
 
-#: judge/models/profile.py:213
+#: judge/models/profile.py:219
 msgid "organization quota"
 msgstr "hạn mức tổ chức"
 
-#: judge/models/profile.py:214
+#: judge/models/profile.py:220
 msgid "organization quotas"
 msgstr "hạn mức tổ chức"
 
-#: judge/models/profile.py:225
+#: judge/models/profile.py:231
 msgid "consumed credit"
 msgstr "tín dụng đã dùng"
 
-#: judge/models/profile.py:228
+#: judge/models/profile.py:234
 msgid "organization monthly usage"
 msgstr "lượng sử dụng hàng tháng của tổ chức"
 
-#: judge/models/profile.py:229
+#: judge/models/profile.py:235
 msgid "organization monthly usages"
 msgstr "lượng sử dụng hàng tháng của các tổ chức"
 
-#: judge/models/profile.py:234
+#: judge/models/profile.py:240
 msgid "badge name"
 msgstr "tên huy hiệu"
 
-#: judge/models/profile.py:235
+#: judge/models/profile.py:241
 msgid "mini badge URL"
 msgstr "URL huy hiệu nhỏ"
 
-#: judge/models/profile.py:236
+#: judge/models/profile.py:242
 msgid "full size badge URL"
 msgstr "URL huy hiệu cỡ đầy đủ"
 
-#: judge/models/profile.py:243
+#: judge/models/profile.py:249
 msgid "user associated"
 msgstr "người sử dụng tương ứng"
 
-#: judge/models/profile.py:244
+#: judge/models/profile.py:250
 msgid "self-description"
 msgstr "tự mô tả"
 
-#: judge/models/profile.py:245
+#: judge/models/profile.py:251
 msgid "time zone"
 msgstr "múi giờ"
 
-#: judge/models/profile.py:247
+#: judge/models/profile.py:253
 msgid "preferred language"
 msgstr "ngôn ngữ"
 
-#: judge/models/profile.py:254
+#: judge/models/profile.py:260
 msgid "Ace theme"
 msgstr "Chủ đề Ace"
 
-#: judge/models/profile.py:255
+#: judge/models/profile.py:261
 msgid "site theme"
 msgstr "giao diện trang web"
 
-#: judge/models/profile.py:256 urlshortener/models.py:16
+#: judge/models/profile.py:262 urlshortener/models.py:16
 msgid "last access time"
 msgstr "lần truy cập cuối cùng"
 
-#: judge/models/profile.py:257
+#: judge/models/profile.py:263
 msgid "last IP"
 msgstr "IP"
 
-#: judge/models/profile.py:258
+#: judge/models/profile.py:264
 msgid "IP-based authentication"
 msgstr "xác thực qua IP"
 
-#: judge/models/profile.py:260
+#: judge/models/profile.py:266
 msgid "badges"
 msgstr "huy hiệu"
 
-#: judge/models/profile.py:261
+#: judge/models/profile.py:267
 msgid "display badge"
 msgstr "huy hiệu hiển thị"
 
-#: judge/models/profile.py:264
+#: judge/models/profile.py:270
 msgid "display rank"
 msgstr "hiển thị xếp hạng"
 
-#: judge/models/profile.py:266
+#: judge/models/profile.py:272
 msgid "comment mute"
 msgstr "tắt bình luận"
 
-#: judge/models/profile.py:266
+#: judge/models/profile.py:272
 msgid "Some users are at their best when silent."
 msgstr "Một vài người tốt nhất là khi im lặng."
 
-#: judge/models/profile.py:268
+#: judge/models/profile.py:274
 msgid "unlisted user"
 msgstr "thành viên không được liệt kê"
 
-#: judge/models/profile.py:268
+#: judge/models/profile.py:274
 msgid "User will not be ranked."
 msgstr "Thành viên không được xếp hạng."
 
-#: judge/models/profile.py:271
+#: judge/models/profile.py:277
 msgid "Show to banned user in login page."
 msgstr "Hiển thị cho người dùng bị cấm ở trang đăng nhập."
 
-#: judge/models/profile.py:272
+#: judge/models/profile.py:278
 msgid "Allow tagging"
 msgstr "Cho phép tag bài"
 
-#: judge/models/profile.py:273
+#: judge/models/profile.py:279
 msgid "User will be allowed to tag problems."
 msgstr "Người dùng có thể tag bài."
 
-#: judge/models/profile.py:276
+#: judge/models/profile.py:282
 msgid "user script"
 msgstr "script tự định nghĩa"
 
-#: judge/models/profile.py:277
+#: judge/models/profile.py:283
 msgid "User-defined JavaScript for site customization."
 msgstr "JavaScript tự định nghĩa bởi người dùng để tùy chỉnh."
 
-#: judge/models/profile.py:278
+#: judge/models/profile.py:284
 msgid "current contest"
 msgstr "kỳ thi hiện tại"
 
-#: judge/models/profile.py:280
+#: judge/models/profile.py:286
 msgid "math engine"
 msgstr "bộ xử lý toán học"
 
-#: judge/models/profile.py:282
+#: judge/models/profile.py:288
 msgid "The rendering engine used to render math."
 msgstr "chọn công cụ để hiện công thức toán"
 
-#: judge/models/profile.py:283
+#: judge/models/profile.py:289
 msgid "TOTP 2FA enabled"
 msgstr "Đã bật 2FA TOTP"
 
-#: judge/models/profile.py:284
+#: judge/models/profile.py:290
 msgid "Check to enable TOTP-based two-factor authentication."
 msgstr "Chọn để bật xác thực hai yếu tố dựa trên TOTP."
 
-#: judge/models/profile.py:285
+#: judge/models/profile.py:291
 msgid "WebAuthn 2FA enabled"
 msgstr "Đã bật 2FA WebAuthn"
 
-#: judge/models/profile.py:286
+#: judge/models/profile.py:292
 msgid "Check to enable WebAuthn-based two-factor authentication."
 msgstr "Chọn để bật xác thực hai yếu tố dựa trên WebAuthn."
 
-#: judge/models/profile.py:287
+#: judge/models/profile.py:293
 msgid "TOTP key"
 msgstr "Mã TOTP"
 
-#: judge/models/profile.py:288
+#: judge/models/profile.py:294
 msgid "32-character Base32-encoded key for TOTP."
 msgstr "mã 32 ký tự base32-encoded cho TOTP"
 
-#: judge/models/profile.py:290
+#: judge/models/profile.py:296
 msgid "TOTP key must be empty or Base32."
 msgstr "Mã TOTP cần rỗng hoặc base32"
 
-#: judge/models/profile.py:291
+#: judge/models/profile.py:297
 msgid "scratch codes"
 msgstr "mã dự phòng"
 
-#: judge/models/profile.py:292
+#: judge/models/profile.py:298
 msgid "JSON array of 16-character Base32-encoded codes for scratch codes."
 msgstr "Mảng JSON các mã Base32 16 ký tự dùng làm mã dự phòng."
 
-#: judge/models/profile.py:296
+#: judge/models/profile.py:302
 msgid ""
 "Scratch codes must be empty or a JSON array of 16-character Base32 codes."
 msgstr ""
 "Mã dự phòng phải để trống hoặc là mảng JSON gồm các mã Base32 16 ký tự."
 
-#: judge/models/profile.py:298
+#: judge/models/profile.py:304
 msgid "last TOTP timecode"
 msgstr "mã thời gian TOTP cuối"
 
-#: judge/models/profile.py:299
+#: judge/models/profile.py:305
 msgid "API token"
 msgstr "Token API"
 
-#: judge/models/profile.py:300
+#: judge/models/profile.py:306
 msgid "64-character hex-encoded API access token."
 msgstr "Token truy cập API được mã hóa hex 64 ký tự."
 
-#: judge/models/profile.py:302
+#: judge/models/profile.py:308
 msgid "API token must be None or hexadecimal"
 msgstr "Token API phải là None hoặc dạng thập lục phân"
 
-#: judge/models/profile.py:303
+#: judge/models/profile.py:309
 msgid "internal notes"
 msgstr "ghi chú nội bộ"
 
-#: judge/models/profile.py:304
+#: judge/models/profile.py:310
 msgid "Notes for administrators regarding this user."
 msgstr "Ghi chú cho quản trị viên chấm lại cho thành viên này."
 
-#: judge/models/profile.py:306
+#: judge/models/profile.py:312
 msgid "display name override"
 msgstr "tên hiển thị thay thế"
 
-#: judge/models/profile.py:307
+#: judge/models/profile.py:313
 msgid "Name displayed in place of username."
 msgstr "Tên hiển thị thay thế cho tên người dùng."
 
-#: judge/models/profile.py:540
+#: judge/models/profile.py:546
 msgid "Shows in-progress development stuff"
 msgstr "Hiển thị các tính năng đang phát triển"
 
-#: judge/models/profile.py:541
+#: judge/models/profile.py:547
 msgid "Edit TOTP settings"
 msgstr "Chỉnh sửa cài đặt TOTP"
 
-#: judge/models/profile.py:542
+#: judge/models/profile.py:548
 msgid "Can upload image directly to server via martor"
 msgstr "Có thể tải ảnh trực tiếp lên máy chủ qua martor"
 
-#: judge/models/profile.py:543
+#: judge/models/profile.py:549
 msgid "Can set high problem timelimit"
 msgstr "Có thể đặt giới hạn thời gian cao cho bài"
 
-#: judge/models/profile.py:544
+#: judge/models/profile.py:550
 msgid "Can set long contest duration"
 msgstr "Có thể đặt thời lượng kỳ thi dài"
 
-#: judge/models/profile.py:545
+#: judge/models/profile.py:551
 msgid "Can create unlimitted number of testcases for a problem"
 msgstr "Có thể tạo số lượng test case không giới hạn cho bài"
 
-#: judge/models/profile.py:546
+#: judge/models/profile.py:552
 msgid "Ban users"
 msgstr "Cấm người dùng"
 
-#: judge/models/profile.py:548
+#: judge/models/profile.py:554
 msgid "user profile"
 msgstr "hồ sơ người dùng"
 
-#: judge/models/profile.py:549
+#: judge/models/profile.py:555
 msgid "user profiles"
 msgstr "hồ sơ người dùng"
 
-#: judge/models/profile.py:562
+#: judge/models/profile.py:568
 msgid "device name"
 msgstr "tên thiết bị"
 
-#: judge/models/profile.py:563
+#: judge/models/profile.py:569
 msgid "credential ID"
 msgstr "ID thông tin xác thực"
 
-#: judge/models/profile.py:564
+#: judge/models/profile.py:570
 msgid "public key"
 msgstr "khóa công khai"
 
-#: judge/models/profile.py:565
+#: judge/models/profile.py:571
 msgid "sign counter"
 msgstr "bộ đếm ký"
 
-#: judge/models/profile.py:583
+#: judge/models/profile.py:589
 #, python-format
 msgid "WebAuthn credential: %(name)s"
 msgstr "Thông tin xác thực WebAuthn: %(name)s"
 
-#: judge/models/profile.py:586
+#: judge/models/profile.py:592
 msgid "WebAuthn credential"
 msgstr "Thông tin xác thực WebAuthn"
 
-#: judge/models/profile.py:587
+#: judge/models/profile.py:593
 msgid "WebAuthn credentials"
 msgstr "Các thông tin xác thực WebAuthn"
 
-#: judge/models/profile.py:594
+#: judge/models/profile.py:600
 msgid "request time"
 msgstr "thời gian yêu cầu"
 
-#: judge/models/profile.py:595
+#: judge/models/profile.py:601
 msgid "state"
 msgstr "trạng thái"
 
-#: judge/models/profile.py:596 templates/organization/requests/tabs.html:4
+#: judge/models/profile.py:602 templates/organization/requests/tabs.html:4
 msgid "Pending"
 msgstr "Đang chờ"
 
-#: judge/models/profile.py:597 templates/organization/requests/tabs.html:10
+#: judge/models/profile.py:603 templates/organization/requests/tabs.html:10
 msgid "Approved"
 msgstr "Phê duyệt"
 
-#: judge/models/profile.py:598 templates/organization/requests/tabs.html:13
+#: judge/models/profile.py:604 templates/organization/requests/tabs.html:13
 msgid "Rejected"
 msgstr "Bị từ chối"
 
-#: judge/models/profile.py:600
+#: judge/models/profile.py:606
 msgid "reason"
 msgstr "lý do"
 
-#: judge/models/profile.py:603
+#: judge/models/profile.py:609
 msgid "organization join request"
 msgstr "yêu cầu tham gia tổ chức"
 
-#: judge/models/profile.py:604
+#: judge/models/profile.py:610
 msgid "organization join requests"
 msgstr "yêu cầu tham gia tổ chức"
 
@@ -3729,6 +3745,20 @@ msgstr "Đang chuẩn bị dữ liệu về bài nộp của bạn"
 msgid "Preparing your comment data"
 msgstr "Đang chuẩn bị dữ liệu về bình luận của bạn"
 
+#: judge/utils/organization.py:10
+msgid "Problem limit reached"
+msgstr "Đã đạt giới hạn bài tập"
+
+#: judge/utils/organization.py:11
+#, python-format
+msgid ""
+"This organization has reached its maximum number of problems (%d) and/or "
+"storage (%s). Please delete some problems or free up storage before creating "
+"new ones."
+msgstr ""
+"Tổ chức đã đạt giới hạn số bài tập tối đa (%d) và/hoặc dung lượng lưu trữ (%s). "
+"Vui lòng xóa một số bài hoặc giải phóng dung lượng trước khi tạo thêm."
+
 #: judge/utils/pdfoid.py:22
 #, python-brace-format
 msgid "Page {page_number} of {total_pages}"
@@ -3898,8 +3928,8 @@ msgid "Creating new blog post"
 msgstr "Tạo blog mới"
 
 #: judge/views/blog.py:379 judge/views/contests.py:1468
-#: judge/views/organization.py:462 judge/views/organization.py:983
-#: judge/views/organization.py:1007 judge/views/problem.py:956
+#: judge/views/organization.py:474 judge/views/organization.py:995
+#: judge/views/organization.py:1019 judge/views/problem.py:956
 #: judge/views/tag.py:182
 msgid "Created on site"
 msgstr "Tạo trên trang web"
@@ -3923,7 +3953,7 @@ msgid "Updating blog post"
 msgstr "Cập nhật blog"
 
 #: judge/views/blog.py:426 judge/views/comment.py:142
-#: judge/views/contests.py:1538 judge/views/organization.py:512
+#: judge/views/contests.py:1538 judge/views/organization.py:524
 #: judge/views/problem.py:1123
 msgid "Edited from site"
 msgstr "Chỉnh sửa từ trang web"
@@ -4305,264 +4335,267 @@ msgstr "Cài đặt trang web"
 msgid "Notifications"
 msgstr "Thông báo"
 
-#: judge/views/organization.py:82
+#: judge/views/organization.py:94
 msgid "Cannot view other organizations"
 msgstr "Không thể xem tổ chức khác"
 
-#: judge/views/organization.py:83
+#: judge/views/organization.py:95
 msgid "You cannot view other organizations"
 msgstr "Bạn không thể xem tổ chức khác."
 
-#: judge/views/organization.py:89 judge/views/organization.py:92
+#: judge/views/organization.py:101 judge/views/organization.py:104
 msgid "No such organization"
 msgstr "Không có tổ chức như vậy"
 
-#: judge/views/organization.py:90
+#: judge/views/organization.py:102
 #, python-format
 msgid "Could not find an organization with the key \"%s\"."
 msgstr "Không thể tìm thấy một tổ chức với khóa \"%s\"."
 
-#: judge/views/organization.py:93
+#: judge/views/organization.py:105
 msgid "Could not find such organization."
 msgstr "Không thể tìm thấy các tổ chức như vậy."
 
-#: judge/views/organization.py:128
+#: judge/views/organization.py:140
 msgid "Cannot view organization's private data"
 msgstr "Không thể xem các dữ liệu riêng tư của tổ chức"
 
-#: judge/views/organization.py:129
+#: judge/views/organization.py:141
 msgid "You must join the organization to view its private data."
 msgstr "Bạn phải tham gia tổ chức để xem các dữ liệu riêng tư của tổ chức."
 
-#: judge/views/organization.py:144
+#: judge/views/organization.py:156
 msgid "Can't edit organization"
 msgstr "Không thể chỉnh sửa tổ chức"
 
-#: judge/views/organization.py:145
+#: judge/views/organization.py:157
 msgid "You are not allowed to edit this organization."
 msgstr "Bạn không có quyền chỉnh sửa tổ chức này."
 
-#: judge/views/organization.py:162 judge/views/register.py:36
+#: judge/views/organization.py:174 judge/views/register.py:36
 #: templates/blog/top-rating.html:32 templates/user/user-list-tabs.html:6
 msgid "Organizations"
 msgstr "Tổ chức"
 
-#: judge/views/organization.py:233 templates/organization/list.html:32
+#: judge/views/organization.py:245 templates/organization/list.html:32
 msgid "Members"
 msgstr "Các thành viên"
 
-#: judge/views/organization.py:275 judge/views/organization.py:278
-#: judge/views/organization.py:283
+#: judge/views/organization.py:287 judge/views/organization.py:290
+#: judge/views/organization.py:295
 msgid "Joining organization"
 msgstr "Đang tham gia tổ chức"
 
-#: judge/views/organization.py:275
+#: judge/views/organization.py:287
 msgid "You are already in the organization."
 msgstr "Bạn đã trong tổ chức."
 
-#: judge/views/organization.py:278
+#: judge/views/organization.py:290
 msgid "This organization is not open."
 msgstr "Tổ chức này không phải là mở."
 
-#: judge/views/organization.py:296 judge/views/organization.py:298
+#: judge/views/organization.py:308 judge/views/organization.py:310
 msgid "Leaving organization"
 msgstr "Rời khỏi tổ chức"
 
-#: judge/views/organization.py:296
+#: judge/views/organization.py:308
 #, python-format
 msgid "You are not in \"%s\"."
 msgstr "Bạn đang không ở trong \"%s\"."
 
-#: judge/views/organization.py:298
+#: judge/views/organization.py:310
 msgid "You cannot leave an organization you own."
 msgstr "Bạn không thể rời tổ chức của chính mình."
 
-#: judge/views/organization.py:314
+#: judge/views/organization.py:326
 #, python-format
 msgid "Can't request to join %s"
 msgstr "Không thể yêu cầu tham gia %s"
 
-#: judge/views/organization.py:315
+#: judge/views/organization.py:327
 #, python-format
 msgid "You already have a pending request to join %s."
 msgstr "Bạn đã có yêu cầu đang chờ để tham gia %s."
 
-#: judge/views/organization.py:322
+#: judge/views/organization.py:334
 #, python-format
 msgid "Request to join %s"
 msgstr "Yêu cầu tham gia %s"
 
-#: judge/views/organization.py:340
+#: judge/views/organization.py:352
 msgid "Join request detail"
 msgstr "Chi tiết yêu cầu tham gia"
 
-#: judge/views/organization.py:372 judge/views/organization.py:373
+#: judge/views/organization.py:384 judge/views/organization.py:385
 #, python-format
 msgid "Managing join requests for %s"
 msgstr "Quản lý các yêu cầu tham gia %s"
 
-#: judge/views/organization.py:407
+#: judge/views/organization.py:419
 #, python-format
 msgid "Your organization can only receive %d more member."
 msgid_plural "Your organization can only receive %d more members."
 msgstr[0] "Tổ chức của bạn chỉ có thể nhận thêm %d thành viên."
 
-#: judge/views/organization.py:409
+#: judge/views/organization.py:421
 #, python-format
 msgid "You cannot approve %d user."
 msgid_plural "You cannot approve %d users."
 msgstr[0] "Bạn không thể chấp nhận %d thành viên."
 
-#: judge/views/organization.py:422
+#: judge/views/organization.py:434
 #, python-format
 msgid "Approved %d user."
 msgid_plural "Approved %d users."
 msgstr[0] "Đã chấp nhận %d thành viên."
 
-#: judge/views/organization.py:423
+#: judge/views/organization.py:435
 #, python-format
 msgid "Rejected %d user."
 msgid_plural "Rejected %d users."
 msgstr[0] "Đã từ chối %d thành viên."
 
-#: judge/views/organization.py:453 templates/organization/list-tabs.html:12
+#: judge/views/organization.py:465 templates/organization/list-tabs.html:12
 msgid "Create new organization"
 msgstr "Tạo tổ chức mới"
 
-#: judge/views/organization.py:481 judge/views/organization.py:485
+#: judge/views/organization.py:493 judge/views/organization.py:497
 msgid "Can't create organization"
 msgstr "Không thể tạo tổ chức"
 
-#: judge/views/organization.py:486
+#: judge/views/organization.py:498
 msgid "You are not allowed to create new organizations."
 msgstr "Bạn không có quyền tạo tổ chức mới."
 
-#: judge/views/organization.py:495
+#: judge/views/organization.py:507
 #, python-format
 msgid "Editing %s"
 msgstr "Đang chỉnh sửa %s"
 
-#: judge/views/organization.py:556
+#: judge/views/organization.py:568
 #, python-format
 msgid "Tags of %s"
 msgstr "Dạng bài của %s"
 
-#: judge/views/organization.py:583 judge/views/organization.py:603
+#: judge/views/organization.py:595 judge/views/organization.py:615
 msgid "A tag with this name already exists."
 msgstr "Dạng bài cùng tên đã tồn tại."
 
-#: judge/views/organization.py:624 judge/views/organization.py:628
-#: judge/views/organization.py:633
+#: judge/views/organization.py:636 judge/views/organization.py:640
+#: judge/views/organization.py:645
 msgid "Can't kick user"
 msgstr "Không thể loại thành viên"
 
-#: judge/views/organization.py:625
+#: judge/views/organization.py:637
 msgid "The user you are trying to kick does not exist!"
 msgstr "Thành viên bạn muốn loại không tồn tại!"
 
-#: judge/views/organization.py:629
+#: judge/views/organization.py:641
 #, python-format
 msgid "The user you are trying to kick is not in organization: %s"
 msgstr "Thành viên mà bạn muốn loại không thuộc tổ chức: %s."
 
-#: judge/views/organization.py:634
+#: judge/views/organization.py:646
 #, python-format
 msgid "The user you are trying to kick is an admin of organization: %s."
 msgstr "Thành viên mà bạn muốn loại là admin của tổ chức: %s."
 
-#: judge/views/organization.py:813
+#: judge/views/organization.py:825
 msgid "No such member"
 msgstr "Không có thành viên"
 
-#: judge/views/organization.py:814
+#: judge/views/organization.py:826
 #, python-format
 msgid "Could not find a member with the username \"%s\" in this organization."
-msgstr "Không thể tìm thấy thành viên với tên đăng nhập \"%s\" trong tổ chức này."
+msgstr ""
+"Không thể tìm thấy thành viên với tên đăng nhập \"%s\" trong tổ chức này."
 
-#: judge/views/organization.py:831
+#: judge/views/organization.py:843
 msgid "Untagged"
 msgstr "Chưa phân loại"
 
-#: judge/views/organization.py:858
+#: judge/views/organization.py:879
 msgid "No problems selected for deletion."
 msgstr "Chưa chọn bài tập nào để xóa."
 
-#: judge/views/organization.py:862
+#: judge/views/organization.py:883
 #, python-format
 msgid "Cannot delete more than %d problems at once."
 msgstr "Không thể xóa quá %d bài tập cùng lúc."
 
-#: judge/views/organization.py:876
+#: judge/views/organization.py:897
 #, python-format
 msgid "%d problem was skipped because you are not its author."
 msgid_plural "%d problems were skipped because you are not their author."
 msgstr[0] "%d bài tập đã bị bỏ qua vì bạn không phải tác giả."
 
-#: judge/views/organization.py:887
+#: judge/views/organization.py:908
 msgid "Bulk marked as deleted"
 msgstr "Đã đánh dấu xóa hàng loạt"
 
-#: judge/views/organization.py:891
+#: judge/views/organization.py:912
 #, python-format
 msgid "Successfully deleted %d problem."
 msgid_plural "Successfully deleted %d problems."
 msgstr[0] "Đã xóa thành công %d bài tập."
 
-#: judge/views/organization.py:896
+#: judge/views/organization.py:917
 msgid "No valid problems could be deleted."
 msgstr "Không có bài tập hợp lệ nào để xóa."
 
-#: judge/views/organization.py:940
-msgid "Problem limit reached"
-msgstr "Đã đạt giới hạn bài tập"
-
-#: judge/views/organization.py:941
-#, python-format
-msgid ""
-"This organization has reached its maximum number of problems (%d). Please "
-"delete some problems before creating new ones."
-msgstr ""
-"Tổ chức đã đạt giới hạn số bài tập tối đa (%d). Vui lòng xóa một số bài "
-"trước khi tạo thêm."
-
-#: judge/views/organization.py:1048
+#: judge/views/organization.py:1060
 #, python-format
 msgid "Organization cost - %s"
 msgstr "Chi phí của tổ chức - %s"
 
-#: judge/views/organization.py:1131 templates/organization/usage.html:351
-#: templates/organization/usage.html:352 templates/organization/usage.html:353
-#: templates/organization/usage.html:354
+#: judge/views/organization.py:1143 templates/organization/usage.html:235
+#: templates/organization/usage.html:236 templates/organization/usage.html:237
+#: templates/organization/usage.html:238
 #, python-format
 msgid "Last submission %(months)d+ months ago"
 msgstr "Lần nộp cuối %(months)d+ tháng trước"
 
-#: judge/views/organization.py:1132
+#: judge/views/organization.py:1144
 #, python-format
 msgid "Last submission %(from)d-%(to)d months ago"
 msgstr "Lần nộp cuối %(from)d-%(to)d tháng trước"
 
-#: judge/views/organization.py:1133
+#: judge/views/organization.py:1145
 #, python-format
 msgid "Last submission < %(months)d months ago"
 msgstr "Lần nộp cuối < %(months)d+ tháng trước"
 
-#: judge/views/organization.py:1135 templates/contest/moss.html:61
-#: templates/organization/usage.html:355
+#: judge/views/organization.py:1147 templates/contest/moss.html:61
+#: templates/organization/usage.html:239
 msgid "No submissions"
 msgstr "Không có bài nộp"
 
-#: judge/views/organization.py:1172
+#: judge/views/organization.py:1184
 msgid "Current month"
 msgstr "Tháng hiện tại"
 
-#: judge/views/organization.py:1176
+#: judge/views/organization.py:1188
 msgid "Credit usage (hour)"
 msgstr "Số giờ chấm bài"
 
-#: judge/views/organization.py:1179
+#: judge/views/organization.py:1191
 msgid "Cost (thousand vnd)"
 msgstr "chi phí (nghìn đồng)"
+
+#: judge/views/organization.py:1227
+#, python-format
+msgid "Archived problems - %s"
+msgstr "Bài tập đã lưu trữ - %s"
+
+#: judge/views/organization.py:1272
+#, python-format
+msgid "Could not restore %s from the archive. Please try again later."
+msgstr "Không thể khôi phục %s từ kho lưu trữ. Vui lòng thử lại sau."
+
+#: judge/views/organization.py:1278
+#, python-format
+msgid "%s has been restored from the archive."
+msgstr "%s đã được khôi phục từ kho lưu trữ."
 
 #: judge/views/problem.py:94 judge/views/tag.py:45
 msgid "No such problem"
@@ -4701,74 +4734,85 @@ msgstr "Không thể xoá bài"
 msgid "You are not allowed to delete this problem."
 msgstr "Bạn không được phép xoá bài tập này."
 
-#: judge/views/problem_data.py:41
+#: judge/views/problem_data.py:43
 msgid "Checker arguments must be a JSON object."
 msgstr "Tham số trình chấm phải là một JSON"
 
-#: judge/views/problem_data.py:43
+#: judge/views/problem_data.py:45
 msgid "Checker arguments is invalid JSON."
 msgstr "Tham số trình chấm không hợp lệ (không phải JSON)"
 
-#: judge/views/problem_data.py:53
+#: judge/views/problem_data.py:55
 msgid "Grader arguments must be a JSON object"
 msgstr "Tham số grader phải là một JSON"
 
-#: judge/views/problem_data.py:55
+#: judge/views/problem_data.py:57
 msgid "Grader arguments is invalid JSON"
 msgstr "Tham số grader không hợp lệ (không phải JSON)"
 
-#: judge/views/problem_data.py:60
+#: judge/views/problem_data.py:62
 msgid "IO Method"
 msgstr "Phương thức IO"
 
-#: judge/views/problem_data.py:62
+#: judge/views/problem_data.py:64
 msgid "Input from file"
 msgstr "Tập tin đầu vào"
 
-#: judge/views/problem_data.py:63
+#: judge/views/problem_data.py:65
 msgid "Output to file"
 msgstr "Tập tin đầu ra"
 
-#: judge/views/problem_data.py:68
+#: judge/views/problem_data.py:70
 msgid "Your zip file is invalid!"
 msgstr "File nén bị lỗi!"
 
-#: judge/views/problem_data.py:89
+#: judge/views/problem_data.py:91
 msgid ""
 "Can be left blank. In case the output can be too long (over 20MB), please "
 "set this."
 msgstr ""
 "Có thể bỏ trống. Chỉ thay đổi nếu độ dài của output quá dài (hơn 20Mb)."
 
-#: judge/views/problem_data.py:139 judge/views/problem_data.py:142
+#: judge/views/problem_data.py:141 judge/views/problem_data.py:144
 #, python-brace-format
 msgid "Comparing submissions for {0}"
 msgstr "So sánh các bài nộp cho {0}"
 
-#: judge/views/problem_data.py:182
+#: judge/views/problem_data.py:184
 msgid "No such submissions"
 msgstr "Không thấy bài nộp"
 
-#: judge/views/problem_data.py:182
+#: judge/views/problem_data.py:184
 msgid "Could not find any submissions."
 msgstr "Không tìm thấy bài nộp nào."
 
-#: judge/views/problem_data.py:189
+#: judge/views/problem_data.py:212
+#, python-format
+msgid ""
+"Problem %s has been archived, so it can no longer be edited. Restore it from "
+"the archive if needed."
+msgstr "Bài tập %s đã được lưu trữ, không thể chỉnh sửa nữa. Hãy khôi phục từ kho lưu trữ nếu cần."
+
+#: judge/views/problem_data.py:227
+msgid "Problem data archived"
+msgstr "Dữ liệu bài tập đã được lưu trữ"
+
+#: judge/views/problem_data.py:230
 #, python-brace-format
 msgid "Editing data for {0}"
 msgstr "Sửa dữ liệu cho {0}"
 
-#: judge/views/problem_data.py:192
+#: judge/views/problem_data.py:233
 #, python-format
 msgid "Editing data for %s"
 msgstr "Chỉnh sửa các dữ liệu cho %s"
 
-#: judge/views/problem_data.py:249
+#: judge/views/problem_data.py:290
 #, python-format
 msgid "Too many testcases, number of testcases must not exceed %s"
 msgstr "Quá nhiều testcase, số lượng testcase không được vượt quá %s"
 
-#: judge/views/problem_data.py:261
+#: judge/views/problem_data.py:302
 #, python-format
 msgid ""
 "Storage limit exceeded for organization \"%(org)s\". Please delete some test "
@@ -4777,10 +4821,15 @@ msgstr ""
 "Dung lượng lưu trữ đã vượt giới hạn cho tổ chức \"%(org)s\". Vui lòng xóa "
 "một số dữ liệu test trước khi tải lên thêm."
 
-#: judge/views/problem_data.py:332 judge/views/problem_data.py:333
+#: judge/views/problem_data.py:373 judge/views/problem_data.py:374
 #, python-format
 msgid "Generated init.yml for %s"
 msgstr "Tạo file Init.yml cho %s"
+
+#: judge/views/problem_download.py:119
+#, python-format
+msgid "Could not fetch the archived data of %s. Please try again later."
+msgstr "Không thể tải dữ liệu đã lưu trữ của %s. Vui lòng thử lại sau."
 
 #: judge/views/problem_manage.py:51 judge/views/problem_manage.py:54
 #, python-format
@@ -5204,7 +5253,7 @@ msgstr "Đặt lại mật khẩu"
 msgid "You have sent too many password reset requests. Please try again later."
 msgstr "Bạn đã gửi quá nhiều yêu cầu đặt lại mật khẩu. Vui lòng thử lại sau."
 
-#: judge/views/widgets.py:87
+#: judge/views/widgets.py:92
 msgid "You do not have permission to upload images"
 msgstr "Bạn không có quyền tải ảnh lên."
 
@@ -5355,11 +5404,11 @@ msgid "Change"
 msgstr "Thay đổi"
 
 #: templates/admin/judge/app_index.html:23 templates/blog/edit.html:55
-#: templates/contest/edit.html:390
+#: templates/contest/edit.html:390 templates/organization/problem-table.html:32
+#: templates/organization/problem-table.html:109
 #: templates/organization/tag-confirm-delete.html:19
 #: templates/organization/tags.html:142 templates/organization/tags.html:163
-#: templates/organization/tags.html:210 templates/organization/usage.html:419
-#: templates/organization/usage.html:458
+#: templates/organization/tags.html:210
 #: templates/problem/confirm_delete.html:43 templates/problem/editor.html:231
 #: templates/urlshortener/confirm_delete.html:91
 #: templates/urlshortener/detail.html:101 templates/urlshortener/list.html:73
@@ -6539,7 +6588,7 @@ msgstr "Bạn có chắc muốn truất quyền tham dự này không?"
 msgid "Are you sure you want to un-disqualify this participation?"
 msgstr "Bạn có chắc muốn hủy truất quyền tham dự này không?"
 
-#: templates/contest/ranking.html:472 templates/organization/usage.html:387
+#: templates/contest/ranking.html:472 templates/organization/usage.html:271
 msgid "Filter"
 msgstr "Lọc"
 
@@ -6764,6 +6813,10 @@ msgstr "Đánh dấu tất cả đã đọc"
 msgid "You have no notifications."
 msgstr "Bạn không có thông báo nào."
 
+#: templates/organization/archived.html:32
+msgid "Show all archived problems"
+msgstr "Hiển thị tất cả bài tập đã lưu trữ"
+
 #: templates/organization/create-limit-error.html:4
 #, python-format
 msgid ""
@@ -6778,7 +6831,7 @@ msgstr ""
 msgid "Below are a list of organizations in which you are the administrator:"
 msgstr "Dưới đây là danh sách các tổ chức mà bạn là admin:"
 
-#: templates/organization/edit.html:62 templates/organization/usage.html:285
+#: templates/organization/edit.html:62 templates/organization/usage.html:169
 msgid "Start"
 msgstr "Bắt đầu"
 
@@ -6786,11 +6839,11 @@ msgstr "Bắt đầu"
 msgid "End"
 msgstr "Kết thúc"
 
-#: templates/organization/edit.html:64 templates/organization/usage.html:287
+#: templates/organization/edit.html:64 templates/organization/usage.html:171
 msgid "+ Problems"
 msgstr "+ Bài tập"
 
-#: templates/organization/edit.html:65 templates/organization/usage.html:288
+#: templates/organization/edit.html:65 templates/organization/usage.html:172
 msgid "+ Storage"
 msgstr "+ Dung lượng"
 
@@ -6898,6 +6951,93 @@ msgstr "Tìm tổ chức..."
 #: templates/organization/list.html:79
 msgid "All organizations"
 msgstr "Tất cả tổ chức"
+
+#: templates/organization/notice.html:4
+msgid "Dismiss until this notice changes"
+msgstr "Bỏ qua cho đến khi thông báo này thay đổi"
+
+#: templates/organization/problem-table-js.html:18
+#: templates/organization/problem-table-js.html:23
+msgid "Cannot delete problems from other authors."
+msgstr "Không thể xóa bài tập của tác giả khác."
+
+#: templates/organization/problem-table-js.html:54
+msgid ""
+"Are you sure you want to delete the selected problems? This action cannot be "
+"undone."
+msgstr ""
+"Bạn có chắc muốn xóa các bài tập đã chọn? Hành động này không thể hoàn tác."
+
+#: templates/organization/problem-table-js.html:99
+msgid "any moment now"
+msgstr "bất cứ lúc nào"
+
+#: templates/organization/problem-table.html:10
+msgid "Select All (Current Page)"
+msgstr "Chọn tất cả (Trang hiện tại)"
+
+#: templates/organization/problem-table.html:13
+msgid "Delete Selected"
+msgstr "Xóa đã chọn"
+
+#: templates/organization/problem-table.html:21
+msgid "Problem Code"
+msgstr "Mã bài tập"
+
+#: templates/organization/problem-table.html:22
+msgid "Problem Name"
+msgstr "Tên bài"
+
+#: templates/organization/problem-table.html:23
+msgid "Authors"
+msgstr "Tác giả"
+
+#: templates/organization/problem-table.html:24
+msgid "Total Size"
+msgstr "Tổng kích thước"
+
+#: templates/organization/problem-table.html:25
+msgid "Last Submission"
+msgstr "Lần nộp cuối"
+
+#: templates/organization/problem-table.html:27
+msgid "Archived"
+msgstr "Đã lưu trữ"
+
+#: templates/organization/problem-table.html:28
+msgid "Deletes In"
+msgstr "Xoá sau"
+
+#: templates/organization/problem-table.html:30
+#: templates/submission/status.html:74
+msgid "Download"
+msgstr "Tải về"
+
+#: templates/organization/problem-table.html:31
+#: templates/organization/problem-table.html:99
+msgid "Restore"
+msgstr "Khôi phục"
+
+#: templates/organization/problem-table.html:80
+msgid "Download archived data"
+msgstr "Tải dữ liệu đã lưu trữ"
+
+#: templates/organization/problem-table.html:87
+msgid "Test data"
+msgstr "Dữ liệu test"
+
+#: templates/organization/problem-table.html:118
+#, python-format
+msgid "No archived problem with code \"%(code)s\"."
+msgstr "Không tìm thấy bài lưu trữ với mã \"%(code)s\"."
+
+#: templates/organization/problem-table.html:120
+msgid "No archived problems for this organization."
+msgstr "Không có bài tập lưu trữ nào cho tổ chức này."
+
+#: templates/organization/problem-table.html:123
+msgid "No problems found for this organization."
+msgstr "Không tìm thấy bài nào cho tổ chức này."
 
 #: templates/organization/requests/detail.html:13
 msgid "User:"
@@ -7049,185 +7189,129 @@ msgstr "Xóa dạng bài \"%(name)s\"?"
 msgid "Could not delete tag."
 msgstr "Không thể xóa dạng bài."
 
-#: templates/organization/usage.html:114
-msgid "Filter by author..."
-msgstr "Lọc theo tác giả..."
-
-#: templates/organization/usage.html:131 templates/organization/usage.html:136
-msgid "Cannot delete problems from other authors."
-msgstr "Không thể xóa bài tập của tác giả khác."
-
-#: templates/organization/usage.html:167
-msgid ""
-"Are you sure you want to delete the selected problems? This action cannot be "
-"undone."
-msgstr ""
-"Bạn có chắc muốn xóa các bài tập đã chọn? Hành động này không thể hoàn tác."
-
-#: templates/organization/usage.html:255
+#: templates/organization/usage-inner-tabs.html:9
+#: templates/organization/usage-inner-tabs.html:23
 msgid "Storage usage"
 msgstr "Mức sử dụng dung lượng"
 
-#: templates/organization/usage.html:260
+#: templates/organization/usage-inner-tabs.html:14
+#: templates/organization/usage-inner-tabs.html:28
 msgid "Credit usage"
 msgstr "Chi phí chấm bài"
 
-#: templates/organization/usage.html:271
+#: templates/organization/usage-inner-tabs.html:18
+#: templates/organization/usage-inner-tabs.html:33
+msgid "Archived problems"
+msgstr "Bài tập đã lưu trữ"
+
+#: templates/organization/usage.html:84
+msgid "Filter by author..."
+msgstr "Lọc theo tác giả..."
+
+#: templates/organization/usage.html:155
 msgid "Total used storage: "
 msgstr "Tổng dung lượng đã dùng: "
 
-#: templates/organization/usage.html:274
+#: templates/organization/usage.html:158
 msgid "Number of problems: "
 msgstr "Số lượng bài tập: "
 
-#: templates/organization/usage.html:281
+#: templates/organization/usage.html:165
 msgid "Active Quota Grants"
 msgstr "Các hạn mức"
 
-#: templates/organization/usage.html:286
+#: templates/organization/usage.html:170
 msgid "Expires"
 msgstr "Hết hạn"
 
-#: templates/organization/usage.html:307
+#: templates/organization/usage.html:191
 msgid "Storage limit reached! Please delete some problems to free up space."
 msgstr ""
 "Đã đạt giới hạn lưu trữ! Vui lòng xóa một số bài tập để giải phóng dung "
 "lượng."
 
-#: templates/organization/usage.html:312 templates/problem/data.html:1013
+#: templates/organization/usage.html:196 templates/problem/data.html:1013
 msgid "You are approaching the storage limit"
 msgstr "Bạn đang sắp đạt giới hạn dung lượng lưu trữ"
 
-#: templates/organization/usage.html:313 templates/problem/data.html:1014
+#: templates/organization/usage.html:197 templates/problem/data.html:1014
 msgid "You will not be able to upload test if the limit is exceeded."
 msgstr "Bạn sẽ không thể tải lên dữ liệu test nếu vượt quá giới hạn."
 
-#: templates/organization/usage.html:320 templates/problem/create.html:7
+#: templates/organization/usage.html:204 templates/problem/create.html:7
 msgid ""
 "Problem limit reached! Please delete some problems before creating new ones."
 msgstr "Đã đạt giới hạn số bài tập! Vui lòng xóa một số bài trước khi tạo mới."
 
-#: templates/organization/usage.html:325 templates/problem/create.html:12
+#: templates/organization/usage.html:209 templates/problem/create.html:12
 msgid "You are approaching the problem limit"
 msgstr "Bạn đang sắp đạt giới hạn số lượng bài tập"
 
-#: templates/organization/usage.html:326 templates/problem/create.html:13
+#: templates/organization/usage.html:210 templates/problem/create.html:13
 msgid "You will not be able to create more problems if the limit is exceeded."
 msgstr "Bạn sẽ không thể tạo thêm bài tập nếu vượt quá giới hạn."
 
-#: templates/organization/usage.html:334
+#: templates/organization/usage.html:218
 msgid "Problems by last submission time"
 msgstr "Bài tập theo thời gian nộp bài cuối"
 
-#: templates/organization/usage.html:338
+#: templates/organization/usage.html:222
 msgid "Storage by last submission time"
 msgstr "Dung lượng theo thời gian nộp bài cuối"
 
-#: templates/organization/usage.html:347
+#: templates/organization/usage.html:231
 msgid "Quick filter"
 msgstr "Lọc nhanh"
 
-#: templates/organization/usage.html:349
+#: templates/organization/usage.html:233
 msgid "Select a filter"
 msgstr "Chọn bộ lọc"
 
-#: templates/organization/usage.html:357
+#: templates/organization/usage.html:241
 msgid "Advanced filter"
 msgstr "Bộ lọc nâng cao"
 
-#: templates/organization/usage.html:365
+#: templates/organization/usage.html:249
 msgid "Author"
 msgstr "Tác giả"
 
-#: templates/organization/usage.html:367
+#: templates/organization/usage.html:251
 msgid "All Authors"
 msgstr "Tất cả tác giả"
 
-#: templates/organization/usage.html:377
+#: templates/organization/usage.html:261
 msgid "Last Submission Time"
 msgstr "Thời gian nộp bài cuối"
 
-#: templates/organization/usage.html:390
+#: templates/organization/usage.html:274
 msgid "Reset"
 msgstr "Đặt lại"
 
-#: templates/organization/usage.html:402
-msgid "Select All (Current Page)"
-msgstr "Chọn tất cả (Trang hiện tại)"
-
-#: templates/organization/usage.html:405
-msgid "Delete Selected"
-msgstr "Xóa đã chọn"
-
-#: templates/organization/usage.html:413
-msgid "Problem Code"
-msgstr "Mã bài tập"
-
-#: templates/organization/usage.html:414
-msgid "Problem Name"
-msgstr "Tên bài"
-
-#: templates/organization/usage.html:415
-msgid "Authors"
-msgstr "Tác giả"
-
-#: templates/organization/usage.html:416
-msgid "Total Size"
-msgstr "Tổng kích thước"
-
-#: templates/organization/usage.html:417
-msgid "Last Submission"
-msgstr "Lần nộp cuối"
-
-#: templates/organization/problem-table.html:27
-msgid "Archived"
-msgstr "Đã lưu trữ"
-
-#: templates/organization/problem-table.html:28
-msgid "Deletes In"
-msgstr "Xoá sau"
-
-#: templates/organization/problem-table-js.html:99
-msgid "any moment now"
-msgstr "bất cứ lúc nào"
-
-#: templates/organization/usage.html:418 templates/submission/status.html:74
-msgid "Download"
-msgstr "Tải về"
-
-#: templates/organization/usage.html:450
-msgid "Test data"
-msgstr "Dữ liệu test"
-
-#: templates/organization/usage.html:465
-msgid "No problems found for this organization."
-msgstr "Không tìm thấy bài nào cho tổ chức này."
-
-#: templates/organization/usage.html:479
+#: templates/organization/usage.html:292
 msgid "Available free credits (reset each month): "
 msgstr "Số giờ chấm bài miễn phí còn lại trong tháng: "
 
-#: templates/organization/usage.html:480 templates/organization/usage.html:483
+#: templates/organization/usage.html:293 templates/organization/usage.html:296
 msgid "hours"
 msgstr "giờ"
 
-#: templates/organization/usage.html:480 templates/organization/usage.html:483
+#: templates/organization/usage.html:293 templates/organization/usage.html:296
 msgid "minutes"
 msgstr "phút"
 
-#: templates/organization/usage.html:480 templates/organization/usage.html:483
+#: templates/organization/usage.html:293 templates/organization/usage.html:296
 msgid "seconds"
 msgstr "giây"
 
-#: templates/organization/usage.html:482
+#: templates/organization/usage.html:295
 msgid "Available paid credits: "
 msgstr "Số giờ chấm bài trả phí còn lại: "
 
-#: templates/organization/usage.html:489
+#: templates/organization/usage.html:302
 msgid "Organization Monthly cost"
 msgstr "Chi phí chấm bài hàng tháng"
 
-#: templates/organization/usage.html:499
+#: templates/organization/usage.html:312
 msgid "Organization Monthly Credit usage"
 msgstr "Số giờ chấm bài hàng tháng"
 

--- a/locale/vi/LC_MESSAGES/django.po
+++ b/locale/vi/LC_MESSAGES/django.po
@@ -1103,6 +1103,40 @@ msgstr "{time}"
 msgid "on {time}"
 msgstr "vào lúc {time}"
 
+#: judge/jinja2/datetime.py:39
+#, python-format
+msgid "%(count)d year ago"
+msgid_plural "%(count)d years ago"
+msgstr[0] "%(count)d năm trước"
+
+#: judge/jinja2/datetime.py:40
+#, python-format
+msgid "%(count)d month ago"
+msgid_plural "%(count)d months ago"
+msgstr[0] "%(count)d tháng trước"
+
+#: judge/jinja2/datetime.py:41
+#, python-format
+msgid "%(count)d day ago"
+msgid_plural "%(count)d days ago"
+msgstr[0] "%(count)d ngày trước"
+
+#: judge/jinja2/datetime.py:42
+#, python-format
+msgid "%(count)d hour ago"
+msgid_plural "%(count)d hours ago"
+msgstr[0] "%(count)d giờ trước"
+
+#: judge/jinja2/datetime.py:43
+#, python-format
+msgid "%(count)d minute ago"
+msgid_plural "%(count)d minutes ago"
+msgstr[0] "%(count)d phút trước"
+
+#: judge/jinja2/datetime.py:59
+msgid "just now"
+msgstr "vừa xong"
+
 #: judge/jinja2/filesize.py:33
 #, python-format
 msgid "%s B"

--- a/templates/organization/archived.html
+++ b/templates/organization/archived.html
@@ -31,6 +31,14 @@
              days=archive_retention_days) }}
     </div>
 
+    {% if problem_filter %}
+        <p>
+            <a href="{{ url('organization_archived_problems', organization.slug) }}">
+                <i class="fa fa-arrow-left"></i> {{ _('Show all archived problems') }}
+            </a>
+        </p>
+    {% endif %}
+
     {% set archived = true %}
     {% include "organization/problem-table.html" %}
 

--- a/templates/organization/archived.html
+++ b/templates/organization/archived.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+
+{% block media %}
+    {% include "organization/problem-table-css.html" %}
+{% endblock %}
+
+{% block js_media %}
+    {% include "organization/problem-table-js.html" %}
+{% endblock %}
+
+{% block title_row %}
+    {% set tab = 'usage' %}
+    {% include "organization/tabs.html" %}
+{% endblock %}
+{% block title_ruler %}{% endblock %}
+
+{% block body %}
+    {% set inner_tab = 'archived' %}
+    {% include "organization/usage-inner-tabs.html" %}
+
+    {% include "messages.html" %}
+
+    <p style="margin-top: 1em;">
+        {{ _('The test data of these problems has been moved to cold storage. '
+             'Download it from the archive to get it back, or delete the problems you no longer need.') }}
+    </p>
+
+    {% if not archive_enabled %}
+        <div class="alert alert-warning">
+            {{ _('The problem archive service is not configured, so archived data cannot be downloaded right now.') }}
+        </div>
+    {% endif %}
+
+    {% set archived = true %}
+    {% include "organization/problem-table.html" %}
+
+    {% if page_obj.has_other_pages() %}
+        <div class="bottom-pagination-bar">{% include "list-pages.html" %}</div>
+    {% endif %}
+{% endblock %}

--- a/templates/organization/archived.html
+++ b/templates/organization/archived.html
@@ -21,9 +21,7 @@
     {% include "messages.html" %}
 
     <div class="alert alert-warning">
-        {{ _('Archived problems are permanently deleted %(days)d days after they were archived, '
-             'along with their data. Download anything you still need before then.',
-             days=archive_retention_days) }}
+        {{ _('Archived problems are permanently deleted %(days)d days after they were archived, along with their data. Download anything you still need before then.', days=archive_retention_days) }}
     </div>
 
     {% if problem_filter %}

--- a/templates/organization/archived.html
+++ b/templates/organization/archived.html
@@ -20,11 +20,6 @@
 
     {% include "messages.html" %}
 
-    <p style="margin-top: 1em;">
-        {{ _('The test data of these problems has been moved to cold storage. '
-             'Download it from the archive to get it back, or delete the problems you no longer need.') }}
-    </p>
-
     <div class="alert alert-warning">
         {{ _('Archived problems are permanently deleted %(days)d days after they were archived, '
              'along with their data. Download anything you still need before then.',

--- a/templates/organization/archived.html
+++ b/templates/organization/archived.html
@@ -25,11 +25,11 @@
              'Download it from the archive to get it back, or delete the problems you no longer need.') }}
     </p>
 
-    {% if not archive_enabled %}
-        <div class="alert alert-warning">
-            {{ _('The problem archive service is not configured, so archived data cannot be downloaded right now.') }}
-        </div>
-    {% endif %}
+    <div class="alert alert-warning">
+        {{ _('Archived problems are permanently deleted %(days)d days after they were archived, '
+             'along with their data. Download anything you still need before then.',
+             days=archive_retention_days) }}
+    </div>
 
     {% set archived = true %}
     {% include "organization/problem-table.html" %}

--- a/templates/organization/problem-table-css.html
+++ b/templates/organization/problem-table-css.html
@@ -1,4 +1,9 @@
 <style>
+    /* The navbar is fixed, so an anchor jump to #problem-<code> must clear it. */
+    .storage-table tr {
+        scroll-margin-top: 70px;
+    }
+
     .storage-table {
         td, th {
             &.problem-code, &.problem-name {

--- a/templates/organization/problem-table-css.html
+++ b/templates/organization/problem-table-css.html
@@ -1,0 +1,39 @@
+<style>
+    .storage-table {
+        td, th {
+            &.problem-code, &.problem-name {
+                text-align: left;
+                padding: 0 10px;
+            }
+
+            &.problem-code {
+                word-break: break-all;
+            }
+        }
+    }
+
+    .bulk-actions {
+        margin-bottom: 15px;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+    .btn-danger-bulk {
+        background: #d9534f;
+        color: #fff;
+        border: 1px solid #d43f3a;
+        padding: 6px 12px;
+        border-radius: 4px;
+        cursor: pointer;
+    }
+    .btn-danger-bulk:disabled {
+        background: #e6e6e6;
+        color: #ababab;
+        border-color: #dcdcdc;
+        cursor: not-allowed;
+    }
+    .btn-archive-disabled {
+        cursor: not-allowed;
+        opacity: 0.6;
+    }
+</style>

--- a/templates/organization/problem-table-js.html
+++ b/templates/organization/problem-table-js.html
@@ -79,6 +79,31 @@
             }
         });
 
+        // Relative timestamps are formatted here rather than server-side, so the backend never has to
+        // build one string per row and the text stays correct however long the page is left open.
+        var retentionDays = parseInt($('.storage-table').attr('data-archive-retention-days'), 10);
+
+        $('.time-rel').each(function () {
+            var $this = $(this);
+            // parseZone keeps the server's timezone, so any date we format here matches the other columns.
+            var when = moment.parseZone($this.attr('data-iso'));
+            if (!when.isValid()) return;
+
+            if ($this.hasClass('time-left')) {
+                // Deletion date is derived from the archive date, so the retention window is stated
+                // once per table rather than baked into every row.
+                if (!retentionDays) return;
+                when.add(retentionDays, 'days');
+                $this.attr('title', when.format('YYYY-MM-DD HH:mm:ss'));
+                // A deadline that has already passed still hasn't happened, so don't show elapsed time.
+                $this.text(when.isAfter() ? when.toNow(true) : {{ _('any moment now')|htmltojs }});
+            } else {
+                // The server-rendered absolute timestamp becomes the tooltip.
+                $this.attr('title', $this.text().trim());
+                $this.text(when.fromNow());
+            }
+        });
+
         // Show download/delete buttons only for authors and superusers
         $('.delete-btn').each(function () {
             if (canDelete($(this))) {

--- a/templates/organization/problem-table-js.html
+++ b/templates/organization/problem-table-js.html
@@ -1,0 +1,89 @@
+{# Behaviour shared by the organization problem tables (usage + archived tabs). #}
+<script type="text/javascript">
+    $(document).ready(function () {
+        var currentProfileId = {{ request.profile.id if request.profile else 'null' }};
+        var isSuperuser = {{ 'true' if request.user.is_superuser else 'false' }};
+
+        function canDelete($el) {
+            var authorIds = $el.data('author-ids');
+            return isSuperuser || (currentProfileId && authorIds.indexOf(currentProfileId) !== -1);
+        }
+
+        // Disable checkboxes for problems the user cannot delete
+        $('.problem-select-checkbox').each(function () {
+            if (!canDelete($(this))) {
+                $(this).prop('disabled', true).css('opacity', '0.4');
+                $(this).wrap('<span style="position:relative;display:inline-block;">');
+                $(this).after($('<span class="no-delete-overlay" style="position:absolute;inset:0;cursor:not-allowed;">')
+                              .attr('title', {{ _('Cannot delete problems from other authors.')|htmltojs }}));
+            }
+        });
+
+        $(document).on('click', '.no-delete-overlay', function () {
+            alert({{ _('Cannot delete problems from other authors.')|htmltojs }});
+        });
+
+        // Select All — skips disabled checkboxes
+        $('#select-all-checkbox').change(function () {
+            var checked = this.checked;
+            $('.problem-select-checkbox:not(:disabled)').each(function () {
+                this.checked = checked;
+            });
+            updateDeleteButtonState();
+        });
+
+        $('.problem-select-checkbox').change(function () {
+            var selectable = $('.problem-select-checkbox:not(:disabled)');
+            var allChecked = selectable.filter(':checked').length === selectable.length && selectable.length > 0;
+            $('#select-all-checkbox').prop('checked', allChecked);
+            updateDeleteButtonState();
+        });
+
+        function updateDeleteButtonState() {
+            var checkedCount = $('.problem-select-checkbox:checked').length;
+            $('#bulk-delete-btn').prop('disabled', checkedCount === 0);
+            $('#selected-count-badge').text(checkedCount);
+        }
+
+        // Submitting bulk delete with confirmation
+        $('#bulk-delete-btn').click(function (e) {
+            e.preventDefault();
+            var checkedCount = $('.problem-select-checkbox:checked').length;
+            if (checkedCount === 0) return;
+
+            if (confirm({{ _('Are you sure you want to delete the selected problems? This action cannot be undone.')|htmltojs }})) {
+                var $form = $('<form>')
+                    .attr('method', 'POST')
+                    .attr('action', "{{ url('organization_problems_bulk_delete', organization.slug) }}");
+
+                $form.append($('<input>')
+                    .attr('type', 'hidden')
+                    .attr('name', 'csrfmiddlewaretoken')
+                    .attr('value', $.cookie('csrftoken')));
+
+                // Come back to whichever table submitted the form.
+                $form.append($('<input>')
+                    .attr('type', 'hidden')
+                    .attr('name', 'next')
+                    .attr('value', window.location.pathname + window.location.search));
+
+                $('.problem-select-checkbox:checked').each(function () {
+                    $form.append($('<input>')
+                        .attr('type', 'hidden')
+                        .attr('name', 'problem_ids')
+                        .attr('value', $(this).val()));
+                });
+
+                $('body').append($form);
+                $form.submit();
+            }
+        });
+
+        // Show download/delete buttons only for authors and superusers
+        $('.delete-btn').each(function () {
+            if (canDelete($(this))) {
+                $(this).show();
+            }
+        });
+    });
+</script>

--- a/templates/organization/problem-table.html
+++ b/templates/organization/problem-table.html
@@ -14,7 +14,7 @@
     </button>
 </div>
 
-<table class="storage-table table">
+<table class="storage-table table"{% if archived %} data-archive-retention-days="{{ archive_retention_days }}"{% endif %}>
     <thead>
         <tr>
             <th style="width: 30px; text-align: center;"></th>
@@ -23,7 +23,10 @@
             <th>{{ _('Authors') }}</th>
             {% if not archived %}<th>{{ _('Total Size') }}</th>{% endif %}
             <th>{{ _('Last Submission') }}</th>
-            {% if archived %}<th>{{ _('Archived At') }}</th>{% endif %}
+            {% if archived %}
+                <th>{{ _('Archived') }}</th>
+                <th>{{ _('Deletes In') }}</th>
+            {% endif %}
             <th>{{ _('Download') }}</th>
             <th>{{ _('Delete') }}</th>
         </tr>
@@ -50,38 +53,31 @@
                 {{ problem.data_size|filesizeformat }}
             </td>
             {% endif %}
+            {# Timestamps are rendered absolute and rewritten to "3 days ago" by the shared table JS. #}
             <td>
                 {% if problem.last_submission_date %}
-                    <span title="{{ problem.last_submission_date|date("Y-m-d H:i:s") }}">
-                        {{ problem.last_submission_date|time_ago }}
-                    </span>
+                    <span class="time-rel time-ago" data-iso="{{ problem.last_submission_date|date("c") }}"
+                    >{{ problem.last_submission_date|date("Y-m-d H:i:s") }}</span>
                 {% else %}—{% endif %}
             </td>
             {% if archived %}
             <td>
-                <span title="{{ problem.archived_at|date("Y-m-d H:i:s") }}">
-                    {{ problem.archived_at|time_ago }}
-                </span>
+                <span class="time-rel time-ago" data-iso="{{ problem.archived_at|date("c") }}"
+                >{{ problem.archived_at|date("Y-m-d H:i:s") }}</span>
+            </td>
+            <td>
+                {# Filled in by the table JS: archived_at plus the retention window on the table element. #}
+                <span class="time-rel time-left" data-iso="{{ problem.archived_at|date("c") }}"></span>
             </td>
             {% endif %}
             <td>
-                {# The download anchor carries `delete-btn` too: one JS loop reveals both action buttons. #}
                 {% if archived %}
-                    {% if archive_enabled %}
-                        <a href="{{ url('problem_download_archived_data', problem.code) }}"
-                           class="btn btn-xs delete-btn"
-                           data-author-ids="{{ author_ids(problem) }}"
-                           style="display:none;">
-                            <i class="fa fa-download"></i> {{ _('Download archived data') }}
-                        </a>
-                    {% else %}
-                        <span class="btn btn-xs delete-btn btn-archive-disabled"
-                              data-author-ids="{{ author_ids(problem) }}"
-                              title="{{ _('The problem archive service is not configured.') }}"
-                              style="display:none;">
-                            <i class="fa fa-download"></i> {{ _('Download archived data') }}
-                        </span>
-                    {% endif %}
+                    <a href="{{ url('problem_download_archived_data', problem.code) }}"
+                        class="btn btn-xs delete-btn"
+                        data-author-ids="{{ author_ids(problem) }}"
+                        style="display:none;">
+                        <i class="fa fa-download"></i> {{ _('Download archived data') }}
+                    </a>
                 {% else %}
                     <a href="{{ url('problem_download_full_package', problem.code) }}"
                        class="btn btn-xs delete-btn"
@@ -102,7 +98,7 @@
         </tr>
         {% else %}
         <tr>
-            <td colspan="8" style="text-align: center; padding: 2em; color: #999;">
+            <td colspan="{{ 9 if archived else 8 }}" style="text-align: center; padding: 2em; color: #999;">
                 {% if archived %}
                     {{ _('No archived problems for this organization.') }}
                 {% else %}

--- a/templates/organization/problem-table.html
+++ b/templates/organization/problem-table.html
@@ -1,0 +1,107 @@
+{# Problem table shared by the organization usage tabs.
+   Set `archived` to true before including to render the archived-data variant. #}
+{% macro author_ids(problem) -%}
+{{ (problem.authors.all()|map(attribute='id')|list + problem.curators.all()|map(attribute='id')|list)|tojson }}
+{%- endmacro %}
+
+<div class="bulk-actions">
+    <input type="checkbox" id="select-all-checkbox" style="transform: scale(1.2); margin-right: 5px; cursor: pointer;">
+    <label for="select-all-checkbox" style="margin-bottom: 0; cursor: pointer; font-weight: normal;">
+        {{ _('Select All (Current Page)') }}
+    </label>
+    <button id="bulk-delete-btn" class="btn-danger-bulk" disabled>
+        <i class="fa fa-trash"></i> {{ _('Delete Selected') }} (<span id="selected-count-badge">0</span>)
+    </button>
+</div>
+
+<table class="storage-table table">
+    <thead>
+        <tr>
+            <th style="width: 30px; text-align: center;"></th>
+            <th>{{ _('Problem Code') }}</th>
+            <th>{{ _('Problem Name') }}</th>
+            <th>{{ _('Authors') }}</th>
+            <th>{{ _('Total Size') }}</th>
+            <th>{{ _('Last Submission') }}</th>
+            {% if archived %}<th>{{ _('Archived At') }}</th>{% endif %}
+            <th>{{ _('Download') }}</th>
+            <th>{{ _('Delete') }}</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for problem in problems %}
+        <tr>
+            <td style="text-align: center; vertical-align: middle;">
+                <input type="checkbox" class="problem-select-checkbox" value="{{ problem.id }}"
+                       data-author-ids="{{ author_ids(problem) }}"
+                       style="transform: scale(1.2); cursor: pointer;">
+            </td>
+            <td class="problem-code">
+                <a href="{{ url('problem_detail', problem.code) }}">{{ problem.code }}</a>
+            </td>
+            <td class="problem-name">
+                <a href="{{ url('problem_detail', problem.code) }}">{{ problem.i18n_name or problem.name }}</a>
+            </td>
+            <td>
+                {{ link_users((problem.authors.all()|list + problem.curators.all()|list)|unique(attribute='id')) }}
+            </td>
+            <td class="size-cell">
+                {{ problem.data_size|filesizeformat }}
+            </td>
+            <td>
+                {{ problem.last_submission_date|date("Y-m-d H:i:s") if problem.last_submission_date else '—' }}
+            </td>
+            {% if archived %}
+            <td>
+                {{ problem.archived_at|date("Y-m-d H:i:s") }}
+            </td>
+            {% endif %}
+            <td>
+                {# The download anchor carries `delete-btn` too: one JS loop reveals both action buttons. #}
+                {% if archived %}
+                    {% if archive_enabled %}
+                        <a href="{{ url('problem_download_archived_data', problem.code) }}"
+                           class="btn btn-xs delete-btn"
+                           data-author-ids="{{ author_ids(problem) }}"
+                           style="display:none;">
+                            <i class="fa fa-download"></i> {{ _('Download archived data') }}
+                        </a>
+                    {% else %}
+                        <span class="btn btn-xs delete-btn btn-archive-disabled"
+                              data-author-ids="{{ author_ids(problem) }}"
+                              title="{{ _('The problem archive service is not configured.') }}"
+                              style="display:none;">
+                            <i class="fa fa-download"></i> {{ _('Download archived data') }}
+                        </span>
+                    {% endif %}
+                {% else %}
+                    <a href="{{ url('problem_download_full_package', problem.code) }}"
+                       class="btn btn-xs delete-btn"
+                       data-author-ids="{{ author_ids(problem) }}"
+                       style="display:none;">
+                        <i class="fa fa-download"></i> {{ _('Test data') }}
+                    </a>
+                {% endif %}
+            </td>
+            <td>
+                <a href="{{ url('problem_delete', problem.code) }}?next={{ request.get_full_path()|urlencode }}"
+                   class="btn btn-xs btn-danger delete-btn"
+                   data-author-ids="{{ author_ids(problem) }}"
+                   style="display:none;">
+                    <i class="fa fa-trash"></i> {{ _('Delete') }}
+                </a>
+            </td>
+        </tr>
+        {% else %}
+        <tr>
+            <td colspan="{{ 9 if archived else 8 }}" style="text-align: center; padding: 2em; color: #999;">
+                {% if archived %}
+                    {{ _('No archived problems for this organization.') }}
+                {% else %}
+                    {{ _('No problems found for this organization.') }}
+                {% endif %}
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/templates/organization/problem-table.html
+++ b/templates/organization/problem-table.html
@@ -100,7 +100,11 @@
         <tr>
             <td colspan="{{ 9 if archived else 8 }}" style="text-align: center; padding: 2em; color: #999;">
                 {% if archived %}
-                    {{ _('No archived problems for this organization.') }}
+                    {% if problem_filter %}
+                        {{ _('No archived problem with code "%(code)s".', code=problem_filter) }}
+                    {% else %}
+                        {{ _('No archived problems for this organization.') }}
+                    {% endif %}
                 {% else %}
                     {{ _('No problems found for this organization.') }}
                 {% endif %}

--- a/templates/organization/problem-table.html
+++ b/templates/organization/problem-table.html
@@ -21,7 +21,7 @@
             <th>{{ _('Problem Code') }}</th>
             <th>{{ _('Problem Name') }}</th>
             <th>{{ _('Authors') }}</th>
-            <th>{{ _('Total Size') }}</th>
+            {% if not archived %}<th>{{ _('Total Size') }}</th>{% endif %}
             <th>{{ _('Last Submission') }}</th>
             {% if archived %}<th>{{ _('Archived At') }}</th>{% endif %}
             <th>{{ _('Download') }}</th>
@@ -45,15 +45,23 @@
             <td>
                 {{ link_users((problem.authors.all()|list + problem.curators.all()|list)|unique(attribute='id')) }}
             </td>
+            {% if not archived %}
             <td class="size-cell">
                 {{ problem.data_size|filesizeformat }}
             </td>
+            {% endif %}
             <td>
-                {{ problem.last_submission_date|date("Y-m-d H:i:s") if problem.last_submission_date else '—' }}
+                {% if problem.last_submission_date %}
+                    <span title="{{ problem.last_submission_date|date("Y-m-d H:i:s") }}">
+                        {{ problem.last_submission_date|time_ago }}
+                    </span>
+                {% else %}—{% endif %}
             </td>
             {% if archived %}
             <td>
-                {{ problem.archived_at|date("Y-m-d H:i:s") }}
+                <span title="{{ problem.archived_at|date("Y-m-d H:i:s") }}">
+                    {{ problem.archived_at|time_ago }}
+                </span>
             </td>
             {% endif %}
             <td>
@@ -94,7 +102,7 @@
         </tr>
         {% else %}
         <tr>
-            <td colspan="{{ 9 if archived else 8 }}" style="text-align: center; padding: 2em; color: #999;">
+            <td colspan="8" style="text-align: center; padding: 2em; color: #999;">
                 {% if archived %}
                     {{ _('No archived problems for this organization.') }}
                 {% else %}

--- a/templates/organization/problem-table.html
+++ b/templates/organization/problem-table.html
@@ -28,6 +28,7 @@
                 <th>{{ _('Deletes In') }}</th>
             {% endif %}
             <th>{{ _('Download') }}</th>
+            {% if archived %}<th>{{ _('Restore') }}</th>{% endif %}
             <th>{{ _('Delete') }}</th>
         </tr>
     </thead>
@@ -87,6 +88,19 @@
                     </a>
                 {% endif %}
             </td>
+            {% if archived %}
+            <td>
+                <form method="post" style="margin: 0;"
+                      action="{{ url('organization_archived_problem_restore', organization.slug, problem.code) }}">
+                    {% csrf_token %}
+                    <button type="submit" class="btn btn-xs delete-btn"
+                            data-author-ids="{{ author_ids(problem) }}"
+                            style="display:none;">
+                        <i class="fa fa-undo"></i> {{ _('Restore') }}
+                    </button>
+                </form>
+            </td>
+            {% endif %}
             <td>
                 <a href="{{ url('problem_delete', problem.code) }}?next={{ request.get_full_path()|urlencode }}"
                    class="btn btn-xs btn-danger delete-btn"
@@ -98,7 +112,7 @@
         </tr>
         {% else %}
         <tr>
-            <td colspan="{{ 9 if archived else 8 }}" style="text-align: center; padding: 2em; color: #999;">
+            <td colspan="{{ 10 if archived else 8 }}" style="text-align: center; padding: 2em; color: #999;">
                 {% if archived %}
                     {% if problem_filter %}
                         {{ _('No archived problem with code "%(code)s".', code=problem_filter) }}

--- a/templates/organization/usage-inner-tabs.html
+++ b/templates/organization/usage-inner-tabs.html
@@ -1,0 +1,38 @@
+{# Inner tab bar of the organization usage page.
+   Storage and Credit live on the same page and are toggled client-side; Archived has its own URL.
+   Set `inner_tab` to 'archived' before including to render it from the archived page. #}
+<div class="tabs" id="inner-page-tabs" style="margin-top: 0.5em;">
+    <ul>
+        {% if inner_tab == 'archived' %}
+            <li class="tab">
+                <a href="{{ url('organization_monthly_usage', organization.slug) }}">
+                    <i class="tab-icon fa fa-hdd-o"></i>{{ _('Storage usage') }}
+                </a>
+            </li>
+            <li class="tab">
+                <a href="{{ url('organization_monthly_usage', organization.slug) }}#credit">
+                    <i class="tab-icon fa fa-line-chart"></i>{{ _('Credit usage') }}
+                </a>
+            </li>
+            <li class="tab active">
+                <span><i class="tab-icon fa fa-archive"></i>{{ _('Archived problems') }}</span>
+            </li>
+        {% else %}
+            <li class="tab">
+                <a href="#" data-tab="storage">
+                    <i class="tab-icon fa fa-hdd-o"></i>{{ _('Storage usage') }}
+                </a>
+            </li>
+            <li class="tab">
+                <a href="#" data-tab="credit">
+                    <i class="tab-icon fa fa-line-chart"></i>{{ _('Credit usage') }}
+                </a>
+            </li>
+            <li class="tab">
+                <a href="{{ url('organization_archived_problems', organization.slug) }}">
+                    <i class="tab-icon fa fa-archive"></i>{{ _('Archived problems') }}
+                </a>
+            </li>
+        {% endif %}
+    </ul>
+</div>

--- a/templates/organization/usage.html
+++ b/templates/organization/usage.html
@@ -1,20 +1,8 @@
 {% extends "base.html" %}
 
 {% block media %}
+    {% include "organization/problem-table-css.html" %}
     <style>
-        .storage-table {
-            td, th {
-                &.problem-code, &.problem-name {
-                    text-align: left;
-                    padding: 0 10px;
-                }
-
-                &.problem-code {
-                    word-break: break-all;
-                }
-            }
-        }
-
         .page-tab-content {
             display: none;
         }
@@ -43,32 +31,12 @@
             margin-bottom: 5px;
             font-weight: bold;
         }
-
-        .bulk-actions {
-            margin-bottom: 15px;
-            display: flex;
-            align-items: center;
-            gap: 10px;
-        }
-        .btn-danger-bulk {
-            background: #d9534f;
-            color: #fff;
-            border: 1px solid #d43f3a;
-            padding: 6px 12px;
-            border-radius: 4px;
-            cursor: pointer;
-        }
-        .btn-danger-bulk:disabled {
-            background: #e6e6e6;
-            color: #ababab;
-            border-color: #dcdcdc;
-            cursor: not-allowed;
-        }
     </style>
 {% endblock %}
 
 {% block js_media %}
     {% include "stats/media-js.html" %}
+    {% include "organization/problem-table-js.html" %}
     <script type="text/javascript">
         $(document).ready(function() {
             var chartsInitialized = false;
@@ -81,7 +49,8 @@
                 }
             }
 
-            $('#inner-page-tabs .tab a').on('click', function(e) {
+            // Only the storage/credit tabs live on this page; the archived tab is a plain link.
+            $('#inner-page-tabs .tab a[data-tab]').on('click', function(e) {
                 e.preventDefault();
                 var target = $(this).data('tab');
                 $('#inner-page-tabs .tab').removeClass('active');
@@ -93,8 +62,9 @@
                 }
             });
 
-            // Activate default tab
-            $('#inner-page-tabs .tab a[data-tab="storage"]').click();
+            // Activate default tab, honouring #credit so the archived page can link straight to it
+            var initialTab = window.location.hash === '#credit' ? 'credit' : 'storage';
+            $('#inner-page-tabs .tab a[data-tab="' + initialTab + '"]').click();
 
             if (window.location.hash === '#preset-filter') {
                 var offset = $('#preset-filter').offset().top - 60;
@@ -119,73 +89,8 @@
                 minimumResultsForSearch: Infinity
             });
 
-            // Disable checkboxes for problems the user cannot delete
             var currentProfileId = {{ request.profile.id if request.profile else 'null' }};
             var isSuperuser = {{ 'true' if request.user.is_superuser else 'false' }};
-
-            $('.problem-select-checkbox').each(function () {
-                var authorIds = $(this).data('author-ids');
-                if (!isSuperuser && !(currentProfileId && authorIds.indexOf(currentProfileId) !== -1)) {
-                    $(this).prop('disabled', true).css('opacity', '0.4');
-                    $(this).wrap('<span style="position:relative;display:inline-block;">');
-                    $(this).after('<span class="no-delete-overlay" style="position:absolute;inset:0;cursor:not-allowed;" title="{{ _("Cannot delete problems from other authors.") }}"></span>');
-                }
-            });
-
-            $(document).on('click', '.no-delete-overlay', function () {
-                alert("{{ _('Cannot delete problems from other authors.') }}");
-            });
-
-            // Select All — skips disabled checkboxes
-            $('#select-all-checkbox').change(function () {
-                var checked = this.checked;
-                $('.problem-select-checkbox:not(:disabled)').each(function () {
-                    this.checked = checked;
-                });
-                updateDeleteButtonState();
-            });
-
-            $('.problem-select-checkbox').change(function () {
-                var selectable = $('.problem-select-checkbox:not(:disabled)');
-                var allChecked = selectable.filter(':checked').length === selectable.length && selectable.length > 0;
-                $('#select-all-checkbox').prop('checked', allChecked);
-                updateDeleteButtonState();
-            });
-
-            function updateDeleteButtonState() {
-                var checkedCount = $('.problem-select-checkbox:checked').length;
-                $('#bulk-delete-btn').prop('disabled', checkedCount === 0);
-                $('#selected-count-badge').text(checkedCount);
-            }
-
-            // Submitting bulk delete with confirmation
-            $('#bulk-delete-btn').click(function (e) {
-                e.preventDefault();
-                var checkedCount = $('.problem-select-checkbox:checked').length;
-                if (checkedCount === 0) return;
-
-                if (confirm("{{ _('Are you sure you want to delete the selected problems? This action cannot be undone.') }}")) {
-                    var $form = $('<form>')
-                        .attr('method', 'POST')
-                        .attr('action', "{{ url('organization_problems_bulk_delete', organization.slug) }}");
-
-                    $form.append($('<input>')
-                        .attr('type', 'hidden')
-                        .attr('name', 'csrfmiddlewaretoken')
-                        .attr('value', $.cookie('csrftoken')));
-
-                    $('.problem-select-checkbox:checked').each(function () {
-                        $form.append($('<input>')
-                            .attr('type', 'hidden')
-                            .attr('name', 'problem_ids')
-                            .attr('value', $(this).val()));
-                    });
-
-                    $('body').append($form);
-                    $form.submit();
-                }
-            });
-
 
             // Quick filter select
             $('#quick-filter-select').change(function () {
@@ -229,14 +134,6 @@
                 $('#preset-filter').hide();
                 $('#advanced-filter').show();
             });
-
-            // Show delete buttons only for authors and superusers
-            $('.delete-btn').each(function() {
-                var authorIds = $(this).data('author-ids');
-                if (isSuperuser || (currentProfileId && authorIds.indexOf(currentProfileId) !== -1)) {
-                    $(this).show();
-                }
-            });
         });
     </script>
 {% endblock %}
@@ -248,20 +145,7 @@
 {% block title_ruler %}{% endblock %}
 
 {% block body %}
-    <div class="tabs" id="inner-page-tabs" style="margin-top: 0.5em;">
-        <ul>
-            <li class="tab">
-                <a href="#" data-tab="storage">
-                    <i class="tab-icon fa fa-hdd-o"></i>{{ _('Storage usage') }}
-                </a>
-            </li>
-            <li class="tab">
-                <a href="#" data-tab="credit">
-                    <i class="tab-icon fa fa-line-chart"></i>{{ _('Credit usage') }}
-                </a>
-            </li>
-        </ul>
-    </div>
+    {% include "organization/usage-inner-tabs.html" %}
 
     {% include "messages.html" %}
 
@@ -395,79 +279,8 @@
             </div>
         </div>
 
-        <!-- Bulk Actions -->
-        <div class="bulk-actions">
-            <input type="checkbox" id="select-all-checkbox" style="transform: scale(1.2); margin-right: 5px; cursor: pointer;">
-            <label for="select-all-checkbox" style="margin-bottom: 0; cursor: pointer; font-weight: normal;">
-                {{ _('Select All (Current Page)') }}
-            </label>
-            <button id="bulk-delete-btn" class="btn-danger-bulk" disabled>
-                <i class="fa fa-trash"></i> {{ _('Delete Selected') }} (<span id="selected-count-badge">0</span>)
-            </button>
-        </div>
-
-        <table class="storage-table table">
-            <thead>
-                <tr>
-                    <th style="width: 30px; text-align: center;"></th>
-                    <th>{{ _('Problem Code') }}</th>
-                    <th>{{ _('Problem Name') }}</th>
-                    <th>{{ _('Authors') }}</th>
-                    <th>{{ _('Total Size') }}</th>
-                    <th>{{ _('Last Submission') }}</th>
-                    <th>{{ _('Download') }}</th>
-                    <th>{{ _('Delete') }}</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for problem in problems %}
-                <tr>
-                    <td style="text-align: center; vertical-align: middle;">
-                        <input type="checkbox" class="problem-select-checkbox" value="{{ problem.id }}"
-                               data-author-ids="{{ (problem.authors.all()|map(attribute='id')|list + problem.curators.all()|map(attribute='id')|list)|tojson }}"
-                               style="transform: scale(1.2); cursor: pointer;">
-                    </td>
-                    <td class="problem-code">
-                        <a href="{{ url('problem_detail', problem.code) }}">{{ problem.code }}</a>
-                    </td>
-                    <td class="problem-name">
-                        <a href="{{ url('problem_detail', problem.code) }}">{{ problem.i18n_name or problem.name }}</a>
-                    </td>
-                    <td>
-                        {{ link_users((problem.authors.all()|list + problem.curators.all()|list)|unique(attribute='id')) }}
-                    </td>
-                    <td class="size-cell">
-                        {{ problem.data_size|filesizeformat }}
-                    </td>
-                    <td>
-                        {{ problem.last_submission_date|date("Y-m-d H:i:s") if problem.last_submission_date else '—' }}
-                    </td>
-                    <td>
-                        <a href="{{ url('problem_download_full_package', problem.code) }}"
-                           class="btn btn-xs delete-btn"
-                           data-author-ids="{{ (problem.authors.all()|map(attribute='id')|list + problem.curators.all()|map(attribute='id')|list)|tojson }}"
-                           style="display:none;">
-                            <i class="fa fa-download"></i> {{ _('Test data') }}
-                        </a>
-                    </td>
-                    <td>
-                        <a href="{{ url('problem_delete', problem.code) }}?next={{ request.path }}"
-                           class="btn btn-xs btn-danger delete-btn"
-                           data-author-ids="{{ (problem.authors.all()|map(attribute='id')|list + problem.curators.all()|map(attribute='id')|list)|tojson }}"
-                           style="display:none;">
-                            <i class="fa fa-trash"></i> {{ _('Delete') }}
-                        </a>
-                    </td>
-                </tr>
-                {% else %}
-                <tr>
-                    <td colspan="8" style="text-align: center; padding: 2em; color: #999;">
-                        {{ _('No problems found for this organization.') }}
-                    </td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+        {% set archived = false %}
+        {% include "organization/problem-table.html" %}
 
         {% if page_obj.has_other_pages() %}
             <div class="bottom-pagination-bar">{% include "list-pages.html" %}</div>


### PR DESCRIPTION
New view to show org admin list of archived problems, allow they to download back the test, or delete it

**The logic to archive problem is not included in this PR**, but it's something like this:

```py
def archive_problem(problem: Problem, org: Organization):
    path = os.path.join(settings.DMOJ_PROBLEM_DATA_ROOT, problem.code)
    if not os.path.exists(path):
        print(f"Path {path} does not exist.")
        return
    archive_service.archive(problem.code, org.slug)
    problem.archived_at = timezone.now()
    problem.save(update_fields=['archived_at'])
    try:
        problem.data_files.archived_size = problem.data_files.zipfile_size
        problem.data_files.save(update_fields=['archived_size'])
    except Exception as e:
        print(f"Error setting archived_size for problem {problem.code}: {e}")

```

<img width="1384" height="575" alt="image" src="https://github.com/user-attachments/assets/11c4b33a-1444-49db-b2c2-f236d7a5d5f7" />


- **Add Archived problem list view in org**
- **Show time as time ago instead of raw time**
- **show auto delete time**
- **don't allow rejudge on archived or deleted problem**
- **don't allow edit test date**
- **allow restore**
