### PR TITLE
[POC] Use s3 as a temporary storage for large file upload

### DIFF
--- a/dmoj/settings.py
+++ b/dmoj/settings.py
@@ -753,6 +753,14 @@ SUBMISSION_FILE_UPLOAD_MEDIA_DIR = 'submission_file'
 STATIC_UPLOAD_URL_PREFIX = '/static-upload'
 STATIC_UPLOAD_MEDIA_DIR = 'static-upload'
 
+# S3 presigned POST uploads (opt-in; set S3_PRESIGNED_UPLOAD_BUCKET to enable)
+S3_PRESIGNED_UPLOAD_BUCKET = None             # bucket name
+S3_PRESIGNED_UPLOAD_REGION = 'auto'           # 'auto' works for R2; use your AWS region for S3
+S3_PRESIGNED_UPLOAD_ENDPOINT_URL = None       # e.g. 'https://<account>.r2.cloudflarestorage.com'
+S3_PRESIGNED_UPLOAD_ACCESS_KEY_ID = None      # R2/S3 access key ID
+S3_PRESIGNED_UPLOAD_SECRET_ACCESS_KEY = None  # R2/S3 secret access key
+S3_PRESIGNED_UPLOAD_EXPIRY = 3600             # presigned URL lifetime in seconds
+
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases
 

--- a/dmoj/urls.py
+++ b/dmoj/urls.py
@@ -373,7 +373,7 @@ urlpatterns = [
 
     path('widgets/', include([
         path('rejudge', widgets.rejudge_submission, name='submission_rejudge'),
-        path('s3-presign', widgets.s3_presign_post, name='s3_presign_post'),
+        path('s3-presign', widgets.s3_presign_put, name='s3_presign_put'),
         path('single_submission', submission.single_submission, name='submission_single_query'),
         path('submission_testcases', submission.SubmissionTestCaseQuery.as_view(), name='submission_testcases_query'),
         path('status-table', status.status_table, name='status_table'),

--- a/dmoj/urls.py
+++ b/dmoj/urls.py
@@ -373,6 +373,7 @@ urlpatterns = [
 
     path('widgets/', include([
         path('rejudge', widgets.rejudge_submission, name='submission_rejudge'),
+        path('s3-presign', widgets.s3_presign_post, name='s3_presign_post'),
         path('single_submission', submission.single_submission, name='submission_single_query'),
         path('submission_testcases', submission.SubmissionTestCaseQuery.as_view(), name='submission_testcases_query'),
         path('status-table', status.status_table, name='status_table'),

--- a/judge/views/problem_data.py
+++ b/judge/views/problem_data.py
@@ -85,7 +85,10 @@ class ProblemDataForm(ModelForm):
             'output_limit',
         ]
         widgets = {
-            'zipfile': S3PresignedUploadWidget(max_size=500 * 1024 * 1024, prefix='zipfiles/'),
+            'zipfile': S3PresignedUploadWidget(
+                max_size=500 * 1024 * 1024,
+                prefix='zipfiles/',
+                fallback_threshold=99 * 1024 * 1024),
             'checker_args': HiddenInput,
             'checker': Select2Widget(attrs={'style': 'width: 200px'}),
             'grader': Select2Widget(attrs={'style': 'width: 200px'}),

--- a/judge/views/problem_data.py
+++ b/judge/views/problem_data.py
@@ -1,6 +1,7 @@
 import json
 import mimetypes
 import os
+from io import BytesIO
 from itertools import chain
 from zipfile import BadZipfile, ZipFile
 
@@ -28,7 +29,8 @@ from judge.utils.problem_data import ProblemDataCompiler
 from judge.utils.unicode import utf8text
 from judge.utils.views import TitleMixin, add_file_response, generic_message
 from judge.views.problem import ProblemMixin
-from judge.widgets import Select2Widget
+from judge.widgets import S3PresignedUploadWidget, Select2Widget
+from judge.widgets.s3_upload import make_s3_client
 
 mimetypes.init()
 mimetypes.add_type('application/x-yaml', '.yml')
@@ -83,6 +85,7 @@ class ProblemDataForm(ModelForm):
             'output_limit',
         ]
         widgets = {
+            'zipfile': S3PresignedUploadWidget(max_size=500 * 1024 * 1024, prefix='zipfiles/'),
             'checker_args': HiddenInput,
             'checker': Select2Widget(attrs={'style': 'width: 200px'}),
             'grader': Select2Widget(attrs={'style': 'width: 200px'}),
@@ -249,6 +252,14 @@ class ProblemDataView(TitleMixin, ProblemManagerMixin):
                 return []
             elif post and 'problem-data-zipfile' in self.request.FILES:
                 return ZipFile(self.request.FILES['problem-data-zipfile']).namelist()
+            elif post and self.request.POST.get('problem-data-zipfile', '').startswith('s3:'):
+                # S3 direct upload: download the zip to list its contents for the case editor.
+                # value_from_datadict will download it again when saving; two fetches is the
+                # cost of the drop-in approach without wiring caching through to the widget.
+                key = self.request.POST['problem-data-zipfile'][len('s3:'):]
+                s3 = make_s3_client()
+                obj = s3.get_object(Bucket=settings.S3_PRESIGNED_UPLOAD_BUCKET, Key=key)
+                return ZipFile(BytesIO(obj['Body'].read())).namelist()
             elif data.zipfile:
                 return ZipFile(data.zipfile.path).namelist()
         except (BadZipfile, FileNotFoundError):

--- a/judge/views/problem_data.py
+++ b/judge/views/problem_data.py
@@ -67,6 +67,14 @@ class ProblemDataForm(ModelForm):
     io_output_file = CharField(max_length=100, label=gettext_lazy('Output to file'), required=False)
     checker_type = ChoiceField(choices=CUSTOM_CHECKERS, widget=Select2Widget(attrs={'style': 'width: 200px'}))
 
+    def __init__(self, *args, **kwargs):
+        user = kwargs.pop('user', None)
+        super().__init__(*args, **kwargs)
+        # Direct S3 upload bypasses the origin's normal request-size limit, so restrict it to
+        # superusers; everyone else falls back to the regular Django upload path (see
+        # S3PresignedUploadWidget._s3_configured and s3_presign_put's matching server-side check).
+        self.fields['zipfile'].widget.s3_enabled = bool(user and user.is_superuser)
+
     def clean_zipfile(self):
         if hasattr(self, 'zip_valid') and not self.zip_valid:
             raise ValidationError(_('Your zip file is invalid!'))
@@ -88,6 +96,7 @@ class ProblemDataForm(ModelForm):
             'zipfile': S3PresignedUploadWidget(
                 max_size=500 * 1024 * 1024,
                 prefix='zipfiles/',
+                # Also the hard cap for users who can't use direct S3 upload (see get_data_form).
                 fallback_threshold=99 * 1024 * 1024),
             'checker_args': HiddenInput,
             'checker': Select2Widget(attrs={'style': 'width: 200px'}),
@@ -243,7 +252,8 @@ class ProblemDataView(TitleMixin, ProblemManagerMixin):
     def get_data_form(self, post=False):
         return ProblemDataForm(data=self.request.POST if post else None, prefix='problem-data',
                                files=self.request.FILES if post else None,
-                               instance=ProblemData.objects.get_or_create(problem=self.object)[0])
+                               instance=ProblemData.objects.get_or_create(problem=self.object)[0],
+                               user=self.request.user)
 
     def get_case_formset(self, files, post=False):
         return ProblemCaseFormSet(data=self.request.POST if post else None, prefix='cases', valid_files=files,
@@ -255,7 +265,8 @@ class ProblemDataView(TitleMixin, ProblemManagerMixin):
                 return []
             elif post and 'problem-data-zipfile' in self.request.FILES:
                 return ZipFile(self.request.FILES['problem-data-zipfile']).namelist()
-            elif post and self.request.POST.get('problem-data-zipfile', '').startswith('s3:'):
+            elif post and self.request.user.is_superuser and \
+                    self.request.POST.get('problem-data-zipfile', '').startswith('s3:'):
                 # S3 direct upload: download the zip to list its contents for the case editor.
                 # value_from_datadict will download it again when saving; two fetches is the
                 # cost of the drop-in approach without wiring caching through to the widget.

--- a/judge/views/widgets.py
+++ b/judge/views/widgets.py
@@ -6,12 +6,14 @@ from urllib.parse import urljoin
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.files.storage import default_storage
+from django.core.signing import BadSignature, Signer
 from django.http import HttpRequest, HttpResponse, HttpResponseBadRequest, HttpResponseForbidden, \
-    HttpResponseRedirect
+    HttpResponseRedirect, JsonResponse
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_POST
 
 from judge.models import Submission
+from judge.widgets.s3_upload import make_s3_client
 
 __all__ = ['rejudge_submission']
 
@@ -102,6 +104,42 @@ def static_uploader(static_file):
     if not url_base.endswith('/'):
         url_base += '/'
     return urljoin(url_base, name)
+
+
+@login_required
+@require_POST
+def s3_presign_post(request):
+    if not getattr(settings, 'S3_PRESIGNED_UPLOAD_BUCKET', None):
+        return JsonResponse({'error': 'S3 upload not configured'}, status=503)
+    try:
+        body = json.loads(request.body)
+        token, filename, content_type = body['token'], body['filename'], body['content_type']
+    except (ValueError, KeyError):
+        return JsonResponse({'error': 'Invalid request'}, status=400)
+
+    try:
+        value = Signer().unsign(token)
+        max_size_str, prefix = value.split(':', 1)
+        max_size = int(max_size_str)
+    except (BadSignature, ValueError):
+        return JsonResponse({'error': 'Invalid token'}, status=400)
+
+    ext = os.path.splitext(filename)[1]
+    key = prefix + str(uuid.uuid4()) + ext
+
+    s3 = make_s3_client()
+    presigned = s3.generate_presigned_post(
+        Bucket=settings.S3_PRESIGNED_UPLOAD_BUCKET,
+        Key=key,
+        Fields={'Content-Type': content_type},
+        Conditions=[
+            {'Content-Type': content_type},
+            ['content-length-range', 0, max_size],  # enforced by S3, not JS
+        ],
+        ExpiresIn=getattr(settings, 'S3_PRESIGNED_UPLOAD_EXPIRY', 3600),
+    )
+    presigned['file_url'] = 's3:' + key
+    return JsonResponse(presigned)
 
 
 def csrf_failure(request: HttpRequest, reason=''):

--- a/judge/views/widgets.py
+++ b/judge/views/widgets.py
@@ -108,7 +108,7 @@ def static_uploader(static_file):
 
 @login_required
 @require_POST
-def s3_presign_post(request):
+def s3_presign_put(request):
     if not getattr(settings, 'S3_PRESIGNED_UPLOAD_BUCKET', None):
         return JsonResponse({'error': 'S3 upload not configured'}, status=503)
     try:
@@ -118,9 +118,9 @@ def s3_presign_post(request):
         return JsonResponse({'error': 'Invalid request'}, status=400)
 
     try:
-        value = Signer().unsign(token)
-        max_size_str, prefix = value.split(':', 1)
-        max_size = int(max_size_str)
+        # R2 doesn't support the S3 POST-with-policy upload API (returns 501), so the max size
+        # here can't be enforced server-side the way `content-length-range` conditions would.
+        _, prefix = Signer().unsign(token).split(':', 1)
     except (BadSignature, ValueError):
         return JsonResponse({'error': 'Invalid token'}, status=400)
 
@@ -128,18 +128,16 @@ def s3_presign_post(request):
     key = prefix + str(uuid.uuid4()) + ext
 
     s3 = make_s3_client()
-    presigned = s3.generate_presigned_post(
-        Bucket=settings.S3_PRESIGNED_UPLOAD_BUCKET,
-        Key=key,
-        Fields={'Content-Type': content_type},
-        Conditions=[
-            {'Content-Type': content_type},
-            ['content-length-range', 0, max_size],  # enforced by S3, not JS
-        ],
+    url = s3.generate_presigned_url(
+        'put_object',
+        Params={
+            'Bucket': settings.S3_PRESIGNED_UPLOAD_BUCKET,
+            'Key': key,
+            'ContentType': content_type,
+        },
         ExpiresIn=getattr(settings, 'S3_PRESIGNED_UPLOAD_EXPIRY', 3600),
     )
-    presigned['file_url'] = 's3:' + key
-    return JsonResponse(presigned)
+    return JsonResponse({'url': url, 'content_type': content_type, 'file_url': 's3:' + key})
 
 
 def csrf_failure(request: HttpRequest, reason=''):

--- a/judge/views/widgets.py
+++ b/judge/views/widgets.py
@@ -114,15 +114,18 @@ def s3_presign_put(request):
     try:
         body = json.loads(request.body)
         token, filename, content_type = body['token'], body['filename'], body['content_type']
-    except (ValueError, KeyError):
+        size = int(body['size'])
+    except (ValueError, KeyError, TypeError):
         return JsonResponse({'error': 'Invalid request'}, status=400)
 
     try:
-        # R2 doesn't support the S3 POST-with-policy upload API (returns 501), so the max size
-        # here can't be enforced server-side the way `content-length-range` conditions would.
-        _, prefix = Signer().unsign(token).split(':', 1)
+        max_size_str, prefix = Signer().unsign(token).split(':', 1)
+        max_size = int(max_size_str)
     except (BadSignature, ValueError):
         return JsonResponse({'error': 'Invalid token'}, status=400)
+
+    if size < 0 or size > max_size:
+        return JsonResponse({'error': 'File too large'}, status=400)
 
     key = f'{prefix}{uuid.uuid4()}/{os.path.basename(filename)}'
 
@@ -133,6 +136,11 @@ def s3_presign_put(request):
             'Bucket': settings.S3_PRESIGNED_UPLOAD_BUCKET,
             'Key': key,
             'ContentType': content_type,
+            # Signing the exact ContentLength (rather than a range, which R2's PutObject presigning
+            # doesn't support) forces the PUT to carry this exact Content-Length or the signature
+            # won't match; browsers always set Content-Length to the real body size, so a client
+            # can't upload more bytes than it declared here.
+            'ContentLength': size,
         },
         ExpiresIn=getattr(settings, 'S3_PRESIGNED_UPLOAD_EXPIRY', 3600),
     )

--- a/judge/views/widgets.py
+++ b/judge/views/widgets.py
@@ -124,8 +124,7 @@ def s3_presign_put(request):
     except (BadSignature, ValueError):
         return JsonResponse({'error': 'Invalid token'}, status=400)
 
-    ext = os.path.splitext(filename)[1]
-    key = prefix + str(uuid.uuid4()) + ext
+    key = f'{prefix}{uuid.uuid4()}/{os.path.basename(filename)}'
 
     s3 = make_s3_client()
     url = s3.generate_presigned_url(

--- a/judge/views/widgets.py
+++ b/judge/views/widgets.py
@@ -109,6 +109,8 @@ def static_uploader(static_file):
 @login_required
 @require_POST
 def s3_presign_put(request):
+    if not request.user.is_superuser:
+        return JsonResponse({'error': 'Forbidden'}, status=403)
     if not getattr(settings, 'S3_PRESIGNED_UPLOAD_BUCKET', None):
         return JsonResponse({'error': 'S3 upload not configured'}, status=503)
     try:

--- a/judge/widgets/__init__.py
+++ b/judge/widgets/__init__.py
@@ -2,4 +2,5 @@ from judge.widgets.ace import *
 from judge.widgets.checkbox import CheckboxSelectMultipleWithSelectAll
 from judge.widgets.martor import *
 from judge.widgets.mixins import CompressorWidgetMixin
+from judge.widgets.s3_upload import *
 from judge.widgets.select2 import *

--- a/judge/widgets/s3_upload.py
+++ b/judge/widgets/s3_upload.py
@@ -37,10 +37,11 @@ class S3PresignedUploadWidget(forms.Widget):
         self.fallback_threshold = fallback_threshold  # bytes; files below this go through Django
         self.prefix = prefix.rstrip('/') + '/'
         self.accept = accept
+        self.s3_enabled = True  # callers can flip this off per-request (e.g. non-superusers)
         super().__init__(attrs)
 
     def _s3_configured(self):
-        return bool(getattr(settings, 'S3_PRESIGNED_UPLOAD_BUCKET', None))
+        return self.s3_enabled and bool(getattr(settings, 'S3_PRESIGNED_UPLOAD_BUCKET', None))
 
     @property
     def media(self):
@@ -54,6 +55,9 @@ class S3PresignedUploadWidget(forms.Widget):
             fi_attrs = dict(attrs or {})
             if self.accept:
                 fi_attrs['accept'] = self.accept
+            # Same data-max-size attribute the S3 branch below stamps on its file input, so any
+            # JS reading the file input's size limit doesn't need to know which branch rendered.
+            fi_attrs['data-max-size'] = str(self.fallback_threshold or self.max_size)
             return forms.ClearableFileInput().render(name, value, fi_attrs, renderer)
         final_attrs = self.build_attrs(attrs or {})
         wid = final_attrs.get('id', f'id_{name}')
@@ -72,17 +76,17 @@ class S3PresignedUploadWidget(forms.Widget):
             )
 
         return format_html(
-            '{}<span class="s3-upload-widget" data-presign-url="{}" data-token="{}" data-max-size="{}"{}>'
-            '<input type="file" name="{}" id="{}"{}>'
+            '{}<span class="s3-upload-widget" data-presign-url="{}" data-token="{}"{}>'
+            '<input type="file" name="{}" id="{}" data-max-size="{}"{}>'
             '<input type="hidden" name="{}" id="{}">'
             '<span class="s3-upload-status"></span>'
             '</span>',
             current_html,
-            reverse('s3_presign_put'), self._token(), str(self.max_size), threshold_html,
+            reverse('s3_presign_put'), self._token(), threshold_html,
             # The visible file input keeps Django's usual id (id_<name>) so existing page JS
             # written against ClearableFileInput's markup (e.g. $('#id_problem-data-zipfile'))
             # keeps working; the S3 reference value is the one that gets the extra suffix.
-            name, wid, accept_html,
+            name, wid, str(self.max_size), accept_html,
             name, f'{wid}_s3ref',
         )
 

--- a/judge/widgets/s3_upload.py
+++ b/judge/widgets/s3_upload.py
@@ -64,7 +64,7 @@ class S3PresignedUploadWidget(forms.Widget):
         current_html = ''
         if value and getattr(value, 'url', None):
             clear_name = f'{name}-clear'
-            clear_id = f'{wid}-clear-id'
+            clear_id = f'{clear_name}_id'  # matches Django's ClearableFileInput id convention
             current_html = format_html(
                 '<p class="file-upload">Currently: <a href="{}">{}</a> '
                 '&nbsp;<label for="{}">Clear: <input type="checkbox" name="{}" id="{}"></label></p>',
@@ -78,9 +78,12 @@ class S3PresignedUploadWidget(forms.Widget):
             '<span class="s3-upload-status"></span>'
             '</span>',
             current_html,
-            reverse('s3_presign_post'), self._token(), str(self.max_size), threshold_html,
-            name, f'{wid}_picker', accept_html,
-            name, wid,
+            reverse('s3_presign_put'), self._token(), str(self.max_size), threshold_html,
+            # The visible file input keeps Django's usual id (id_<name>) so existing page JS
+            # written against ClearableFileInput's markup (e.g. $('#id_problem-data-zipfile'))
+            # keeps working; the S3 reference value is the one that gets the extra suffix.
+            name, wid, accept_html,
+            name, f'{wid}_s3ref',
         )
 
     def value_from_datadict(self, data, files, name):

--- a/judge/widgets/s3_upload.py
+++ b/judge/widgets/s3_upload.py
@@ -79,6 +79,8 @@ class S3PresignedUploadWidget(forms.Widget):
             '{}<span class="s3-upload-widget" data-presign-url="{}" data-token="{}"{}>'
             '<input type="file" name="{}" id="{}" data-max-size="{}"{}>'
             '<input type="hidden" name="{}" id="{}">'
+            '<progress class="s3-upload-progress" value="0" max="100" '
+            'style="display:none; vertical-align:middle;"></progress>'
             '<span class="s3-upload-status"></span>'
             '</span>',
             current_html,

--- a/judge/widgets/s3_upload.py
+++ b/judge/widgets/s3_upload.py
@@ -1,0 +1,134 @@
+import os
+
+from django import forms
+from django.conf import settings
+from django.core.signing import Signer
+from django.urls import reverse
+from django.utils.html import format_html
+
+__all__ = ['S3PresignedUploadWidget', 'S3FileField', 'make_s3_client']
+
+
+def make_s3_client():
+    from django.core.exceptions import ImproperlyConfigured
+    import boto3
+    required = [
+        'S3_PRESIGNED_UPLOAD_BUCKET',
+        'S3_PRESIGNED_UPLOAD_ENDPOINT_URL',
+        'S3_PRESIGNED_UPLOAD_ACCESS_KEY_ID',
+        'S3_PRESIGNED_UPLOAD_SECRET_ACCESS_KEY',
+        'S3_PRESIGNED_UPLOAD_REGION',
+    ]
+    missing = [k for k in required if not getattr(settings, k, None)]
+    if missing:
+        raise ImproperlyConfigured(f'Missing S3 upload settings: {", ".join(missing)}')
+    return boto3.client(
+        service_name='s3',
+        endpoint_url=settings.S3_PRESIGNED_UPLOAD_ENDPOINT_URL,
+        aws_access_key_id=settings.S3_PRESIGNED_UPLOAD_ACCESS_KEY_ID,
+        aws_secret_access_key=settings.S3_PRESIGNED_UPLOAD_SECRET_ACCESS_KEY,
+        region_name=settings.S3_PRESIGNED_UPLOAD_REGION,
+    )
+
+
+class S3PresignedUploadWidget(forms.Widget):
+    def __init__(self, max_size, fallback_threshold=None, prefix='uploads/', accept=None, attrs=None):
+        self.max_size = max_size
+        self.fallback_threshold = fallback_threshold  # bytes; files below this go through Django
+        self.prefix = prefix.rstrip('/') + '/'
+        self.accept = accept
+        super().__init__(attrs)
+
+    def _s3_configured(self):
+        return bool(getattr(settings, 'S3_PRESIGNED_UPLOAD_BUCKET', None))
+
+    @property
+    def media(self):
+        return forms.Media(js=['s3_upload.js'])
+
+    def _token(self):
+        return Signer().sign(f'{self.max_size}:{self.prefix}')
+
+    def render(self, name, value, attrs=None, renderer=None):
+        if not self._s3_configured():
+            fi_attrs = dict(attrs or {})
+            if self.accept:
+                fi_attrs['accept'] = self.accept
+            return forms.ClearableFileInput().render(name, value, fi_attrs, renderer)
+        final_attrs = self.build_attrs(attrs or {})
+        wid = final_attrs.get('id', f'id_{name}')
+        accept_html = format_html(' accept="{}"', self.accept) if self.accept else ''
+        threshold_html = format_html(' data-fallback-threshold="{}"', self.fallback_threshold) \
+            if self.fallback_threshold else ''
+
+        current_html = ''
+        if value and getattr(value, 'url', None):
+            clear_name = f'{name}-clear'
+            clear_id = f'{wid}-clear-id'
+            current_html = format_html(
+                '<p class="file-upload">Currently: <a href="{}">{}</a> '
+                '&nbsp;<label for="{}">Clear: <input type="checkbox" name="{}" id="{}"></label></p>',
+                value.url, os.path.basename(value.name), clear_id, clear_name, clear_id,
+            )
+
+        return format_html(
+            '{}<span class="s3-upload-widget" data-presign-url="{}" data-token="{}" data-max-size="{}"{}>'
+            '<input type="file" name="{}" id="{}"{}>'
+            '<input type="hidden" name="{}" id="{}">'
+            '<span class="s3-upload-status"></span>'
+            '</span>',
+            current_html,
+            reverse('s3_presign_post'), self._token(), str(self.max_size), threshold_html,
+            name, f'{wid}_picker', accept_html,
+            name, wid,
+        )
+
+    def value_from_datadict(self, data, files, name):
+        if not self._s3_configured():
+            return forms.ClearableFileInput().value_from_datadict(data, files, name)
+
+        clear = forms.CheckboxInput().value_from_datadict(data, files, f'{name}-clear')
+        value = data.get(name, '')
+
+        if value.startswith('s3:'):
+            if clear:
+                from django.forms.widgets import FILE_INPUT_CONTRADICTION
+                return FILE_INPUT_CONTRADICTION
+            from django.core.files.uploadedfile import TemporaryUploadedFile
+            key = value[len('s3:'):]
+            s3 = make_s3_client()
+            obj = s3.get_object(Bucket=settings.S3_PRESIGNED_UPLOAD_BUCKET, Key=key)
+            body = obj['Body']
+            content_type = obj.get('ContentType', 'application/octet-stream')
+            filename = os.path.basename(key)
+            tmp = TemporaryUploadedFile(filename, content_type, 0, None)
+            for chunk in iter(lambda: body.read(65536), b''):
+                tmp.write(chunk)
+            tmp.size = tmp.tell()
+            tmp.seek(0)
+            return tmp
+
+        upload = files.get(name)
+        if clear:
+            if upload:
+                from django.forms.widgets import FILE_INPUT_CONTRADICTION
+                return FILE_INPUT_CONTRADICTION
+            return False
+        return upload
+
+
+class S3FileField(forms.CharField):
+    """CharField backed by S3PresignedUploadWidget; cleaned value is the full file URL."""
+
+    def __init__(self, max_size, prefix='uploads/', accept=None, **kwargs):
+        kwargs.setdefault('required', False)
+        super().__init__(**kwargs)
+        self.widget = S3PresignedUploadWidget(max_size=max_size, prefix=prefix, accept=accept)
+
+    def clean(self, value):
+        value = super().clean(value)
+        if not value:
+            return None
+        if not value.startswith('s3:'):
+            raise forms.ValidationError('Invalid file reference.')
+        return value

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Django>=4.2,<5
+boto3
 django-cleanup
 django_compressor>=3
 django-mptt>=0.13

--- a/resources/s3_upload.js
+++ b/resources/s3_upload.js
@@ -1,0 +1,51 @@
+$(function () {
+    document.querySelectorAll('.s3-upload-widget').forEach(function (widget) {
+        var picker = widget.querySelector('input[type=file]');
+        var hidden = widget.querySelector('input[type=hidden]');
+        var status = widget.querySelector('.s3-upload-status');
+        var threshold = parseInt(widget.dataset.fallbackThreshold || '0');
+
+        picker.addEventListener('change', async function () {
+            var file = this.files[0];
+            if (!file) return;
+
+            // Below threshold: let the native file input submit as a regular upload.
+            if (threshold > 0 && file.size <= threshold) {
+                hidden.value = '';
+                status.textContent = '';
+                return;
+            }
+
+            var maxSize = parseInt(widget.dataset.maxSize);
+            if (file.size > maxSize) {
+                status.textContent = 'File too large (max ' + Math.round(maxSize / 1048576) + ' MB)';
+                return;
+            }
+            status.textContent = 'Uploading…';
+            hidden.value = '';
+            try {
+                var resp = await fetch(widget.dataset.presignUrl, {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json', 'X-CSRFToken': $.cookie('csrftoken')},
+                    body: JSON.stringify({token: widget.dataset.token, filename: file.name,
+                                         content_type: file.type || 'application/octet-stream'}),
+                });
+                var data = await resp.json();
+                if (data.error) throw new Error(data.error);
+                var form = new FormData();
+                Object.entries(data.fields).forEach(([k, v]) => form.append(k, v));
+                form.append('file', file);
+                var up = await fetch(data.url, {method: 'POST', body: form});
+                if (!up.ok) throw new Error('S3 error ' + up.status);
+                hidden.value = data.file_url;
+                picker.disabled = true;  // ponytail: prevents double-submit of the file body
+                status.textContent = '✓ ' + file.name;
+            } catch (e) {
+                // S3 failed: fall back to regular upload via the file input.
+                hidden.value = '';
+                picker.disabled = false;
+                status.textContent = 'Direct upload failed, uploading via server…';
+            }
+        });
+    });
+});

--- a/resources/s3_upload.js
+++ b/resources/s3_upload.js
@@ -27,7 +27,7 @@ $(function () {
                 var resp = await fetch(widget.dataset.presignUrl, {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json', 'X-CSRFToken': $.cookie('csrftoken')},
-                    body: JSON.stringify({token: widget.dataset.token, filename: file.name,
+                    body: JSON.stringify({token: widget.dataset.token, filename: file.name, size: file.size,
                                          content_type: file.type || 'application/octet-stream'}),
                 });
                 var data = await resp.json();

--- a/resources/s3_upload.js
+++ b/resources/s3_upload.js
@@ -1,8 +1,26 @@
+function putWithProgress(url, contentType, file, onProgress) {
+    return new Promise(function (resolve, reject) {
+        var xhr = new XMLHttpRequest();
+        xhr.open('PUT', url);
+        xhr.setRequestHeader('Content-Type', contentType);
+        xhr.upload.onprogress = function (e) {
+            if (e.lengthComputable) onProgress(e.loaded / e.total);
+        };
+        xhr.onload = function () {
+            if (xhr.status >= 200 && xhr.status < 300) resolve();
+            else reject(new Error('S3 error ' + xhr.status));
+        };
+        xhr.onerror = function () { reject(new Error('S3 network error')); };
+        xhr.send(file);
+    });
+}
+
 $(function () {
     document.querySelectorAll('.s3-upload-widget').forEach(function (widget) {
         var picker = widget.querySelector('input[type=file]');
         var hidden = widget.querySelector('input[type=hidden]');
         var status = widget.querySelector('.s3-upload-status');
+        var progress = widget.querySelector('.s3-upload-progress');
         var threshold = parseInt(widget.dataset.fallbackThreshold || '0');
 
         picker.addEventListener('change', async function () {
@@ -23,6 +41,8 @@ $(function () {
             }
             status.textContent = 'Uploading…';
             hidden.value = '';
+            progress.value = 0;
+            progress.style.display = '';
             try {
                 var resp = await fetch(widget.dataset.presignUrl, {
                     method: 'POST',
@@ -32,12 +52,10 @@ $(function () {
                 });
                 var data = await resp.json();
                 if (data.error) throw new Error(data.error);
-                var up = await fetch(data.url, {
-                    method: 'PUT',
-                    headers: {'Content-Type': data.content_type},
-                    body: file,
+                await putWithProgress(data.url, data.content_type, file, function (fraction) {
+                    progress.value = Math.round(fraction * 100);
+                    status.textContent = 'Uploading… ' + progress.value + '%';
                 });
-                if (!up.ok) throw new Error('S3 error ' + up.status);
                 hidden.value = data.file_url;
                 picker.disabled = true;  // ponytail: prevents double-submit of the file body
                 status.textContent = '✓ ' + file.name;
@@ -46,6 +64,8 @@ $(function () {
                 hidden.value = '';
                 picker.disabled = false;
                 status.textContent = 'Direct upload failed, uploading via server…';
+            } finally {
+                progress.style.display = 'none';
             }
         });
     });

--- a/resources/s3_upload.js
+++ b/resources/s3_upload.js
@@ -16,7 +16,7 @@ $(function () {
                 return;
             }
 
-            var maxSize = parseInt(widget.dataset.maxSize);
+            var maxSize = parseInt(picker.dataset.maxSize);
             if (file.size > maxSize) {
                 status.textContent = 'File too large (max ' + Math.round(maxSize / 1048576) + ' MB)';
                 return;

--- a/resources/s3_upload.js
+++ b/resources/s3_upload.js
@@ -32,10 +32,11 @@ $(function () {
                 });
                 var data = await resp.json();
                 if (data.error) throw new Error(data.error);
-                var form = new FormData();
-                Object.entries(data.fields).forEach(([k, v]) => form.append(k, v));
-                form.append('file', file);
-                var up = await fetch(data.url, {method: 'POST', body: form});
+                var up = await fetch(data.url, {
+                    method: 'PUT',
+                    headers: {'Content-Type': data.content_type},
+                    body: file,
+                });
                 if (!up.ok) throw new Error('S3 error ' + up.status);
                 hidden.value = data.file_url;
                 picker.disabled = true;  // ponytail: prevents double-submit of the file body

--- a/templates/problem/data.html
+++ b/templates/problem/data.html
@@ -579,12 +579,13 @@
 
             $("#id_problem-data-zipfile").change((event) => {
                 let fileInput = event.target.files[0];
+                let sizeLimit = parseInt(event.target.dataset.maxSize, 10);
 
-                // 100 MB limit (Cloudflare's request body size limit)
-                if (fileInput && fileInput.size > 100 * 1024 * 1024) {
+                if (fileInput && sizeLimit && fileInput.size > sizeLimit) {
                     alert({{ _('File too large!')|htmltojs }} + ' ' +
                         {{ _('Your file is')|htmltojs }} + ' ' + (fileInput.size / (1024 * 1024)).toFixed(2) + ' MB. ' +
-                        {{ _('Maximum allowed is 100 MB.')|htmltojs }});
+                        {{ _('Maximum allowed is')|htmltojs }} + ' ' +
+                        Math.round(sizeLimit / (1024 * 1024)) + ' MB.');
                     event.target.value = "";
                     return;
                 }


### PR DESCRIPTION
S3PresignedUploadWidget is designed as a drop-in replacement for the default file upload of Django, most of the case we can just use it
without the need to change any old code, unless it requires request.FILES access

- **Initial commit for s3 widget**
- **Use PUT instead of POST**
- **match ClearableFileInput id**
- **Add fallback threshold**
